### PR TITLE
Mega QA: layout consistency supports link-based sidebar

### DIFF
--- a/tests-e2e/mega/must-hit.spec.ts
+++ b/tests-e2e/mega/must-hit.spec.ts
@@ -381,9 +381,10 @@ test.describe("Layout Consistency", () => {
 
       // Sidebar is implemented as a list of buttons (not necessarily <nav>/<aside>).
       // Verify key shell elements exist on every page.
-      await expect(
-        page.getByRole("button", { name: /dashboard/i }).first()
-      ).toBeVisible({ timeout: 5000 });
+      const dashboardNav = page
+        .getByRole("link", { name: /dashboard/i })
+        .or(page.getByRole("button", { name: /dashboard/i }));
+      await expect(dashboardNav.first()).toBeVisible({ timeout: 5000 });
 
       await expect(
         page.getByRole("searchbox", {


### PR DESCRIPTION
## Summary\n- Layout consistency Must-Hit now treats "Dashboard" nav as either a link or a button, since prod renders both variants depending on layout.\n\n## Test plan\n- [ ] Run "Mega QA (Cloud / Live DB)" quick_mode=true\n