### PR TITLE
fix: Add missing AddClientWizard to ClientsWorkSurface

### DIFF
--- a/client/src/components/work-surface/ClientsWorkSurface.tsx
+++ b/client/src/components/work-surface/ClientsWorkSurface.tsx
@@ -60,6 +60,9 @@ import {
   useInspectorPanel,
 } from "./InspectorPanel";
 
+// Client Components
+import { AddClientWizard } from "@/components/clients/AddClientWizard";
+
 // Icons
 import {
   Search,
@@ -857,6 +860,18 @@ export function ClientsWorkSurface() {
 
       {/* Concurrent Edit Conflict Dialog (UXS-705) */}
       <ConflictDialog />
+
+      {/* Add Client Wizard - FIX: Missing dialog for add client button */}
+      <AddClientWizard
+        open={isAddClientOpen}
+        onOpenChange={setIsAddClientOpen}
+        onSuccess={(clientId) => {
+          // Refresh the list and navigate to the new client
+          utils.clients.list.invalidate();
+          utils.clients.count.invalidate();
+          setLocation(`/clients/${clientId}`);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
The "Add Client" button in ClientsWorkSurface was not working because
the AddClientWizard component was never rendered. The button correctly
set the isAddClientOpen state to true, but there was no dialog
component to respond to this state change.

This fix:
- Imports AddClientWizard component
- Adds the AddClientWizard dialog to the render, connected to
  isAddClientOpen state
- On success, refreshes the client list and navigates to the new client

https://claude.ai/code/session_012WrcsU6hm7gFn6E6AQkSX7