### PR TITLE
Add notification center and preferences

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import CreditSettingsPage from "@/pages/CreditSettingsPage";
 import PricingRulesPage from "@/pages/PricingRulesPage";
 import PricingProfilesPage from "@/pages/PricingProfilesPage";
 import SalesSheetCreatorPage from "@/pages/SalesSheetCreatorPage";
+import { NotificationPreferencesPage } from "@/pages/settings/NotificationPreferences";
 import OrderCreatorPage from "@/pages/OrderCreatorPage";
 import Orders from "@/pages/Orders";
 import Quotes from "@/pages/Quotes";
@@ -52,6 +53,7 @@ import SessionEndedPage from "@/pages/vip-portal/SessionEndedPage";
 import { TodoListsPage } from "@/pages/TodoListsPage";
 import { TodoListDetailPage } from "@/pages/TodoListDetailPage";
 import { InboxPage } from "@/pages/InboxPage";
+import { NotificationsPage } from "@/pages/NotificationsPage";
 import CalendarPage from "@/pages/CalendarPage";
 import WorkflowQueuePage from "@/pages/WorkflowQueuePage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
@@ -130,6 +132,10 @@ function Router() {
               <Route path="/orders/create" component={OrderCreatorPage} />
               <Route path="/quotes" component={Quotes} />
               <Route path="/settings/cogs" component={CogsSettingsPage} />
+              <Route
+                path="/settings/notifications"
+                component={NotificationPreferencesPage}
+              />
               <Route path="/settings/feature-flags" component={FeatureFlagsPage} />
               <Route path="/settings" component={Settings} />
               <Route path="/credit-settings" component={CreditSettingsPage} />
@@ -158,6 +164,7 @@ function Router() {
               <Route path="/todo" component={TodoListsPage} />
               <Route path="/todos" component={TodoListsPage} />
               <Route path="/todos/:listId" component={TodoListDetailPage} />
+              <Route path="/notifications" component={NotificationsPage} />
               <Route path="/inbox" component={InboxPage} />
               <Route path="/calendar" component={CalendarPage} />
               <Route path="/workflow-queue" component={WorkflowQueuePage} />

--- a/client/src/components/layout/AppHeader.test.tsx
+++ b/client/src/components/layout/AppHeader.test.tsx
@@ -1,8 +1,7 @@
 /**
  * AppHeader Tests
  *
- * Tests for the AppHeader component, specifically the Inbox dropdown functionality.
- * Ensures the Inbox button opens a dropdown menu instead of navigating directly.
+ * Tests for the AppHeader component, focusing on the Notification bell rendering.
  *
  * @vitest-environment jsdom
  */
@@ -26,29 +25,36 @@ vi.mock("../../../version.json", () => ({
   },
 }));
 
-// Mock tRPC with specific inbox data
+// Mock tRPC with notification data
 vi.mock("@/lib/trpc", () => ({
   trpc: {
-    inbox: {
-      getStats: {
+    notifications: {
+      getUnreadCount: {
         useQuery: vi.fn(() => ({
-          data: { unread: 3, total: 10 },
+          data: { unread: 2 },
           isLoading: false,
           isError: false,
         })),
       },
-      getUnread: {
+      list: {
         useQuery: vi.fn(() => ({
-          data: [
-            { id: 1, title: "Test Item 1", createdAt: new Date() },
-            { id: 2, title: "Test Item 2", createdAt: new Date() },
-            { id: 3, title: "Test Item 3", createdAt: new Date() },
-          ],
+          data: {
+            items: [],
+            total: 0,
+            unread: 2,
+            pagination: { limit: 5, offset: 0 },
+          },
           isLoading: false,
           isError: false,
         })),
       },
-      bulkMarkAsSeen: {
+      markRead: {
+        useMutation: vi.fn(() => ({
+          mutate: vi.fn(),
+          isLoading: false,
+        })),
+      },
+      markAllRead: {
         useMutation: vi.fn(() => ({
           mutate: vi.fn(),
           isLoading: false,
@@ -56,64 +62,31 @@ vi.mock("@/lib/trpc", () => ({
       },
     },
     useContext: vi.fn(() => ({
-      inbox: {
-        getMyItems: { invalidate: vi.fn() },
-        getStats: { invalidate: vi.fn() },
-        getUnread: { invalidate: vi.fn() },
+      notifications: {
+        list: { invalidate: vi.fn() },
+        getUnreadCount: { invalidate: vi.fn() },
       },
     })),
   },
 }));
 
-describe("AppHeader - Inbox Dropdown", () => {
+describe("AppHeader - Notification Bell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render the Inbox button with unread badge", () => {
+  it("renders the notification bell with unread badge", () => {
     render(
       <ThemeProvider>
         <AppHeader />
       </ThemeProvider>
     );
 
-    const inboxButton = screen.getByTitle("Inbox");
-    expect(inboxButton).toBeInTheDocument();
+    const notificationsButton = screen.getByLabelText("Notifications");
+    expect(notificationsButton).toBeInTheDocument();
 
-    // Check for unread badge - should show "3" based on mock data
-    const badge = screen.getByText("3");
+    // Check for unread badge - should show the mocked unread count
+    const badge = screen.getByText("2");
     expect(badge).toBeInTheDocument();
-  });
-
-  it("should render Inbox button as a dropdown trigger, not a direct link", () => {
-    render(
-      <ThemeProvider>
-        <AppHeader />
-      </ThemeProvider>
-    );
-
-    const inboxButton = screen.getByTitle("Inbox");
-
-    // The button should not have an onClick that directly navigates
-    // Instead, it should be wrapped in a DropdownMenuTrigger
-    expect(inboxButton).toBeInTheDocument();
-
-    // Verify it's part of a dropdown menu structure
-    expect(
-      inboxButton.closest('[data-slot="dropdown-menu-trigger"]')
-    ).toBeInTheDocument();
-  });
-
-  it("should display correct unread count in badge", () => {
-    render(
-      <ThemeProvider>
-        <AppHeader />
-      </ThemeProvider>
-    );
-
-    // Should show "3" based on mock data
-    const badge = screen.getByText("3");
-    expect(badge).toBeInTheDocument();
-    expect(badge).toHaveClass("absolute", "-top-1", "-right-1");
   });
 });

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -1,31 +1,19 @@
 import React from "react";
 import {
-  Inbox,
   Search,
   Settings,
   User,
   Menu,
-  CheckCheck,
   Sun,
   Moon,
 } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useLocation } from "wouter";
-import { trpc } from "@/lib/trpc";
 import { useState } from "react";
-import { formatDistanceToNow } from "date-fns";
 import { AppBreadcrumb } from "./AppBreadcrumb";
+import { NotificationBell } from "../notifications/NotificationBell";
 
 interface AppHeaderProps {
   onMenuClick?: () => void;
@@ -35,31 +23,6 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
   const [, setLocation] = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
   const { theme, toggleTheme, switchable } = useTheme();
-
-  // Fetch inbox stats for unread count
-  const { data: inboxStats } = trpc.inbox.getStats.useQuery();
-
-  // Fetch recent inbox items for dropdown preview - handle paginated response
-  const { data: recentItemsData } = trpc.inbox.getUnread.useQuery();
-  const recentItems = Array.isArray(recentItemsData) ? recentItemsData : (recentItemsData?.items ?? []);
-
-  const utils = trpc.useContext();
-
-  // Bulk mark as seen mutation
-  const bulkMarkAsSeen = trpc.inbox.bulkMarkAsSeen.useMutation({
-    onSuccess: () => {
-      utils.inbox.getMyItems.invalidate();
-      utils.inbox.getUnread.invalidate();
-      utils.inbox.getStats.invalidate();
-    },
-  });
-
-  const handleMarkAllAsSeen = () => {
-    const unreadIds = recentItems.map((item: any) => item.id);
-    if (unreadIds.length > 0) {
-      bulkMarkAsSeen.mutate({ itemIds: unreadIds });
-    }
-  };
 
   // Handle search submission
   const handleSearch = (e: React.FormEvent) => {
@@ -115,120 +78,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
 
         {/* Action buttons */}
         <div className="flex items-center gap-1 md:gap-2 ml-2">
-          {/* Inbox Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hidden sm:flex relative"
-                title="Inbox"
-              >
-                <Inbox className="h-5 w-5" />
-                {inboxStats && inboxStats.unread > 0 && (
-                  <Badge
-                    variant="destructive"
-                    className="absolute -top-1 -right-1 h-5 w-5 p-0 flex items-center justify-center text-xs"
-                  >
-                    {inboxStats.unread > 9 ? "9+" : inboxStats.unread}
-                  </Badge>
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-80">
-              <DropdownMenuLabel className="flex items-center justify-between">
-                <span>Inbox</span>
-                {inboxStats && inboxStats.unread > 0 && (
-                  <Badge variant="destructive" className="ml-2">
-                    {inboxStats.unread}
-                  </Badge>
-                )}
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-
-              {recentItems.length === 0 ? (
-                <div className="py-6 text-center text-sm text-muted-foreground">
-                  <Inbox className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                  <p>No unread items</p>
-                </div>
-              ) : (
-                <>
-                  <div className="max-h-[300px] overflow-y-auto">
-                    {recentItems.slice(0, 5).map(item => (
-                      <DropdownMenuItem
-                        key={item.id}
-                        className="flex flex-col items-start gap-1 cursor-pointer"
-                        onClick={() => {
-                          // Navigate based on source type
-                          if (
-                            item.sourceType === "task_assignment" ||
-                            item.sourceType === "task_update"
-                          ) {
-                            setLocation(`/todos/${item.sourceId}`);
-                          }
-                        }}
-                      >
-                        <div className="flex items-center gap-2 w-full">
-                          <div
-                            className={`w-2 h-2 rounded-full ${
-                              item.sourceType === "mention"
-                                ? "bg-blue-500"
-                                : item.sourceType === "task_assignment"
-                                  ? "bg-purple-500"
-                                  : "bg-green-500"
-                            }`}
-                          />
-                          <span className="font-medium text-sm flex-1 truncate">
-                            {item.sourceType === "mention"
-                              ? "Mentioned you"
-                              : item.sourceType === "task_assignment"
-                                ? "Task assigned"
-                                : "Task updated"}
-                          </span>
-                          <span className="text-xs text-muted-foreground">
-                            {formatDistanceToNow(new Date(item.createdAt), {
-                              addSuffix: true,
-                            })}
-                          </span>
-                        </div>
-                        {item.description && (
-                          <p className="text-xs text-muted-foreground line-clamp-2 pl-4">
-                            {item.description}
-                          </p>
-                        )}
-                      </DropdownMenuItem>
-                    ))}
-                  </div>
-                  <DropdownMenuSeparator />
-                  <div className="flex gap-2 p-2">
-                    {recentItems.length > 0 && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="flex-1"
-                        onClick={e => {
-                          e.preventDefault();
-                          handleMarkAllAsSeen();
-                        }}
-                        disabled={bulkMarkAsSeen.isPending}
-                      >
-                        <CheckCheck className="h-4 w-4 mr-2" />
-                        Mark all read
-                      </Button>
-                    )}
-                    <Button
-                      variant="default"
-                      size="sm"
-                      className="flex-1"
-                      onClick={() => setLocation("/inbox")}
-                    >
-                      View all
-                    </Button>
-                  </div>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <NotificationBell className="hidden sm:flex relative" />
 
           {/* Theme Toggle */}
           {switchable && toggleTheme && (

--- a/client/src/components/notifications/NotificationBell.test.tsx
+++ b/client/src/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationBell } from "./NotificationBell";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const mockSetLocation = vi.fn();
+const mockMarkRead = vi.fn();
+const mockMarkAllRead = vi.fn();
+const mockInvalidate = vi.fn();
+
+const sampleNotifications = [
+  {
+    id: 1,
+    title: "New Order",
+    message: "Order #123 created",
+    type: "info",
+    channel: "in_app",
+    read: false,
+    createdAt: new Date(),
+  },
+  {
+    id: 2,
+    title: "Reminder",
+    message: "Appointment tomorrow",
+    type: "warning",
+    channel: "in_app",
+    read: true,
+    createdAt: new Date(),
+  },
+];
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    notifications: {
+      getUnreadCount: {
+        useQuery: vi.fn(() => ({
+          data: { unread: 1 },
+          isLoading: false,
+        })),
+      },
+      list: {
+        useQuery: vi.fn(() => ({
+          data: {
+            items: sampleNotifications,
+            total: sampleNotifications.length,
+            unread: 1,
+            pagination: { limit: 5, offset: 0 },
+          },
+          isLoading: false,
+          refetch: vi.fn(),
+        })),
+      },
+      markRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkRead,
+          isLoading: false,
+        })),
+      },
+      markAllRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkAllRead,
+          isLoading: false,
+        })),
+      },
+    },
+    useContext: vi.fn(() => ({
+      notifications: {
+        list: { invalidate: mockInvalidate },
+        getUnreadCount: { invalidate: mockInvalidate },
+      },
+    })),
+  },
+}));
+
+vi.mock("wouter", () => ({
+  useLocation: () => ["/", mockSetLocation],
+}));
+
+describe("NotificationBell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderBell = () =>
+    render(
+      <ThemeProvider>
+        <NotificationBell />
+      </ThemeProvider>
+    );
+
+  const openDropdown = () => {
+    const trigger = screen.getByRole("button", { name: /notifications/i });
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+  };
+
+  it("renders unread badge from query data", () => {
+    renderBell();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("opens dropdown and lists notifications", async () => {
+    renderBell();
+    openDropdown();
+
+    await waitFor(() => {
+      expect(screen.getByText("New Order")).toBeInTheDocument();
+      expect(screen.getByText("Reminder")).toBeInTheDocument();
+    });
+  });
+
+  it("marks a notification as read when clicked", async () => {
+    renderBell();
+
+    openDropdown();
+    const target = await screen.findByText("New Order");
+    fireEvent.click(target);
+
+    expect(mockMarkRead).toHaveBeenCalledWith({ notificationId: 1 });
+  });
+
+  it("navigates to view all notifications", async () => {
+    renderBell();
+
+    openDropdown();
+    const viewAll = await screen.findByText(/view all/i);
+    fireEvent.click(viewAll);
+
+    expect(mockSetLocation).toHaveBeenCalledWith("/notifications");
+  });
+});

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,185 @@
+import React, { useCallback } from "react";
+import { Bell, CheckCheck, Inbox } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useLocation } from "wouter";
+import { formatDistanceToNow } from "date-fns";
+
+export interface NotificationBellProps {
+  className?: string;
+}
+
+export const NotificationBell = React.memo(function NotificationBell({
+  className,
+}: NotificationBellProps) {
+  const [, setLocation] = useLocation();
+  const utils = trpc.useContext();
+
+  const { data: unreadData } = trpc.notifications.getUnreadCount.useQuery();
+  const { data: listData } = trpc.notifications.list.useQuery({
+    limit: 5,
+    offset: 0,
+  });
+
+  const markRead = trpc.notifications.markRead.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.notifications.list.invalidate(),
+        utils.notifications.getUnreadCount.invalidate(),
+      ]);
+    },
+  });
+
+  const markAllRead = trpc.notifications.markAllRead.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.notifications.list.invalidate(),
+        utils.notifications.getUnreadCount.invalidate(),
+      ]);
+    },
+  });
+
+  const notifications = listData?.items ?? [];
+  const unreadCount = unreadData?.unread ?? 0;
+
+  const handleViewAll = useCallback(() => {
+    setLocation("/notifications");
+  }, [setLocation]);
+
+  const handleMarkAll = useCallback(() => {
+    if (notifications.length === 0) {
+      return;
+    }
+    markAllRead.mutate();
+  }, [markAllRead, notifications.length]);
+
+  const handleSelect = useCallback(
+    (notificationId: number, link?: string | null) => {
+      markRead.mutate({ notificationId });
+      if (link) {
+        setLocation(link);
+      }
+    },
+    [markRead, setLocation]
+  );
+
+  const renderEmpty = () => (
+    <div className="py-6 text-center text-sm text-muted-foreground">
+      <Inbox className="h-8 w-8 mx-auto mb-2 opacity-50" />
+      <p>No notifications yet</p>
+    </div>
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className={className ?? "relative"}
+          aria-label="Notifications"
+        >
+          <Bell className="h-5 w-5" />
+          {unreadCount > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -top-1 -right-1 h-5 w-5 p-0 flex items-center justify-center text-xs"
+            >
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <DropdownMenuLabel className="flex items-center justify-between">
+          <span>Notifications</span>
+          {unreadCount > 0 && (
+            <Badge variant="destructive" className="ml-2">
+              {unreadCount}
+            </Badge>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {notifications.length === 0 ? (
+          renderEmpty()
+        ) : (
+          <>
+            <div className="max-h-[320px] overflow-y-auto">
+              {notifications.map(notification => (
+                <DropdownMenuItem
+                  key={notification.id}
+                  className="flex flex-col items-start gap-1 cursor-pointer"
+                  onClick={() =>
+                    handleSelect(notification.id, notification.link ?? undefined)
+                  }
+                >
+                  <div className="flex items-center gap-2 w-full">
+                    <div
+                      className={`w-2 h-2 rounded-full ${
+                        notification.type === "success"
+                          ? "bg-green-500"
+                          : notification.type === "error"
+                            ? "bg-destructive"
+                            : notification.type === "warning"
+                              ? "bg-amber-500"
+                              : "bg-primary"
+                      }`}
+                    />
+                    <span className="font-medium text-sm flex-1 truncate">
+                      {notification.title}
+                    </span>
+                    {notification.createdAt && (
+                      <span className="text-xs text-muted-foreground">
+                        {formatDistanceToNow(new Date(notification.createdAt), {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    )}
+                  </div>
+                  {notification.message && (
+                    <p className="text-xs text-muted-foreground line-clamp-2 pl-4">
+                      {notification.message}
+                    </p>
+                  )}
+                  {notification.read === false && (
+                    <div className="h-1.5 w-1.5 rounded-full bg-primary ml-4" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </div>
+            <DropdownMenuSeparator />
+            <div className="flex gap-2 p-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
+                onClick={handleMarkAll}
+                disabled={markAllRead.isPending}
+              >
+                <CheckCheck className="h-4 w-4 mr-2" />
+                Mark all read
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                className="flex-1"
+                onClick={handleViewAll}
+              >
+                View All
+              </Button>
+            </div>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+});

--- a/client/src/pages/NotificationsPage.test.tsx
+++ b/client/src/pages/NotificationsPage.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationsPage } from "./NotificationsPage";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const mockMarkRead = vi.fn();
+const mockDelete = vi.fn();
+const mockMarkAll = vi.fn();
+const mockInvalidate = vi.fn();
+
+const sampleNotifications = [
+  {
+    id: 1,
+    title: "New Event",
+    message: "Meeting scheduled",
+    type: "info",
+    channel: "in_app",
+    read: false,
+    createdAt: new Date(),
+  },
+  {
+    id: 2,
+    title: "Update",
+    message: "Task completed",
+    type: "success",
+    channel: "in_app",
+    read: true,
+    createdAt: new Date(),
+  },
+];
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    notifications: {
+      list: {
+        useQuery: vi.fn(() => ({
+          data: {
+            items: sampleNotifications,
+            total: 2,
+            unread: 1,
+            pagination: { limit: 50, offset: 0 },
+          },
+          isLoading: false,
+          isError: false,
+        })),
+      },
+      markRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkRead,
+          isLoading: false,
+        })),
+      },
+      delete: {
+        useMutation: vi.fn(() => ({
+          mutate: mockDelete,
+          isLoading: false,
+        })),
+      },
+      markAllRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkAll,
+          isLoading: false,
+        })),
+      },
+      getUnreadCount: {
+        useQuery: vi.fn(() => ({
+          data: { unread: 1 },
+          isLoading: false,
+          isError: false,
+        })),
+      },
+    },
+    useContext: vi.fn(() => ({
+      notifications: {
+        list: { invalidate: mockInvalidate },
+        getUnreadCount: { invalidate: mockInvalidate },
+      },
+    })),
+  },
+}));
+
+describe("NotificationsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderPage = () =>
+    render(
+      <ThemeProvider>
+        <NotificationsPage />
+      </ThemeProvider>
+    );
+
+  it("renders notification items", () => {
+    renderPage();
+    expect(screen.getByText("New Event")).toBeInTheDocument();
+    expect(screen.getByText("Update")).toBeInTheDocument();
+  });
+
+  it("marks a notification as read", () => {
+    renderPage();
+    fireEvent.click(screen.getAllByRole("button", { name: /mark read/i })[0]);
+    expect(mockMarkRead).toHaveBeenCalledWith({ notificationId: 1 });
+  });
+
+  it("deletes a notification", () => {
+    renderPage();
+    fireEvent.click(screen.getAllByRole("button", { name: /delete/i })[0]);
+    expect(mockDelete).toHaveBeenCalledWith({ notificationId: 1 });
+  });
+});

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -1,0 +1,135 @@
+import React, { useCallback } from "react";
+import { trpc } from "@/lib/trpc";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatDistanceToNow } from "date-fns";
+
+export const NotificationsPage = React.memo(function NotificationsPage(): JSX.Element {
+  const utils = trpc.useContext();
+  const { data: listData, isLoading } = trpc.notifications.list.useQuery({
+    limit: 50,
+    offset: 0,
+  });
+
+  const markRead = trpc.notifications.markRead.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.notifications.list.invalidate(),
+        utils.notifications.getUnreadCount.invalidate(),
+      ]);
+    },
+  });
+
+  const deleteMutation = trpc.notifications.delete.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.notifications.list.invalidate(),
+        utils.notifications.getUnreadCount.invalidate(),
+      ]);
+    },
+  });
+
+  const markAllRead = trpc.notifications.markAllRead.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.notifications.list.invalidate(),
+        utils.notifications.getUnreadCount.invalidate(),
+      ]);
+    },
+  });
+
+  const handleMarkRead = useCallback(
+    (notificationId: number) => {
+      markRead.mutate({ notificationId });
+    },
+    [markRead]
+  );
+
+  const handleDelete = useCallback(
+    (notificationId: number) => {
+      deleteMutation.mutate({ notificationId });
+    },
+    [deleteMutation]
+  );
+
+  const items = listData?.items ?? [];
+  const unreadCount = listData?.unread ?? 0;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Notifications</CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">Unread: {unreadCount}</Badge>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => markAllRead.mutate()}
+              disabled={markAllRead.isPending || items.length === 0}
+            >
+              Mark all read
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {isLoading && <p className="text-sm text-muted-foreground">Loading notifications...</p>}
+          {!isLoading && items.length === 0 && (
+            <p className="text-sm text-muted-foreground">No notifications yet.</p>
+          )}
+          {items.map(item => (
+            <div
+              key={item.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-border p-3"
+            >
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Badge
+                    variant={
+                      item.type === "error"
+                        ? "destructive"
+                        : item.type === "warning"
+                          ? "secondary"
+                          : "default"
+                    }
+                  >
+                    {item.type}
+                  </Badge>
+                  {item.read === false && <Badge variant="outline">Unread</Badge>}
+                </div>
+                <p className="font-medium">{item.title}</p>
+                {item.message && (
+                  <p className="text-sm text-muted-foreground">{item.message}</p>
+                )}
+                {item.createdAt && (
+                  <p className="text-xs text-muted-foreground">
+                    {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleMarkRead(item.id)}
+                  disabled={markRead.isPending}
+                >
+                  Mark Read
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleDelete(item.id)}
+                  disabled={deleteMutation.isPending}
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+});

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Plus, Trash2, Edit2, Save, X, Database, AlertTriangle, Flag } from "lucide-react";
+import { Plus, Trash2, Edit2, Save, X, Database, AlertTriangle, Flag, Bell } from "lucide-react";
 import { BackButton } from "@/components/common/BackButton";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
@@ -49,6 +49,7 @@ export default function Settings() {
             <TabsTrigger value="database" className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2">Database</TabsTrigger>
             <TabsTrigger value="feature-flags" className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2">Feature Flags</TabsTrigger>
             <TabsTrigger value="vip-impersonation" className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2">VIP Access</TabsTrigger>
+            <TabsTrigger value="notifications" className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2">Notifications</TabsTrigger>
           </TabsList>
         </div>
 
@@ -108,6 +109,26 @@ export default function Settings() {
 
         <TabsContent value="vip-impersonation" className="space-y-3 sm:space-y-4 mt-3 sm:mt-4">
           <VIPImpersonationManager />
+        </TabsContent>
+
+        <TabsContent value="notifications" className="space-y-3 sm:space-y-4 mt-3 sm:mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Bell className="h-5 w-5" />
+                Notification Preferences
+              </CardTitle>
+              <CardDescription>Control how you receive alerts and reminders.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Configure in-app and email notifications along with reminders for appointments, orders, and system alerts.
+              </p>
+              <Button asChild>
+                <a href="/settings/notifications">Open Notification Preferences</a>
+              </Button>
+            </CardContent>
+          </Card>
         </TabsContent>
       </Tabs>
     </div>
@@ -708,4 +729,3 @@ function GradesManager() {
     </Card>
   );
 }
-

--- a/client/src/pages/settings/NotificationPreferences.test.tsx
+++ b/client/src/pages/settings/NotificationPreferences.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationPreferencesPage } from "./NotificationPreferences";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const mockUpdate = vi.fn();
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    useContext: vi.fn(() => ({
+      notifications: {
+        getPreferences: { invalidate: vi.fn() },
+      },
+    })),
+    notifications: {
+      getPreferences: {
+        useQuery: vi.fn(() => ({
+          data: {
+            inAppEnabled: true,
+            emailEnabled: true,
+            appointmentReminders: true,
+            orderUpdates: false,
+            systemAlerts: true,
+          },
+          isLoading: false,
+        })),
+      },
+      updatePreferences: {
+        useMutation: vi.fn(() => ({
+          mutate: mockUpdate,
+          isLoading: false,
+        })),
+      },
+    },
+  },
+}));
+
+describe("NotificationPreferencesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderPage = () =>
+    render(
+      <ThemeProvider>
+        <NotificationPreferencesPage />
+      </ThemeProvider>
+    );
+
+  it("renders toggle controls for each preference", () => {
+    renderPage();
+    expect(screen.getByLabelText(/in-app notifications/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email notifications/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/appointment reminders/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/order updates/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/system alerts/i)).toBeInTheDocument();
+  });
+
+  it("submits updated preferences", () => {
+    renderPage();
+
+    const orderToggle = screen.getByLabelText(/order updates/i);
+    fireEvent.click(orderToggle);
+
+    const saveButton = screen.getByRole("button", { name: /save preferences/i });
+    fireEvent.click(saveButton);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      orderUpdates: true,
+      inAppEnabled: true,
+      emailEnabled: true,
+      appointmentReminders: true,
+      systemAlerts: true,
+    });
+  });
+});

--- a/client/src/pages/settings/NotificationPreferences.tsx
+++ b/client/src/pages/settings/NotificationPreferences.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { trpc } from "@/lib/trpc";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+type PreferenceKey =
+  | "inAppEnabled"
+  | "emailEnabled"
+  | "appointmentReminders"
+  | "orderUpdates"
+  | "systemAlerts";
+
+type PreferencesState = Record<PreferenceKey, boolean>;
+
+const defaultState: PreferencesState = {
+  inAppEnabled: true,
+  emailEnabled: true,
+  appointmentReminders: true,
+  orderUpdates: true,
+  systemAlerts: true,
+};
+
+export const NotificationPreferencesPage = React.memo(
+  function NotificationPreferencesPage(): JSX.Element {
+    const utils = trpc.useContext();
+    const { data: preferencesData } = trpc.notifications.getPreferences.useQuery();
+    const mutation = trpc.notifications.updatePreferences.useMutation({
+      onSuccess: async () => {
+        await utils.notifications.getPreferences.invalidate();
+      },
+    });
+
+    const [state, setState] = useState<PreferencesState>(defaultState);
+    const [hasHydrated, setHasHydrated] = useState(false);
+    const controls = useMemo(
+      () => [
+        {
+          key: "inAppEnabled" as const,
+          title: "In-App Notifications",
+          description: "Receive notifications within the ERP dashboard.",
+        },
+        {
+          key: "emailEnabled" as const,
+          title: "Email Notifications",
+          description: "Enable future email alerts for critical events.",
+        },
+        {
+          key: "appointmentReminders" as const,
+          title: "Appointment Reminders",
+          description: "Get reminded about upcoming client appointments.",
+        },
+        {
+          key: "orderUpdates" as const,
+          title: "Order Updates",
+          description: "Stay informed about order changes and status updates.",
+        },
+        {
+          key: "systemAlerts" as const,
+          title: "System Alerts",
+          description: "Receive system health and maintenance notifications.",
+        },
+      ],
+      []
+    );
+
+    useEffect(() => {
+      if (!preferencesData || hasHydrated) {
+        return;
+      }
+      const nextState = controls.reduce<PreferencesState>(
+        (acc, control) => ({
+          ...acc,
+          [control.key]:
+            preferencesData[control.key] ?? defaultState[control.key],
+        }),
+        defaultState
+      );
+      setState(nextState);
+      setHasHydrated(true);
+    }, [controls, hasHydrated, preferencesData]);
+
+    const handleToggle = useCallback(
+      (key: PreferenceKey) => (checked: boolean) => {
+      setState(prev => ({
+        ...prev,
+        [key]: checked,
+      }));
+    },
+    []
+  );
+
+    const handleSave = useCallback(() => {
+      mutation.mutate(state);
+    }, [mutation, state]);
+
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Notification Preferences</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {controls.map(control => (
+              <div
+                key={control.key}
+                className="flex items-center justify-between border border-border rounded-lg p-4"
+              >
+                <div className="space-y-1">
+                  <Label htmlFor={control.key}>{control.title}</Label>
+                  <p className="text-sm text-muted-foreground">
+                    {control.description}
+                  </p>
+                </div>
+                <Switch
+                  id={control.key}
+                  checked={state[control.key]}
+                  onCheckedChange={handleToggle(control.key)}
+                  aria-label={control.title}
+                />
+              </div>
+            ))}
+
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={mutation.isPending}
+              >
+                Save Preferences
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+);

--- a/docs/ACTIVE_SESSIONS.md
+++ b/docs/ACTIVE_SESSIONS.md
@@ -22,11 +22,10 @@
 
 ## 🟢 Currently Working
 
-| Session ID                              | Task                     | Branch                                  | Module        | Status      | Started    | ETA |
-| --------------------------------------- | ------------------------ | --------------------------------------- | ------------- | ----------- | ---------- | --- |
-| Session-20251230-ROADMAP-CLEANUP-39dfaf | ROADMAP-CLEANUP          | main                                    | docs          | In Progress | 2025-12-30 | TBA |
-| Session-20260102-SPRINT-B-f0b134        | Sprint B Frontend UX     | main                                    | client/src    | In Progress | 2026-01-02 | -   |
-
+| Session ID                              | Task                 | Branch | Module     | Status      | Started    | ETA |
+| --------------------------------------- | -------------------- | ------ | ---------- | ----------- | ---------- | --- |
+| Session-20251230-ROADMAP-CLEANUP-39dfaf | ROADMAP-CLEANUP      | main   | docs       | In Progress | 2025-12-30 | TBA |
+| Session-20260102-SPRINT-B-f0b134        | Sprint B Frontend UX | main   | client/src | In Progress | 2026-01-02 | -   |
 
 ## ⏸️ Paused / Waiting
 
@@ -73,6 +72,6 @@ Branch: `claude/DOCS-002-20251231-82fd9d00`
 
 ## ✅ Completed Recently (2026-01-03)
 
-| Session ID                          | Task                                         | Status      |
-| ----------------------------------- | -------------------------------------------- | ----------- |
+| Session ID                          | Task                                           | Status      |
+| ----------------------------------- | ---------------------------------------------- | ----------- |
 | Session-20260103-FEATURE-012-f75eef | FEATURE-012 VIP Portal Admin Access Deployment | ✅ Complete |

--- a/docs/roadmaps/MASTER_ROADMAP.md
+++ b/docs/roadmaps/MASTER_ROADMAP.md
@@ -8535,7 +8535,7 @@ Core systems are foundational components that:
 ### NOTIF-001: Unified Notification System Architecture (32h)
 
 **Priority:** HIGH
-**Status:** 🔴 Not Started
+**Status:** 🟡 In Progress
 **Blocking:** VIP-C-001 (Appointment Scheduling System)
 
 Replaces the current "Inbox" with a unified "Notifications" system that serves both ERP users and VIP Portal clients.
@@ -8562,13 +8562,13 @@ Replaces the current "Inbox" with a unified "Notifications" system that serves b
 
 | Task ID  | Task                                  | Estimate | Status         |
 | -------- | ------------------------------------- | -------- | -------------- |
-| NOTIF-01 | Database schema changes & migration   | 4h       | 🔴 Not Started |
-| NOTIF-02 | Notification service refactor         | 8h       | 🔴 Not Started |
-| NOTIF-03 | Notifications router refactor         | 4h       | 🔴 Not Started |
-| NOTIF-04 | VIP Portal notification endpoints     | 4h       | 🔴 Not Started |
-| NOTIF-05 | ERP UI rename (Inbox → Notifications) | 4h       | 🔴 Not Started |
-| NOTIF-06 | VIP Portal notification bell UI       | 4h       | 🔴 Not Started |
-| NOTIF-07 | Notification preferences UI           | 4h       | 🔴 Not Started |
+| NOTIF-01 | Database schema changes & migration   | 4h       | 🟡 In Progress |
+| NOTIF-02 | Notification service refactor         | 8h       | 🟡 In Progress |
+| NOTIF-03 | Notifications router refactor         | 4h       | 🟡 In Progress |
+| NOTIF-04 | VIP Portal notification endpoints     | 4h       | 🟡 In Progress |
+| NOTIF-05 | ERP UI rename (Inbox → Notifications) | 4h       | 🟡 In Progress |
+| NOTIF-06 | VIP Portal notification bell UI       | 4h       | 🟡 In Progress |
+| NOTIF-07 | Notification preferences UI           | 4h       | 🟡 In Progress |
 
 #### Specifications
 

--- a/docs/sessions/completed/Session-20260103-NOTIF-001-007-edcfff.md
+++ b/docs/sessions/completed/Session-20260103-NOTIF-001-007-edcfff.md
@@ -1,0 +1,34 @@
+# Session: NOTIF-001 to NOTIF-007 - Unified Notification System
+
+**Status**: In Progress
+**Started**: 2026-01-03
+**Agent Type**: Core Systems Agent - Notifications (External)
+**Branch**: main
+
+## File Ownership (Planned)
+
+- drizzle/schema.ts
+- server/services/notificationService.ts
+- server/routers/notifications.ts
+- client/src/components/layout/Sidebar.tsx
+- client/src/components/notifications/
+- client/src/pages/Settings/NotificationPreferences.tsx
+- docs/roadmaps/MASTER_ROADMAP.md
+
+## Tasks
+
+- [ ] NOTIF-001: Notification service architecture
+- [ ] NOTIF-002: Notification preferences schema & migration
+- [ ] NOTIF-003: Notifications router
+- [ ] NOTIF-004: VIP portal notification endpoints
+- [ ] NOTIF-005: ERP UI rename Inbox → Notifications
+- [ ] NOTIF-006: Notification bell UI
+- [ ] NOTIF-007: Notification preferences UI
+
+## Progress Log
+
+- 2026-01-03: Session registered
+
+## Notes
+
+- Follow strict file boundaries and testing requirements

--- a/drizzle/migrations/0023_add_notifications_tables.sql
+++ b/drizzle/migrations/0023_add_notifications_tables.sql
@@ -1,0 +1,45 @@
+-- Migration: 0023_add_notifications_tables
+-- Feature: NOTIF-001 Unified Notification System
+-- Date: 2026-01-03
+-- Description: Adds notifications and notification_preferences tables for ERP and VIP portal recipients
+
+CREATE TABLE IF NOT EXISTS `notifications` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `recipient_type` ENUM('user', 'client') NOT NULL DEFAULT 'user',
+  `user_id` INT NULL,
+  `client_id` INT NULL,
+  `type` ENUM('info', 'warning', 'success', 'error') NOT NULL,
+  `title` VARCHAR(255) NOT NULL,
+  `message` TEXT NULL,
+  `link` VARCHAR(500) NULL,
+  `channel` ENUM('in_app', 'email', 'sms') NOT NULL DEFAULT 'in_app',
+  `read` BOOLEAN NOT NULL DEFAULT FALSE,
+  `metadata` JSON NULL,
+  `is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX `idx_notifications_recipient_channel` (`recipient_type`, `user_id`, `client_id`, `channel`),
+  INDEX `idx_notifications_recipient_read` (`recipient_type`, `user_id`, `client_id`, `read`),
+  INDEX `idx_notifications_recipient_created` (`recipient_type`, `user_id`, `client_id`, `created_at`),
+  CONSTRAINT `fk_notifications_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_notifications_client` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `notification_preferences` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `recipient_type` ENUM('user', 'client') NOT NULL DEFAULT 'user',
+  `user_id` INT NULL,
+  `client_id` INT NULL,
+  `in_app_enabled` BOOLEAN NOT NULL DEFAULT TRUE,
+  `email_enabled` BOOLEAN NOT NULL DEFAULT TRUE,
+  `appointment_reminders` BOOLEAN NOT NULL DEFAULT TRUE,
+  `order_updates` BOOLEAN NOT NULL DEFAULT TRUE,
+  `system_alerts` BOOLEAN NOT NULL DEFAULT TRUE,
+  `is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX `idx_notification_preferences_recipient` (`recipient_type`, `user_id`, `client_id`),
+  UNIQUE INDEX `uid_notification_preferences_recipient` (`recipient_type`, `user_id`, `client_id`),
+  CONSTRAINT `fk_notification_preferences_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_notification_preferences_client` FOREIGN KEY (`client_id`) REFERENCES `clients` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/_core/calendarJobs.ts
+++ b/server/_core/calendarJobs.ts
@@ -57,14 +57,15 @@ export async function reminderNotificationJob(): Promise<void> {
         if (reminder.method === "IN_APP" || reminder.method === "BOTH") {
           await sendNotification({
             userId: reminder.userId,
+            type: "info",
             title: notificationTitle,
             message: notificationMessage,
-            method: "in-app",
             metadata: {
               eventId: event.id,
               type: "calendar_reminder",
               startTime: event.startDate.toISOString(),
             },
+            category: "appointment",
           });
         }
 
@@ -286,13 +287,14 @@ export async function collectionsAlertJob(): Promise<void> {
     if (highPriorityClients.length > 0) {
       await sendNotification({
         userId: 1,
+        type: "warning",
         title: "Collections Queue Updated",
         message: `${highPriorityClients.length} high-priority clients need collections calls today.`,
-        method: "in-app",
         metadata: {
           type: "collections_alert",
           clientCount: highPriorityClients.length,
         },
+        category: "system",
       });
     }
 

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -58,6 +58,7 @@ import { todoTasksRouter } from "./routers/todoTasks";
 import { commentsRouter } from "./routers/comments";
 import { usersRouter } from "./routers/users";
 import { inboxRouter } from "./routers/inbox";
+import { notificationsRouter } from "./routers/notifications";
 import { todoActivityRouter } from "./routers/todoActivity";
 import { calendarRouter } from "./routers/calendar";
 import { calendarParticipantsRouter } from "./routers/calendarParticipants";
@@ -166,6 +167,7 @@ export const appRouter = router({
   comments: commentsRouter,
   users: usersRouter,
   inbox: inboxRouter,
+  notifications: notificationsRouter,
   todoActivity: todoActivityRouter,
   calendar: calendarRouter,
   calendarParticipants: calendarParticipantsRouter,

--- a/server/routers/calendarParticipants.ts
+++ b/server/routers/calendarParticipants.ts
@@ -95,15 +95,16 @@ export const calendarParticipantsRouter = router({
           const { sendNotification } = await import("../services/notificationService");
           await sendNotification({
             userId: input.userId,
+            type: "info",
             title: "Calendar Invitation",
             message: `You've been invited to "${event.title}" on ${new Date(event.startDate).toLocaleDateString()}`,
-            method: "in-app",
             metadata: {
               eventId: input.eventId,
               type: "calendar_invitation",
               startTime: event.startDate.toISOString(),
               role: input.role,
             },
+            category: "appointment",
           });
         }
         

--- a/server/routers/notifications.test.ts
+++ b/server/routers/notifications.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment node
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { notificationsRouter } from "./notifications";
+import type { TrpcContext } from "../_core/context";
+
+const serviceMocks = vi.hoisted(() => ({
+  mockListNotifications: vi.fn(),
+  mockMarkRead: vi.fn(),
+  mockMarkAll: vi.fn(),
+  mockDelete: vi.fn(),
+  mockUnread: vi.fn(),
+  mockGetPreferences: vi.fn(),
+  mockUpdatePreferences: vi.fn(),
+}));
+
+vi.mock("../services/notificationService", () => ({
+  listNotifications: serviceMocks.mockListNotifications,
+  markNotificationRead: serviceMocks.mockMarkRead,
+  markAllNotificationsRead: serviceMocks.mockMarkAll,
+  deleteNotification: serviceMocks.mockDelete,
+  getUnreadCount: serviceMocks.mockUnread,
+  getNotificationPreferences: serviceMocks.mockGetPreferences,
+  updateNotificationPreferences: serviceMocks.mockUpdatePreferences,
+}));
+
+const baseUser = {
+  id: 10,
+  openId: "user-10",
+  email: "user@example.com",
+  name: "User Ten",
+  role: "user" as const,
+  loginMethod: null,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastSignedIn: new Date(),
+};
+
+const baseContext: TrpcContext = {
+  user: baseUser,
+  req: { headers: {} } as TrpcContext["req"],
+  res: {} as TrpcContext["res"],
+};
+
+const createCaller = () => notificationsRouter.createCaller(baseContext);
+
+describe("notificationsRouter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists notifications with pagination data", async () => {
+    serviceMocks.mockListNotifications.mockResolvedValue([{ id: 1, title: "Test" }]);
+    serviceMocks.mockUnread.mockResolvedValue(2);
+    const caller = createCaller();
+
+    const result = await caller.list({ limit: 5, offset: 0 });
+
+    expect(serviceMocks.mockListNotifications).toHaveBeenCalledWith(
+      { userId: 10 },
+      { limit: 5, offset: 0 }
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.unread).toBe(2);
+  });
+
+  it("marks a notification as read", async () => {
+    const caller = createCaller();
+    await caller.markRead({ notificationId: 4 });
+    expect(serviceMocks.mockMarkRead).toHaveBeenCalledWith(4, { userId: 10 });
+  });
+
+  it("marks all notifications as read", async () => {
+    serviceMocks.mockMarkAll.mockResolvedValue(3);
+    const caller = createCaller();
+    const result = await caller.markAllRead();
+    expect(serviceMocks.mockMarkAll).toHaveBeenCalledWith({ userId: 10 });
+    expect(result.updated).toBe(3);
+  });
+
+  it("deletes a notification", async () => {
+    const caller = createCaller();
+    await caller.delete({ notificationId: 7 });
+    expect(serviceMocks.mockDelete).toHaveBeenCalledWith(7, { userId: 10 });
+  });
+
+  it("returns unread count", async () => {
+    serviceMocks.mockUnread.mockResolvedValue(5);
+    const caller = createCaller();
+    const result = await caller.getUnreadCount();
+    expect(serviceMocks.mockUnread).toHaveBeenCalledWith({ userId: 10 });
+    expect(result.unread).toBe(5);
+  });
+
+  it("updates preferences", async () => {
+    serviceMocks.mockUpdatePreferences.mockResolvedValue({
+      userId: 10,
+      recipientType: "user",
+      clientId: null,
+      inAppEnabled: false,
+      emailEnabled: true,
+      appointmentReminders: false,
+      orderUpdates: true,
+      systemAlerts: true,
+      isDeleted: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      id: 2,
+    });
+    const caller = createCaller();
+    await caller.updatePreferences({ inAppEnabled: false });
+    expect(serviceMocks.mockUpdatePreferences).toHaveBeenCalledWith(
+      { userId: 10 },
+      {
+      inAppEnabled: false,
+    },
+    );
+  });
+});

--- a/server/routers/notifications.ts
+++ b/server/routers/notifications.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import { router, protectedProcedure, vipPortalProcedure } from "../_core/trpc";
+import {
+  deleteNotification,
+  getNotificationPreferences,
+  getUnreadCount,
+  listNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  updateNotificationPreferences,
+} from "../services/notificationService";
+
+const paginationInput = z
+  .object({
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  })
+  .optional();
+
+const resolvePagination = (input: z.infer<typeof paginationInput>) => ({
+  limit: input?.limit ?? 20,
+  offset: input?.offset ?? 0,
+});
+
+const preferenceInput = z.object({
+  inAppEnabled: z.boolean().optional(),
+  emailEnabled: z.boolean().optional(),
+  appointmentReminders: z.boolean().optional(),
+  orderUpdates: z.boolean().optional(),
+  systemAlerts: z.boolean().optional(),
+});
+
+export const notificationsRouter = router({
+  list: protectedProcedure.input(paginationInput).query(async ({ ctx, input }) => {
+    const { limit, offset } = resolvePagination(input);
+    const items = await listNotifications({ userId: ctx.user.id }, { limit, offset });
+    const unread = await getUnreadCount({ userId: ctx.user.id });
+
+    return {
+      items,
+      unread,
+      total: items.length,
+      pagination: { limit, offset },
+    };
+  }),
+
+  markRead: protectedProcedure
+    .input(z.object({ notificationId: z.number().int() }))
+    .mutation(async ({ ctx, input }) => {
+      await markNotificationRead(input.notificationId, { userId: ctx.user.id });
+      return { success: true };
+    }),
+
+  markAllRead: protectedProcedure.mutation(async ({ ctx }) => {
+    const updated = await markAllNotificationsRead({ userId: ctx.user.id });
+    return { updated };
+  }),
+
+  delete: protectedProcedure
+    .input(z.object({ notificationId: z.number().int() }))
+    .mutation(async ({ ctx, input }) => {
+      await deleteNotification(input.notificationId, { userId: ctx.user.id });
+      return { success: true };
+    }),
+
+  getUnreadCount: protectedProcedure.query(async ({ ctx }) => ({
+    unread: await getUnreadCount({ userId: ctx.user.id }),
+  })),
+
+  getPreferences: protectedProcedure.query(async ({ ctx }) =>
+    getNotificationPreferences({ userId: ctx.user.id })
+  ),
+
+  updatePreferences: protectedProcedure
+    .input(preferenceInput)
+    .mutation(async ({ ctx, input }) =>
+      updateNotificationPreferences({ userId: ctx.user.id }, input)
+    ),
+
+  vipList: vipPortalProcedure.input(paginationInput).query(async ({ ctx, input }) => {
+    const { limit, offset } = resolvePagination(input);
+    const clientId = ctx.clientId;
+    const items = await listNotifications(
+      { clientId, recipientType: "client" },
+      { limit, offset }
+    );
+    const unread = await getUnreadCount({ clientId, recipientType: "client" });
+
+    return {
+      items,
+      unread,
+      total: items.length,
+      pagination: { limit, offset },
+    };
+  }),
+
+  vipMarkRead: vipPortalProcedure
+    .input(z.object({ notificationId: z.number().int() }))
+    .mutation(async ({ ctx, input }) => {
+      await markNotificationRead(input.notificationId, {
+        clientId: ctx.clientId,
+        recipientType: "client",
+      });
+      return { success: true };
+    }),
+
+  vipMarkAllRead: vipPortalProcedure.mutation(async ({ ctx }) => {
+    const updated = await markAllNotificationsRead({
+      clientId: ctx.clientId,
+      recipientType: "client",
+    });
+    return { updated };
+  }),
+
+  vipGetUnreadCount: vipPortalProcedure.query(async ({ ctx }) => ({
+    unread: await getUnreadCount({
+      clientId: ctx.clientId,
+      recipientType: "client",
+    }),
+  })),
+
+  vipGetPreferences: vipPortalProcedure.query(async ({ ctx }) =>
+    getNotificationPreferences({
+      clientId: ctx.clientId,
+      recipientType: "client",
+    })
+  ),
+
+  vipUpdatePreferences: vipPortalProcedure
+    .input(preferenceInput)
+    .mutation(async ({ ctx, input }) =>
+      updateNotificationPreferences(
+        { clientId: ctx.clientId, recipientType: "client" },
+        input
+      )
+    ),
+});

--- a/server/routers/vipPortal.ts
+++ b/server/routers/vipPortal.ts
@@ -246,14 +246,16 @@ export const vipPortalRouter = router({
           const appUrl = process.env.APP_URL || "https://terp-app-b9s35.ondigitalocean.app";
           await sendNotification({
             userId: authRecord.clientId,
+            type: "warning",
             title: "Password Reset Request",
             message: `Click here to reset your VIP Portal password: ${appUrl}/vip-portal/reset-password?token=${resetToken}`,
-            method: "email",
+            channels: ["email"],
             metadata: {
               type: "password_reset",
               token: resetToken,
               expiresAt: resetTokenExpiresAt.toISOString(),
             },
+            category: "system",
           });
         } catch (emailError) {
           // Log but don't fail - user can still use the token

--- a/server/services/notificationRepository.ts
+++ b/server/services/notificationRepository.ts
@@ -1,0 +1,453 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import {
+  notificationPreferences,
+  notifications,
+  type InsertNotification,
+  type InsertNotificationPreference,
+  type Notification,
+  type NotificationPreference,
+} from "../../drizzle/schema";
+import { getDb } from "../db";
+import { logger } from "../_core/logger";
+
+export type NotificationChannel = "in_app" | "email" | "sms";
+export type NotificationType = "info" | "warning" | "success" | "error";
+export type NotificationCategory = "appointment" | "order" | "system" | "general";
+
+export interface NotificationRecipient {
+  userId?: number;
+  clientId?: number;
+  recipientType?: "user" | "client";
+}
+
+export interface ResolvedRecipient {
+  userId: number | null;
+  clientId: number | null;
+  recipientType: "user" | "client";
+}
+
+export type PreferenceFlags = {
+  inAppEnabled: boolean;
+  emailEnabled: boolean;
+  appointmentReminders: boolean;
+  orderUpdates: boolean;
+  systemAlerts: boolean;
+  isDeleted: boolean;
+};
+
+export type PreferenceUpdateInput = Partial<PreferenceFlags>;
+
+export interface NotificationRepository {
+  insertNotification: (input: InsertNotification) => Promise<number>;
+  listNotifications: (
+    recipient: ResolvedRecipient,
+    limit: number,
+    offset: number
+  ) => Promise<Notification[]>;
+  markRead: (id: number, recipient: ResolvedRecipient) => Promise<void>;
+  markAllRead: (recipient: ResolvedRecipient) => Promise<number>;
+  softDelete: (id: number, recipient: ResolvedRecipient) => Promise<void>;
+  countUnread: (recipient: ResolvedRecipient) => Promise<number>;
+  getPreferences: (recipient: ResolvedRecipient) => Promise<NotificationPreference | null>;
+  savePreferences: (
+    recipient: ResolvedRecipient,
+    updates: PreferenceUpdateInput
+  ) => Promise<NotificationPreference>;
+}
+
+type Database = NonNullable<Awaited<ReturnType<typeof getDb>>>;
+
+const defaultPreferences: PreferenceFlags = {
+  inAppEnabled: true,
+  emailEnabled: true,
+  appointmentReminders: true,
+  orderUpdates: true,
+  systemAlerts: true,
+  isDeleted: false,
+};
+
+const ensureIdentifier = (value: number | null | undefined): number => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    throw new Error("Notification recipient is required");
+  }
+  return value;
+};
+
+export const resolveRecipient = (input: NotificationRecipient): ResolvedRecipient => {
+  if (
+    input.recipientType === "client" ||
+    (!input.userId && input.clientId !== undefined)
+  ) {
+    return {
+      recipientType: "client",
+      userId: null,
+      clientId: ensureIdentifier(input.clientId),
+    };
+  }
+
+  if (input.userId !== undefined) {
+    return {
+      recipientType: "user",
+      userId: ensureIdentifier(input.userId),
+      clientId: null,
+    };
+  }
+
+  if (input.clientId !== undefined) {
+    return {
+      recipientType: "client",
+      userId: null,
+      clientId: ensureIdentifier(input.clientId),
+    };
+  }
+
+  throw new Error("Notification recipient is required");
+};
+
+const recipientKey = (recipient: ResolvedRecipient): string =>
+  `${recipient.recipientType}:${recipient.recipientType === "user" ? recipient.userId : recipient.clientId}`;
+
+const preferencesFromRecipient = (
+  recipient: ResolvedRecipient,
+  updates?: PreferenceUpdateInput,
+  timestamps?: { createdAt?: Date; updatedAt?: Date }
+): InsertNotificationPreference => {
+  const now = new Date();
+  const createdAt = timestamps?.createdAt ?? now;
+  const updatedAt = timestamps?.updatedAt ?? now;
+  return {
+    recipientType: recipient.recipientType,
+    userId: recipient.userId,
+    clientId: recipient.clientId,
+    ...defaultPreferences,
+    ...updates,
+    isDeleted: updates?.isDeleted ?? false,
+    createdAt,
+    updatedAt,
+  };
+};
+
+const normalizePreferenceRecord = (
+  preference: InsertNotificationPreference & { id: number }
+): NotificationPreference => {
+  const now = new Date();
+  return {
+    id: preference.id,
+    recipientType: preference.recipientType ?? "user",
+    userId: preference.userId ?? null,
+    clientId: preference.clientId ?? null,
+    inAppEnabled:
+      preference.inAppEnabled ?? defaultPreferences.inAppEnabled,
+    emailEnabled: preference.emailEnabled ?? defaultPreferences.emailEnabled,
+    appointmentReminders:
+      preference.appointmentReminders ?? defaultPreferences.appointmentReminders,
+    orderUpdates: preference.orderUpdates ?? defaultPreferences.orderUpdates,
+    systemAlerts: preference.systemAlerts ?? defaultPreferences.systemAlerts,
+    isDeleted: preference.isDeleted ?? false,
+    createdAt: preference.createdAt ?? now,
+    updatedAt: preference.updatedAt ?? now,
+  };
+};
+
+const matchesRecipient = (
+  record: Notification,
+  recipient: ResolvedRecipient
+): boolean => {
+  if (record.recipientType !== recipient.recipientType) {
+    return false;
+  }
+  if (recipient.recipientType === "user") {
+    return record.userId === recipient.userId && (record.isDeleted ?? false) === false;
+  }
+  return record.clientId === recipient.clientId && (record.isDeleted ?? false) === false;
+};
+
+const notificationRecipientWhere = (recipient: ResolvedRecipient) =>
+  and(
+    eq(notifications.recipientType, recipient.recipientType),
+    recipient.recipientType === "user"
+      ? eq(notifications.userId, ensureIdentifier(recipient.userId))
+      : eq(notifications.clientId, ensureIdentifier(recipient.clientId)),
+    eq(notifications.isDeleted, false)
+  );
+
+const preferenceRecipientWhere = (recipient: ResolvedRecipient) =>
+  and(
+    eq(notificationPreferences.recipientType, recipient.recipientType),
+    recipient.recipientType === "user"
+      ? eq(notificationPreferences.userId, ensureIdentifier(recipient.userId))
+      : eq(
+          notificationPreferences.clientId,
+          ensureIdentifier(recipient.clientId)
+        ),
+    eq(notificationPreferences.isDeleted, false)
+  );
+
+const inMemoryNotifications: Notification[] = [];
+const inMemoryPreferences = new Map<string, NotificationPreference>();
+let inMemoryNotificationId = 1;
+let inMemoryPreferenceId = 1;
+
+const inMemoryRepository: NotificationRepository = {
+  insertNotification: async (input: InsertNotification): Promise<number> => {
+    const id = inMemoryNotificationId;
+    inMemoryNotificationId += 1;
+    const createdAt = input.createdAt ?? new Date();
+    const updatedAt = input.updatedAt ?? createdAt;
+    inMemoryNotifications.unshift({
+      id,
+      recipientType: input.recipientType ?? "user",
+      userId: input.userId ?? null,
+      clientId: input.clientId ?? null,
+      type: input.type,
+      title: input.title,
+      message: input.message ?? null,
+      link: input.link ?? null,
+      channel: input.channel ?? "in_app",
+      read: input.read ?? false,
+      metadata: input.metadata ?? null,
+      isDeleted: input.isDeleted ?? false,
+      createdAt,
+      updatedAt,
+    });
+    return id;
+  },
+  listNotifications: async (
+    recipient: ResolvedRecipient,
+    limit: number,
+    offset: number
+  ): Promise<Notification[]> => {
+    return inMemoryNotifications
+      .filter(item => matchesRecipient(item, recipient))
+      .sort(
+        (a, b) =>
+          (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0)
+      )
+      .slice(offset, offset + limit);
+  },
+  markRead: async (
+    id: number,
+    recipient: ResolvedRecipient
+  ): Promise<void> => {
+    const target = inMemoryNotifications.find(
+      item =>
+        item.id === id &&
+        matchesRecipient(item, recipient)
+    );
+    if (target) {
+      target.read = true;
+      target.updatedAt = new Date();
+    }
+  },
+  markAllRead: async (recipient: ResolvedRecipient): Promise<number> => {
+    let updated = 0;
+    inMemoryNotifications.forEach(item => {
+      const matches = matchesRecipient(item, recipient);
+      if (matches && !item.read && !item.isDeleted) {
+        item.read = true;
+        item.updatedAt = new Date();
+        updated += 1;
+      }
+    });
+    return updated;
+  },
+  softDelete: async (
+    id: number,
+    recipient: ResolvedRecipient
+  ): Promise<void> => {
+    const target = inMemoryNotifications.find(
+      item =>
+        item.id === id &&
+        matchesRecipient(item, recipient)
+    );
+    if (target) {
+      target.isDeleted = true;
+      target.updatedAt = new Date();
+    }
+  },
+  countUnread: async (recipient: ResolvedRecipient): Promise<number> => {
+    return inMemoryNotifications.filter(
+      item =>
+        matchesRecipient(item, recipient) &&
+        (item.isDeleted ?? false) === false &&
+        (item.read ?? false) === false
+    ).length;
+  },
+  getPreferences: async (
+    recipient: ResolvedRecipient
+  ): Promise<NotificationPreference | null> => {
+    const key = recipientKey(recipient);
+    const preference = inMemoryPreferences.get(key);
+    if (!preference || preference.isDeleted) {
+      return null;
+    }
+    return preference;
+  },
+  savePreferences: async (
+    recipient: ResolvedRecipient,
+    updates: PreferenceUpdateInput
+  ): Promise<NotificationPreference> => {
+    const key = recipientKey(recipient);
+    const existing = inMemoryPreferences.get(key);
+    const now = new Date();
+    if (!existing || existing.isDeleted) {
+      const basePreference = preferencesFromRecipient(recipient, updates, {
+        createdAt: now,
+        updatedAt: now,
+      });
+      const created = normalizePreferenceRecord({
+        ...basePreference,
+        id: inMemoryPreferenceId,
+      });
+      inMemoryPreferenceId += 1;
+      inMemoryPreferences.set(key, created);
+      return created;
+    }
+
+    const updated = normalizePreferenceRecord({
+      ...existing,
+      ...updates,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      updatedAt: now,
+      isDeleted: updates.isDeleted ?? existing.isDeleted,
+    });
+    inMemoryPreferences.set(key, updated);
+    return updated;
+  },
+};
+
+function createDbRepository(db: Database): NotificationRepository {
+  return {
+    insertNotification: async (input: InsertNotification): Promise<number> => {
+      const [created] = await db.insert(notifications).values(input).$returningId();
+      return created?.id ?? 0;
+    },
+    listNotifications: async (
+      recipient: ResolvedRecipient,
+      limit: number,
+      offset: number
+    ): Promise<Notification[]> => {
+      return db.query.notifications.findMany({
+        where: notificationRecipientWhere(recipient),
+        orderBy: [desc(notifications.createdAt)],
+        limit,
+        offset,
+      });
+    },
+    markRead: async (
+      id: number,
+      recipient: ResolvedRecipient
+    ): Promise<void> => {
+      await db
+        .update(notifications)
+        .set({ read: true, updatedAt: new Date() })
+        .where(
+          and(notificationRecipientWhere(recipient), eq(notifications.id, id))
+        );
+    },
+    markAllRead: async (recipient: ResolvedRecipient): Promise<number> => {
+      const result = await db
+        .update(notifications)
+        .set({ read: true, updatedAt: new Date() })
+        .where(
+          and(notificationRecipientWhere(recipient), eq(notifications.read, false))
+        );
+
+      if (typeof result === "object" && "affectedRows" in result) {
+        return Number(result.affectedRows ?? 0);
+      }
+      return 0;
+    },
+    softDelete: async (
+      id: number,
+      recipient: ResolvedRecipient
+    ): Promise<void> => {
+      await db
+        .update(notifications)
+        .set({ isDeleted: true, updatedAt: new Date() })
+        .where(
+          and(notificationRecipientWhere(recipient), eq(notifications.id, id))
+        );
+    },
+    countUnread: async (recipient: ResolvedRecipient): Promise<number> => {
+      const [row] = await db
+        .select({
+          count: sql<number>`COUNT(*)`,
+        })
+        .from(notifications)
+        .where(
+          and(notificationRecipientWhere(recipient), eq(notifications.read, false))
+        );
+      return row?.count ?? 0;
+    },
+    getPreferences: async (
+      recipient: ResolvedRecipient
+    ): Promise<NotificationPreference | null> => {
+      const preference = await db.query.notificationPreferences.findFirst({
+        where: preferenceRecipientWhere(recipient),
+      });
+      return preference ?? null;
+    },
+    savePreferences: async (
+      recipient: ResolvedRecipient,
+      updates: PreferenceUpdateInput
+    ): Promise<NotificationPreference> => {
+      const now = new Date();
+      const values: InsertNotificationPreference = preferencesFromRecipient(
+        recipient,
+        updates,
+        { updatedAt: now }
+      );
+
+      await db
+        .insert(notificationPreferences)
+        .values(values)
+        .onDuplicateKeyUpdate({
+          set: {
+            ...values,
+            updatedAt: now,
+            isDeleted: values.isDeleted,
+          },
+        });
+
+      const saved = await db.query.notificationPreferences.findFirst({
+        where: preferenceRecipientWhere(recipient),
+      });
+
+      if (!saved) {
+        return normalizePreferenceRecord({
+          ...values,
+          id: 0,
+          createdAt: values.createdAt ?? now,
+          updatedAt: values.updatedAt ?? now,
+        });
+      }
+
+      return normalizePreferenceRecord({
+        ...saved,
+        id: saved.id,
+      });
+    },
+  };
+}
+
+export async function getNotificationRepository(): Promise<NotificationRepository> {
+  const dbInstance = await getDb();
+  if (!dbInstance) {
+    logger.warn("Database unavailable, using in-memory notification store");
+    return inMemoryRepository;
+  }
+  return createDbRepository(dbInstance);
+}
+
+export function resetNotificationRepositoryState(): void {
+  inMemoryNotifications.splice(0, inMemoryNotifications.length);
+  inMemoryPreferences.clear();
+  inMemoryNotificationId = 1;
+  inMemoryPreferenceId = 1;
+}
+
+export function getDefaultPreferenceFlags(): PreferenceFlags {
+  return { ...defaultPreferences };
+}

--- a/server/services/notificationService.ts
+++ b/server/services/notificationService.ts
@@ -1,82 +1,308 @@
+import {
+  getNotificationRepository,
+  resolveRecipient,
+  resetNotificationRepositoryState,
+  type NotificationCategory,
+  type NotificationChannel,
+  type NotificationRecipient,
+  type NotificationType,
+  type PreferenceUpdateInput,
+  type ResolvedRecipient,
+} from "./notificationRepository";
+import { type InsertNotification, type Notification, type NotificationPreference } from "../../drizzle/schema";
 import { logger } from "../_core/logger";
 
-export type NotificationMethod = "email" | "sms" | "push" | "in-app";
-
-export interface NotificationPayload {
-  userId: number;
+export interface NotificationRequest extends NotificationRecipient {
+  type: NotificationType;
   title: string;
-  message: string;
-  method: NotificationMethod;
+  message?: string;
+  link?: string;
+  channels?: NotificationChannel[];
   metadata?: Record<string, unknown>;
+  category?: NotificationCategory;
 }
 
-/**
- * Send a notification to a user.
- * Currently logs the notification - implement actual delivery later.
- *
- * @param payload - The notification payload
- */
-export async function sendNotification(
-  payload: NotificationPayload
-): Promise<void> {
-  logger.info({ payload }, "Notification requested");
+export interface NotificationListOptions {
+  limit?: number;
+  offset?: number;
+}
 
-  // TODO: Implement actual notification delivery
-  // For now, just log it
-  switch (payload.method) {
-    case "email":
-      logger.info(
-        { to: payload.userId, subject: payload.title },
-        "Email notification (stub)"
-      );
-      break;
-    case "sms":
-      logger.info({ to: payload.userId }, "SMS notification (stub)");
-      break;
-    case "push":
-      logger.info({ to: payload.userId }, "Push notification (stub)");
-      break;
-    case "in-app":
-      // Could create inbox item here
-      logger.info({ to: payload.userId }, "In-app notification (stub)");
-      break;
+export interface QueueProcessResult {
+  processed: number;
+  skipped: number;
+  failed: number;
+}
+
+interface NotificationQueueItem {
+  userId: number | null;
+  clientId: number | null;
+  recipientType: "user" | "client";
+  type: NotificationType;
+  title: string;
+  message?: string;
+  link?: string;
+  channels: NotificationChannel[];
+  metadata?: Record<string, unknown>;
+  category: NotificationCategory;
+  queuedAt: Date;
+}
+
+const notificationQueue: NotificationQueueItem[] = [];
+const recipientKey = (recipient: ResolvedRecipient): string =>
+  `${recipient.recipientType}:${recipient.recipientType === "user" ? recipient.userId : recipient.clientId}`;
+const toRecipient = (recipient: NotificationRecipient | number): NotificationRecipient =>
+  typeof recipient === "number" ? { userId: recipient } : recipient;
+
+function isCategoryEnabled(
+  preferences: NotificationPreference,
+  category: NotificationCategory
+): boolean {
+  if (category === "appointment") {
+    return preferences.appointmentReminders;
   }
+  if (category === "order") {
+    return preferences.orderUpdates;
+  }
+  if (category === "system") {
+    return preferences.systemAlerts;
+  }
+  return true;
 }
 
-/**
- * Send notification to multiple users.
- *
- * @param userIds - Array of user IDs to notify
- * @param notification - The notification payload (without userId)
- */
+function filterChannelsByPreferences(
+  channels: NotificationChannel[],
+  preferences: NotificationPreference,
+  category: NotificationCategory
+): NotificationChannel[] {
+  if (!isCategoryEnabled(preferences, category)) {
+    return [];
+  }
+
+  const enabled: NotificationChannel[] = [];
+  if (channels.includes("in_app") && preferences.inAppEnabled) {
+    enabled.push("in_app");
+  }
+  if (channels.includes("email") && preferences.emailEnabled) {
+    enabled.push("email");
+  }
+  if (channels.includes("sms") && preferences.emailEnabled) {
+    enabled.push("sms");
+  }
+  return enabled;
+}
+
+async function ensurePreferences(
+  recipient: ResolvedRecipient
+): Promise<NotificationPreference> {
+  const repository = await getNotificationRepository();
+  const existing = await repository.getPreferences(recipient);
+  if (existing) {
+    return existing;
+  }
+  return repository.savePreferences(recipient, {});
+}
+
+function toInsertNotification(
+  item: NotificationQueueItem,
+  channel: NotificationChannel
+): InsertNotification {
+  return {
+    userId: item.userId,
+    clientId: item.clientId,
+    recipientType: item.recipientType,
+    type: item.type,
+    title: item.title,
+    message: item.message ?? null,
+    link: item.link ?? null,
+    channel,
+    read: false,
+    metadata: item.metadata ?? null,
+    isDeleted: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+export function resetNotificationStateForTests(): void {
+  notificationQueue.splice(0, notificationQueue.length);
+  resetNotificationRepositoryState();
+}
+
+export async function queueNotification(
+  request: NotificationRequest
+): Promise<void> {
+  const recipient = resolveRecipient(request);
+  const channels: NotificationChannel[] =
+    request.channels && request.channels.length > 0
+      ? Array.from(new Set(request.channels))
+      : ["in_app"];
+
+  notificationQueue.push({
+    userId: recipient.userId,
+    clientId: recipient.clientId,
+    recipientType: recipient.recipientType,
+    type: request.type,
+    title: request.title,
+    message: request.message,
+    link: request.link,
+    channels,
+    metadata: request.metadata,
+    queuedAt: new Date(),
+    category: request.category ?? "system",
+  });
+}
+
+export async function sendNotification(
+  request: NotificationRequest
+): Promise<void> {
+  await queueNotification(request);
+}
+
 export async function sendBulkNotification(
   userIds: number[],
-  notification: Omit<NotificationPayload, "userId">
+  notification: Omit<NotificationRequest, "userId">
 ): Promise<void> {
+  if (userIds.length === 0) {
+    return;
+  }
+
   await Promise.all(
-    userIds.map((userId) => sendNotification({ ...notification, userId }))
+    userIds.map(userId => queueNotification({ ...notification, userId }))
   );
 }
 
-/**
- * Send a reminder notification.
- *
- * @param userId - The user to remind
- * @param reminderType - Type of reminder (e.g., "payment due", "appointment")
- * @param entityId - ID of the related entity
- * @param entityType - Type of the related entity (e.g., "invoice", "event")
- */
 export async function sendReminder(
   userId: number,
   reminderType: string,
   entityId: number,
   entityType: string
 ): Promise<void> {
-  await sendNotification({
+  await queueNotification({
     userId,
+    type: "info",
     title: `Reminder: ${reminderType}`,
     message: `You have a ${reminderType} for ${entityType} #${entityId}`,
-    method: "in-app",
     metadata: { entityId, entityType, reminderType },
+    category: "appointment",
   });
+}
+
+export async function processNotificationQueue(
+  options?: { batchSize?: number }
+): Promise<QueueProcessResult> {
+  const batchSize = options?.batchSize ?? notificationQueue.length;
+  const items = notificationQueue.splice(0, batchSize);
+  const preferencesCache = new Map<string, NotificationPreference>();
+
+  let processed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const repository = await getNotificationRepository();
+
+  for (const item of items) {
+    try {
+      const recipient: ResolvedRecipient = {
+        recipientType: item.recipientType,
+        userId: item.userId,
+        clientId: item.clientId,
+      };
+      const cacheKey = recipientKey(recipient);
+      const cached = preferencesCache.get(cacheKey);
+      const preferences = cached ?? (await ensurePreferences(recipient));
+      preferencesCache.set(cacheKey, preferences);
+
+      const enabledChannels = filterChannelsByPreferences(
+        item.channels ?? ["in_app"],
+        preferences,
+        item.category ?? "system"
+      );
+
+      if (enabledChannels.length === 0) {
+        skipped += 1;
+        continue;
+      }
+
+      for (const channel of enabledChannels) {
+        const insertPayload = toInsertNotification(item, channel);
+        await repository.insertNotification(insertPayload);
+      }
+
+      processed += 1;
+    } catch (error) {
+      failed += 1;
+      logger.error(
+        {
+          error: error instanceof Error ? error.message : String(error),
+          userId: item.userId,
+        },
+        "Failed to process notification"
+      );
+    }
+  }
+
+  return { processed, skipped, failed };
+}
+
+export async function listNotifications(
+  recipient: NotificationRecipient | number,
+  options?: NotificationListOptions
+): Promise<Notification[]> {
+  const limit = options?.limit ?? 20;
+  const offset = options?.offset ?? 0;
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  return repository.listNotifications(resolvedRecipient, limit, offset);
+}
+
+export async function markNotificationRead(
+  notificationId: number,
+  recipient: NotificationRecipient | number
+): Promise<boolean> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  await repository.markRead(notificationId, resolvedRecipient);
+  return true;
+}
+
+export async function markAllNotificationsRead(
+  recipient: NotificationRecipient | number
+): Promise<number> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  return repository.markAllRead(resolvedRecipient);
+}
+
+export async function deleteNotification(
+  notificationId: number,
+  recipient: NotificationRecipient | number
+): Promise<boolean> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  await repository.softDelete(notificationId, resolvedRecipient);
+  return true;
+}
+
+export async function getUnreadCount(
+  recipient: NotificationRecipient | number
+): Promise<number> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  return repository.countUnread(resolvedRecipient);
+}
+
+export async function getNotificationPreferences(
+  recipient: NotificationRecipient | number
+): Promise<NotificationPreference> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  return ensurePreferences(resolvedRecipient);
+}
+
+export async function updateNotificationPreferences(
+  recipient: NotificationRecipient | number,
+  updates: PreferenceUpdateInput
+): Promise<NotificationPreference> {
+  const resolvedRecipient = resolveRecipient(toRecipient(recipient));
+  const repository = await getNotificationRepository();
+  return repository.savePreferences(resolvedRecipient, updates);
 }


### PR DESCRIPTION
## Summary
- add NotificationBell dropdown, notifications list page, and notification preferences UI
- implement notification TRPC router backed by a shared repository abstraction and new migration
- cover notification UI, router, and service flows with targeted tests

## Testing
- pnpm vitest run client/src/components/notifications/NotificationBell.test.tsx client/src/pages/NotificationsPage.test.tsx client/src/pages/settings/NotificationPreferences.test.tsx server/routers/notifications.test.ts server/services/notificationService.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586ae725588330945611f2df4e8abd)