### PR TITLE
chore(session): register seeding execution session

### DIFF
--- a/docs/ACTIVE_SESSIONS.md
+++ b/docs/ACTIVE_SESSIONS.md
@@ -35,3 +35,4 @@
 **All sessions cleared to unblock Wave 2 execution.**
 
 - Session-20260104-UX-015-00a24e: UX-015/UX-022/UX-011 - [Platform: External] [Branch: wave-2/ux-foundation-parallel] [Files: client/src/components/layout/Sidebar.tsx, client/src/components/layout/Layout.tsx, client/src/components/layout/MobileNav.tsx, client/src/components/ui/DataTable.tsx, client/src/components/ui/DataTablePagination.tsx, client/src/components/ui/DataTableFilters.tsx, client/src/components/ui/Skeleton.tsx, client/src/components/skeletons/DashboardSkeleton.tsx, client/src/components/skeletons/TableSkeleton.tsx, client/src/components/skeletons/CardSkeleton.tsx, client/src/pages/InventoryPage.tsx, client/src/pages/ProductsPage.tsx, client/src/pages/VendorsPage.tsx]
+- Session-20260108-DATA-SEED-EXEC-1b7f13: DATA-SEED-EXEC - [Platform: External] [Files: docs/sessions/active/Session-20260108-DATA-SEED-EXEC-1b7f13.md, docs/ACTIVE_SESSIONS.md]

--- a/docs/sessions/active/Session-20260108-DATA-SEED-EXEC-1b7f13.md
+++ b/docs/sessions/active/Session-20260108-DATA-SEED-EXEC-1b7f13.md
@@ -1,0 +1,16 @@
+# Session: DATA-SEED-EXEC - Execute Seeding Plan v1.2
+
+**Status**: In Progress
+**Started**: 2026-01-08
+**Agent Type**: External
+**Files**: docs/sessions/active/Session-20260108-DATA-SEED-EXEC-1b7f13.md, docs/ACTIVE_SESSIONS.md
+
+## Progress
+
+- [ ] Phase 0: Safety + schema preflight
+- [ ] Phase 1: Seed asset inventory + dry-run checks
+- [ ] Phase 2: Validation + reporting
+
+## Notes
+
+- Executing plan with strict safety gates; no destructive actions without explicit approval.


### PR DESCRIPTION
### Motivation
- Register an active session for the DATA-SEED-EXEC seeding plan to enable agent coordination and auditing.
- Make session metadata discoverable under `docs/sessions/active/` and tracked in `docs/ACTIVE_SESSIONS.md` before any schema or seed actions.
- Capture a safety-first progress checklist so the seeding plan cannot proceed without explicit preflight validation. 
- Surface environment blocking issues early so the seed is paused until safety gates are satisfied.

### Description
- Add `docs/sessions/active/Session-20260108-DATA-SEED-EXEC-1b7f13.md` containing session metadata, progress checklist, and notes. 
- Append a reference to the new session in `docs/ACTIVE_SESSIONS.md` so the session appears in the active sessions index. 
- This change is documentation-only and does not modify application source code or runtime behavior. 
- Session registration follows the repository’s session-management protocol to enable safe, auditable execution of seeded changes.

### Testing
- Ran `pnpm test`, which executed the test suite and showed the majority of tests passed while a small set of DB-dependent tests failed or were skipped. 
- Ran `pnpm validate:schema`, which failed because the `DATABASE_URL` environment variable was not provided. 
- Attempted `pnpm typecheck` and `pnpm lint`, but those scripts were not present in the local `package.json` and did not run successfully. 
- DB-required tests remain blocked until a valid `DATABASE_URL` is supplied and the schema preflight checks pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603a8855f88330ba48eda84c716bad)