### PR TITLE
FIX-006: Add TiDB ENUM compatibility fix at connection pool level

### DIFF
--- a/server/clientsDb.ts
+++ b/server/clientsDb.ts
@@ -44,16 +44,9 @@ export async function getClients(options: {
     hasDebt,
   } = options;
 
-  // FIX-005: Use explicit column selection with CAST for ENUM columns
-  // TiDB may return ENUM values as integers, causing Drizzle parsing to fail
-  // By casting ENUM columns to CHAR, we ensure string values are returned
-  // Using spread operator to include all columns automatically, only overriding ENUM columns
-  let query = db.select({
-    ...clients,
-    // Cast ENUM columns to CHAR to avoid TiDB integer representation issue
-    cogsAdjustmentType: sql<string>`CAST(${clients.cogsAdjustmentType} AS CHAR)`.as('cogsAdjustmentType'),
-    creditLimitSource: sql<string>`CAST(${clients.creditLimitSource} AS CHAR)`.as('creditLimitSource'),
-  }).from(clients);
+  // FIX-006: ENUM handling is now done at connection pool level via typeCast
+  // See: server/_core/connectionPool.ts
+  let query = db.select().from(clients);
 
   // Build WHERE conditions
   const conditions: (SQL<unknown> | undefined)[] = [];


### PR DESCRIPTION
Root cause: TiDB returns ENUM columns with type code 0xf7 (247) in binary
protocol instead of STRING type with ENUM flag like MySQL does. This
causes "Unknown type '247'" errors in the mysql2 driver.

Solution: Add a typeCast handler to the mysql2 connection pool that
intercepts ENUM (and SET) type fields and returns them as strings.
This is a centralized fix that handles ALL queries automatically,
replacing the per-query CAST workaround from FIX-005.

Changes:
- connectionPool.ts: Added typeCast function to handle ENUM/SET types
- clientsDb.ts: Removed FIX-005 CAST workaround (no longer needed)

Reference: https://github.com/pingcap/tidb/issues/6910