### PR TITLE
Mega QA: tune Playwright for cloud/live runs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,11 @@ const __dirname = dirname(__filename);
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || process.env.MEGA_QA_BASE_URL || 'http://localhost:5173';
 const isRemoteBaseURL = !baseURL.includes('localhost') && !baseURL.includes('127.0.0.1');
+const isCloud =
+  process.env.MEGA_QA_CLOUD === '1' ||
+  process.env.MEGA_QA_CLOUD === 'true' ||
+  process.env.MEGA_QA_USE_LIVE_DB === '1' ||
+  process.env.MEGA_QA_USE_LIVE_DB === 'true';
 
 export default defineConfig({
   testDir: './tests-e2e',
@@ -14,7 +19,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Cloud/live runs should avoid parallelizing against production.
+  workers: process.env.CI || isCloud ? 1 : undefined,
   reporter: [
     process.env.CI ? ['dot'] : ['list'],
     ['html'],
@@ -46,7 +52,7 @@ export default defineConfig({
   // In CI, we start the server manually before running tests
   // In local dev, Playwright starts the dev server automatically
   // In cloud/remote mode, never start a local dev server.
-  webServer: process.env.CI || isRemoteBaseURL ? undefined : {
+  webServer: process.env.CI || isRemoteBaseURL || isCloud ? undefined : {
     command: 'pnpm dev',
     url: 'http://localhost:5173',
     reuseExistingServer: true,


### PR DESCRIPTION
## Summary\n- Stop forcing CI=1 for cloud runs (avoids unexpected retries/workers).\n- Force single worker in cloud mode and disable retries in quick mode for speed + safety.\n- Ensure Playwright never starts a local dev server in cloud/live mode.\n\n## Test plan\n- [ ] Dispatch "Mega QA (Cloud / Live DB)" quick_mode=true\n