### PR TITLE
Update pre-merge checks to be non-blocking

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -83,7 +83,6 @@ jobs:
               task_id
             } = ${{ steps.extract_task.outputs }};
 
-            let conclusion = "success";
             let summary = "";
 
             if (is_hotfix === 'true') {
@@ -91,15 +90,15 @@ jobs:
             } else if (status === 'fully_tested' || status === 'testing_task') {
               summary = "✅ **PASS:** Feature is fully tested or is a testing task.";
             } else {
-              conclusion = "failure";
+              // Softened restrictions: Warnings instead of blockers
               if (status === 'untested') {
-                summary = "❌ **FAIL:** Feature is untested. Merge blocked.";
+                summary = "⚠️ **WARNING:** Feature is untested. Please ensure adequate testing before merging.";
               } else if (status === 'no_task_id') {
-                summary = "❌ **FAIL:** Could not extract Task ID from branch name. Merge blocked.";
+                summary = "⚠️ **WARNING:** Could not extract Task ID from branch name. Roadmap tracking skipped.";
               } else if (status === 'not_found') {
-                summary = `❌ **FAIL:** Task ${task_id} not found in any roadmap. Merge blocked.`;
+                summary = `⚠️ **WARNING:** Task ${task_id} not found in any roadmap. Please ensure it is tracked.`;
               } else {
-                summary = `❌ **FAIL:** Test status is not '✅ Fully Tested'. Merge blocked.`;
+                summary = `⚠️ **WARNING:** Test status is not '✅ Fully Tested'. Proceed with caution.`;
               }
             }
 
@@ -112,6 +111,5 @@ jobs:
               body: body
             });
 
-            if (conclusion === 'failure') {
-              core.setFailed(summary);
-            }
+            // Note: We are no longer failing the build (core.setFailed) to avoid blocking merges.
+            // The warnings above serve as the quality gate feedback.


### PR DESCRIPTION
## Summary
This PR modifies the `pre-merge.yml` workflow to relax the quality gate restrictions. Previously, the workflow would block merges if the task status in the roadmap was not "Fully Tested" or if the task ID was missing.

## Changes
- Changed "Test Status" checks from **failures** to **warnings**.
- Removed `core.setFailed()` calls, so the workflow will pass even if the quality checks trigger warnings.
- Updated status comments to reflect the new warning level (⚠️ instead of ❌).

## Impact
- Pull requests can now be merged even if the roadmap status hasn't been updated to "Fully Tested".
- The quality gate will still provide feedback via comments, ensuring visibility without blocking progress.