### PR TITLE
Mega QA: make must-hit invalid-login assertion robust

### DIFF
--- a/tests-e2e/mega/must-hit.spec.ts
+++ b/tests-e2e/mega/must-hit.spec.ts
@@ -148,8 +148,10 @@ test.describe("Authentication", () => {
     await page.click('button[type="submit"]');
 
     // Should show error
-    const error = page.locator('[role="alert"], .error, .toast');
-    await expect(error.first()).toBeVisible({ timeout: 5000 });
+    // Login page renders errors as inline text (not necessarily role=alert)
+    await expect(
+      page.getByText(/invalid username or password/i).first()
+    ).toBeVisible({ timeout: 5000 });
 
     // Test success path
     await fillFirstVisible(


### PR DESCRIPTION
## Summary\n- Must-Hit now asserts the actual rendered error text ("Invalid username or password") instead of relying on role=alert/toast selectors.\n\n## Test plan\n- [ ] Run "Mega QA (Cloud / Live DB)" quick_mode=true\n