### PR TITLE
chore: register session Session-20251218-MASTER-FIX-c0f9fa

### DIFF
--- a/docs/ACTIVE_SESSIONS.md
+++ b/docs/ACTIVE_SESSIONS.md
@@ -10,9 +10,9 @@
 
 ## 🟢 Currently Working
 
-| Session ID | Task | Branch | Module | Status | Started | ETA |
-| ---------- | ---- | ------ | ------ | ------ | ------- | --- |
-| _(none)_   | -    | -      | -      | -      | -       | -   |
+| Session ID                         | Task       | Branch                   | Module     | Status      | Started    | ETA |
+| ---------------------------------- | ---------- | ------------------------ | ---------- | ----------- | ---------- | --- |
+| Session-20251218-MASTER-FIX-c0f9fa | MASTER-FIX | claude/master-fix-c0f9fa | full-stack | In Progress | 2025-12-18 | TBA |
 
 ## ⏸️ Paused / Waiting
 

--- a/docs/sessions/active/Session-20251218-MASTER-FIX-c0f9fa.md
+++ b/docs/sessions/active/Session-20251218-MASTER-FIX-c0f9fa.md
@@ -1,0 +1,15 @@
+# Session: MASTER-FIX - MASTER_FIX_SPEC
+
+**Status**: In Progress
+**Started**: 2025-12-18T00:51:13+00:00
+**Agent Type**: ChatGPT (External)
+**Files**: TBD
+
+## Progress
+
+- [ ] Phase 1
+- [ ] Phase 2
+
+## Notes
+
+Working on MASTER_FIX_SPECIFICATION v2 items.


### PR DESCRIPTION
## Summary
- register new work session for MASTER_FIX_SPECIFICATION v2 and record status in ACTIVE_SESSIONS
- correct ACTIVE_SESSIONS entry to reference the claude/master-fix-c0f9fa branch

## Testing
- `pnpm check` *(fails: existing TypeScript errors in repo)*
- `pnpm lint` *(fails: script not defined in package.json)*
- `pnpm test` *(fails: multiple existing test failures and missing DATABASE_URL)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694348a6e7b48330ae560870172f1e24)