### PR TITLE
docs(qa): add run sheet summary, update roadmap, archive session

### DIFF
--- a/docs/roadmaps/MASTER_ROADMAP.md
+++ b/docs/roadmaps/MASTER_ROADMAP.md
@@ -490,6 +490,7 @@ All 15 tasks from the Cooper Rd Working Session completed:
 | IMPROVE-002 | Enhance Health Check Endpoints  | MEDIUM   | ✅ COMPLETE |
 | IMPROVE-003 | Add Composite Database Indexes  | MEDIUM   | ✅ COMPLETE |
 | IMPROVE-004 | Reduce Rate Limiting Thresholds | LOW      | ✅ COMPLETE |
+| DOCS-001    | QA run sheet summary cleanup    | LOW      | ✅ COMPLETE |
 
 ---
 
@@ -623,11 +624,11 @@ tsx scripts/seed-client-needs.ts  # Seed client needs
 | Data Integrity (QA)   | 8         | 0     | 0       | 8       |
 | Frontend Quality (QA) | 3         | 0     | 0       | 3       |
 | Backend Quality (QA)  | 5         | 0     | 0       | 5       |
-| Improvements          | 4         | 0     | 0       | 4       |
+| Improvements          | 5         | 0     | 0       | 5       |
 | E2E Testing           | 3         | 0     | 0       | 3       |
-| **TOTAL**             | **182**   | **0** | **2**   | **184** |
+| **TOTAL**             | **183**   | **0** | **2**   | **185** |
 
-> **MVP STATUS: 100% RESOLVED** (182 completed + 2 removed, 0 tasks open)
+> **MVP STATUS: 100% RESOLVED** (183 completed + 2 removed, 0 tasks open)
 
 > **E2E Testing Infrastructure (Jan 16, 2026):** All 3 E2E tasks COMPLETED.
 > Final pass rate: 88.5% (54/61 core tests). Full suite has 338 tests across 44 spec files.
@@ -712,9 +713,9 @@ tsx scripts/seed-client-needs.ts  # Seed client needs
 
 | Milestone | Completed | Open   | Total   | Progress |
 | --------- | --------- | ------ | ------- | -------- |
-| MVP       | 179       | 3      | 184     | ~97%     |
+| MVP       | 183       | 0      | 185     | 100%     |
 | Beta      | 0         | 17     | 17      | 0%       |
-| **TOTAL** | **179**   | **20** | **201** | ~89%     |
+| **TOTAL** | **183**   | **17** | **202** | ~91%     |
 
 ---
 

--- a/docs/sessions/completed/Session-20260116-DOCS-RUN-SHEET-3e6e59.md
+++ b/docs/sessions/completed/Session-20260116-DOCS-RUN-SHEET-3e6e59.md
@@ -1,0 +1,41 @@
+# Session: DOCS-RUN-SHEET - Run Sheet Summary Cleanup
+
+**Status**: Completed
+**Started**: 2026-01-16
+**Agent Type**: External
+**Files**:
+
+- qa-results/USER_FLOW_RUN_SHEET_SUMMARY.md
+- docs/ACTIVE_SESSIONS.md
+- docs/roadmaps/MASTER_ROADMAP.md
+
+## Progress
+
+- [x] Draft run sheet summary cleanup
+- [x] Update roadmap entry and archive session
+
+## Notes
+
+- Cleaned up run sheet summary formatting and duplicates.
+
+## Handoff Notes
+
+**What was completed:**
+
+- Created a cleaned run sheet summary report with tested flow details.
+- Added a completed documentation entry to the roadmap and updated summary counts.
+
+**What's pending:**
+
+- None.
+
+**Known issues:**
+
+- `pnpm typecheck` and `pnpm lint` commands are not defined in this repo.
+- `pnpm test` was interrupted after DB connection warnings due to missing `DATABASE_URL`.
+
+**Files modified:**
+
+- qa-results/USER_FLOW_RUN_SHEET_SUMMARY.md
+- docs/roadmaps/MASTER_ROADMAP.md
+- docs/ACTIVE_SESSIONS.md

--- a/qa-results/USER_FLOW_RUN_SHEET_SUMMARY.md
+++ b/qa-results/USER_FLOW_RUN_SHEET_SUMMARY.md
@@ -1,0 +1,46 @@
+# User Flow Run Sheet Summary
+
+**Tester:** QA Sales Manager (manual execution on live site)  
+**Matrix Coverage:** 509 total flows (each unique flow represented once; roles condensed to the primary role in the matrix)  
+**Execution Policy:** Only flows tested during the session were executed; all others are marked **BLOCKED** with blocker type **other** and a note explaining they were not executed.
+
+## Summary of Results
+
+| Status    | Count   |
+| --------- | ------- |
+| PASS      | 2       |
+| FAIL      | 1       |
+| BLOCKED   | 506     |
+| N/A       | 0       |
+| **Total** | **509** |
+
+## Tested Flows
+
+| Row Key                                                  | Status  | Notes                                                     |
+| -------------------------------------------------------- | ------- | --------------------------------------------------------- |
+| CRM \| Clients \| Sales Manager \| List Clients          | PASS    | Client list loaded as expected.                           |
+| Inventory \| Products \| Sales Manager \| List Products  | PASS    | Product list loaded as expected.                          |
+| Inventory \| Products \| Sales Manager \| Create Product | BLOCKED | Permission error: Sales Manager lacks `inventory:create`. |
+| CRM \| Clients \| Sales Manager \| Create Client (Base)  | FAIL    | SQL error after submit; client not created.               |
+
+## Evidence Highlights
+
+- **Permissions Enforcement:** The product creation flow blocked the Sales Manager with a clear permission error, demonstrating proper RBAC enforcement.
+- **Failed Client Creation:** Attempting to create a new client produced a database error after submitting the form, and the client did not appear in the list.
+
+## Top Failing Row(s)
+
+1. **CRM \| Clients \| Sales Manager \| Create Client \| Base** — The SQL error prevents client creation, making this the highest-priority fix.
+
+## Top Blocker Reasons
+
+1. **other** (505 occurrences) — Most flows were not executed due to time/resource constraints.
+2. **permissions** (1 occurrence) — The Sales Manager lacks `inventory:create` permission for creating products.
+
+## Unblock Plan
+
+1. **Time and Coverage:** Allocate additional QA time or testers to systematically execute remaining flows.
+2. **Role-Specific Accounts:** Ensure accounts for all roles in the matrix (e.g., Inventory Manager, Super Admin) are accessible per the QA auth file.
+3. **Seed Test Data:** Provide seed data for orders, batches, invoices, etc., or use a safe test environment to avoid running against production data.
+4. **Database Stability:** Investigate and fix the SQL error encountered when creating clients. This may require migrations or validation updates.
+5. **Permission Adjustments:** Verify RBAC settings; either grant required permissions for QA roles or test with roles that already have them.


### PR DESCRIPTION
### Motivation
- Capture and publish the manual QA run sheet (509 flows) and its high‑level outcomes so the team has a single, importable summary of the execution. 
- Record the documentation cleanup as a formal roadmap task and keep roadmap totals consistent with the new documentation work. 
- Archive the session metadata so active sessions reflect work completed and handoff notes are preserved.

### Description
- Added `qa-results/USER_FLOW_RUN_SHEET_SUMMARY.md` containing the tester, matrix coverage, summary counts, tested flows, evidence highlights, top failing row, top blocker reasons, and an unblock plan. 
- Updated `docs/roadmaps/MASTER_ROADMAP.md` to add `DOCS-001: QA run sheet summary cleanup` and adjusted the MVP / overall summary counts to include the completed documentation task. 
- Created and archived `docs/sessions/completed/Session-20260116-DOCS-RUN-SHEET-3e6e59.md` and updated `docs/ACTIVE_SESSIONS.md` to reflect the session registration and completion. 
- Commits include the new QA report, roadmap edits, session archival, and updated active sessions file.

### Testing
- Ran `pnpm test`; the test suite started and many unit/property tests ran successfully, but execution surfaced repeated `DATABASE_URL` warnings and the run was interrupted (DB‑backed tests were skipped or failed due to missing DB connection). 
- `pnpm typecheck` and `pnpm lint` were attempted but those scripts are not defined in this environment (commands returned not found). 
- Ran `pnpm roadmap:validate` which returned `Validation PASSED`. 
- No further automated changes to production code were made; this PR is documentation-only and did not introduce runtime code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0d4b4c948330a20ad7a75f23a4c0)