### PR TITLE
fix(schema): Shorten FK identifiers and fix seed column names

### DIFF
--- a/drizzle/schema-client360.ts
+++ b/drizzle/schema-client360.ts
@@ -18,6 +18,7 @@ import {
   json,
   index,
   mysqlEnum,
+  foreignKey,
 } from "drizzle-orm/mysql-core";
 import { clients, products, categories, users, orders, batches } from "./schema";
 
@@ -237,9 +238,7 @@ export const officeSupplyNeeds = mysqlTable(
   "office_supply_needs",
   {
     id: int("id").primaryKey().autoincrement(),
-    officeSupplyItemId: int("office_supply_item_id")
-      .notNull()
-      .references(() => officeSupplyItems.id, { onDelete: "cascade" }),
+    officeSupplyItemId: int("office_supply_item_id").notNull(),
 
     // Quantities
     currentStock: decimal("current_stock", {
@@ -258,7 +257,7 @@ export const officeSupplyNeeds = mysqlTable(
     purchaseOrderId: int("purchase_order_id"),
 
     // Processing
-    approvedBy: int("approved_by").references(() => users.id),
+    approvedBy: int("approved_by"),
     approvedAt: timestamp("approved_at"),
 
     createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -269,6 +268,17 @@ export const officeSupplyNeeds = mysqlTable(
       table.officeSupplyItemId
     ),
     statusIdx: index("idx_osn_status").on(table.status),
+    // FKs with explicit short names to avoid MySQL 64-char identifier limit
+    itemFk: foreignKey({
+      name: "fk_osn_item",
+      columns: [table.officeSupplyItemId],
+      foreignColumns: [officeSupplyItems.id],
+    }).onDelete("cascade"),
+    approvedByFk: foreignKey({
+      name: "fk_osn_approved_by",
+      columns: [table.approvedBy],
+      foreignColumns: [users.id],
+    }),
   })
 );
 

--- a/drizzle/schema-scheduling.ts
+++ b/drizzle/schema-scheduling.ts
@@ -14,6 +14,7 @@ import {
   json,
   date,
   index,
+  foreignKey,
 } from "drizzle-orm/mysql-core";
 import { relations } from "drizzle-orm";
 import { users, clients, calendarEvents } from "./schema";
@@ -251,9 +252,7 @@ export const appointmentStatusHistory = mysqlTable(
   "appointment_status_history",
   {
     id: int("id").autoincrement().primaryKey(),
-    calendarEventId: int("calendar_event_id")
-      .notNull()
-      .references(() => calendarEvents.id, { onDelete: "cascade" }),
+    calendarEventId: int("calendar_event_id").notNull(),
 
     // Status transition
     previousStatus: varchar("previous_status", { length: 50 }),
@@ -261,7 +260,7 @@ export const appointmentStatusHistory = mysqlTable(
 
     // Timing
     changedAt: timestamp("changed_at").defaultNow().notNull(),
-    changedById: int("changed_by_id").references(() => users.id),
+    changedById: int("changed_by_id"),
 
     // Additional info
     notes: text("notes"),
@@ -274,6 +273,17 @@ export const appointmentStatusHistory = mysqlTable(
     changedAtIdx: index("idx_appointment_status_history_changed").on(
       table.changedAt
     ),
+    // FKs with explicit short names to avoid MySQL 64-char identifier limit
+    eventFk: foreignKey({
+      name: "fk_appt_status_hist_event",
+      columns: [table.calendarEventId],
+      foreignColumns: [calendarEvents.id],
+    }).onDelete("cascade"),
+    changedByFk: foreignKey({
+      name: "fk_appt_status_hist_user",
+      columns: [table.changedById],
+      foreignColumns: [users.id],
+    }),
   })
 );
 

--- a/drizzle/schema-vip-portal.ts
+++ b/drizzle/schema-vip-portal.ts
@@ -259,12 +259,8 @@ export const clientInterestListItems = mysqlTable(
   "client_interest_list_items",
   {
     id: int("id").primaryKey().autoincrement(),
-    interestListId: int("interest_list_id")
-      .notNull()
-      .references(() => clientInterestLists.id, { onDelete: "cascade" }),
-    batchId: int("batch_id")
-      .notNull()
-      .references(() => batches.id, { onDelete: "cascade" }),
+    interestListId: int("interest_list_id").notNull(),
+    batchId: int("batch_id").notNull(),
     // Snapshot data at time of interest
     itemName: varchar("item_name", { length: 255 }).notNull(),
     category: varchar("category", { length: 100 }),
@@ -284,6 +280,17 @@ export const clientInterestListItems = mysqlTable(
       table.interestListId
     ),
     batchIdIdx: index("idx_interest_list_items_batch_id").on(table.batchId),
+    // FKs with explicit short names to avoid MySQL 64-char identifier limit
+    interestListFk: foreignKey({
+      name: "fk_int_list_items_list",
+      columns: [table.interestListId],
+      foreignColumns: [clientInterestLists.id],
+    }).onDelete("cascade"),
+    batchFk: foreignKey({
+      name: "fk_int_list_items_batch",
+      columns: [table.batchId],
+      foreignColumns: [batches.id],
+    }).onDelete("cascade"),
   })
 );
 


### PR DESCRIPTION
## Summary
This PR fixes multiple issues preventing drizzle-kit push and seed:comprehensive from completing successfully.

## Schema Fixes (FK identifier length)
MySQL has a 64-character limit for identifiers. The following tables had auto-generated FK names exceeding this limit:

| Table | FK Name (before) | FK Name (after) |
|-------|------------------|-----------------|
| calendar_recurrence_instances | calendar_recurrence_instances_parent_event_id_calendar_events_id_fk (68 chars) | fk_cal_recur_inst_parent (24 chars) |
| cash_location_transactions | cash_location_transactions_transfer_to_location_id_cash_locations_id_fk (72 chars) | fk_cash_loc_tx_to (17 chars) |
| client_interest_list_items | client_interest_list_items_interest_list_id_client_interest_lists_id_fk (72 chars) | fk_int_list_items_list (22 chars) |
| appointment_status_history | appointment_status_history_calendar_event_id_calendar_events_id_fk (67 chars) | fk_appt_status_hist_event (25 chars) |
| office_supply_needs | office_supply_needs_office_supply_item_id_office_supply_items_id_fk (68 chars) | fk_osn_item (11 chars) |

## Seed Script Fixes (column name mismatches)
The seed script was using column names that don't match the actual schema:

| Table | Column (seed script) | Column (actual schema) |
|-------|---------------------|------------------------|
| vip_portal_configurations | module_leaderboard_enabled | (removed - column doesn't exist) |
| intake_sessions | payment_terms | paymentTerms |
| referral_credits | status | referralCreditStatus |

## Testing
- [x] drizzle-kit push completes successfully
- [x] pnpm seed:comprehensive runs without column errors
- [x] Database contains expected seeded data