### PR TITLE
docs: refine Jan-26 AI-parsable checkpoint report & register session

### DIFF
--- a/docs/ACTIVE_SESSIONS.md
+++ b/docs/ACTIVE_SESSIONS.md
@@ -10,21 +10,21 @@
 
 ## 🟢 Currently Working
 
-| Session ID                               | Task                                             | Branch                                             | Module        | Status      | Started    | ETA        |
-| ---------------------------------------- | ------------------------------------------------ | -------------------------------------------------- | ------------- | ----------- | ---------- | ---------- |
-| Session-20260126-TEAM-B-ACCOUNTING-EBDIr | Team B Accounting & GL                           | claude/team-b-accounting-gl-EBDIr                  | Accounting    | In Progress | 2026-01-26 | 2026-01-27 |
-| Session-20260125-TEAM-A-STABILITY-9fc6d6 | Team A Core Stability Fixes                      | claude/execute-team-a-stability-fLgHH              | Test/Perf     | Complete    | 2026-01-25 | 2026-01-25 |
-| Session-20260126-TEAM-D-CODE-QUALITY-9V7zW | Team D Code Quality (Lint/Test)                  | claude/team-d-code-quality-9V7zW                   | Client/Server | In Progress | 2026-01-26 | 2026-01-26 |
-| Session-20260126-TEAM-F-UI-f9b20085      | Team F UI Features                               | claude/review-terp-instructions-hIUWu              | UI/Features   | In Progress | 2026-01-26 | 2026-01-26 |
-| Session-20260123-AUDIT-e345e7            | Roadmap extraction QA audit                      | -                                                  | Documentation | In Progress | 2026-01-23 | -          |
-| Session-20260115-DOCS-USERFLOWS-d5ea18   | DOCS-USERFLOWS                                   | -                                                  | Documentation | In Progress | 2026-01-15 | -          |
-| Session-20260114-QA-TERP-664c9b          | Deep QA Review                                   | main                                               | Repo-wide     | In Progress | 2026-01-14 | TBD        |
-| Session-20260109-QA-E2E-a63131           | QA-E2E full browser coverage                     | main                                               | QA/Automation | In Progress | 2026-01-09 | -          |
-| Session-20260109-QA-E2E-0c47cb           | QA-E2E credential provisioning + flow completion | main                                               | QA/Automation | In Progress | 2026-01-09 | -          |
-| Session-20260116-E2E-INFRA               | E2E-001, E2E-002, E2E-003 Infrastructure         | manus/e2e-infrastructure-implementation-2026-01-16 | tests-e2e/    | In Progress | 2026-01-16 | 2026-01-16 |
-| Session-20260126-TEAM-E-INFRA-RNtE3      | Team E Infrastructure & Schema                   | claude/setup-team-e-infrastructure-RNtE3           | drizzle/, server/ | In Progress | 2026-01-26 | 2026-01-26 |
-| Session-20260126-TEAM-C-INVENTORY-VolPg  | Team C: Inventory & Orders (14 tasks)            | claude/terp-team-c-setup-VolPg                     | Inventory/Orders | In Progress | 2026-01-26 | 2026-01-27 |
-| Session-20260126-TEAM-A-SECURITY-feoXR   | Team A Security Critical                         | claude/review-security-critical-feoXR              | Security      | In Progress | 2026-01-26 | 2026-01-26 |
+| Session ID                                 | Task                                             | Branch                                             | Module            | Status      | Started    | ETA        |
+| ------------------------------------------ | ------------------------------------------------ | -------------------------------------------------- | ----------------- | ----------- | ---------- | ---------- |
+| Session-20260126-TEAM-B-ACCOUNTING-EBDIr   | Team B Accounting & GL                           | claude/team-b-accounting-gl-EBDIr                  | Accounting        | In Progress | 2026-01-26 | 2026-01-27 |
+| Session-20260125-TEAM-A-STABILITY-9fc6d6   | Team A Core Stability Fixes                      | claude/execute-team-a-stability-fLgHH              | Test/Perf         | Complete    | 2026-01-25 | 2026-01-25 |
+| Session-20260126-TEAM-D-CODE-QUALITY-9V7zW | Team D Code Quality (Lint/Test)                  | claude/team-d-code-quality-9V7zW                   | Client/Server     | In Progress | 2026-01-26 | 2026-01-26 |
+| Session-20260126-TEAM-F-UI-f9b20085        | Team F UI Features                               | claude/review-terp-instructions-hIUWu              | UI/Features       | In Progress | 2026-01-26 | 2026-01-26 |
+| Session-20260123-AUDIT-e345e7              | Roadmap extraction QA audit                      | -                                                  | Documentation     | In Progress | 2026-01-23 | -          |
+| Session-20260115-DOCS-USERFLOWS-d5ea18     | DOCS-USERFLOWS                                   | -                                                  | Documentation     | In Progress | 2026-01-15 | -          |
+| Session-20260114-QA-TERP-664c9b            | Deep QA Review                                   | main                                               | Repo-wide         | In Progress | 2026-01-14 | TBD        |
+| Session-20260109-QA-E2E-a63131             | QA-E2E full browser coverage                     | main                                               | QA/Automation     | In Progress | 2026-01-09 | -          |
+| Session-20260109-QA-E2E-0c47cb             | QA-E2E credential provisioning + flow completion | main                                               | QA/Automation     | In Progress | 2026-01-09 | -          |
+| Session-20260116-E2E-INFRA                 | E2E-001, E2E-002, E2E-003 Infrastructure         | manus/e2e-infrastructure-implementation-2026-01-16 | tests-e2e/        | In Progress | 2026-01-16 | 2026-01-16 |
+| Session-20260126-TEAM-E-INFRA-RNtE3        | Team E Infrastructure & Schema                   | claude/setup-team-e-infrastructure-RNtE3           | drizzle/, server/ | In Progress | 2026-01-26 | 2026-01-26 |
+| Session-20260126-TEAM-C-INVENTORY-VolPg    | Team C: Inventory & Orders (14 tasks)            | claude/terp-team-c-setup-VolPg                     | Inventory/Orders  | In Progress | 2026-01-26 | 2026-01-27 |
+| Session-20260126-TEAM-A-SECURITY-feoXR     | Team A Security Critical                         | claude/review-security-critical-feoXR              | Security          | In Progress | 2026-01-26 | 2026-01-26 |
 
 ## ⏸️ Paused / Waiting
 
@@ -54,3 +54,5 @@
 - Session-20260116-TASK-PREMORTEM-11ec2f: TASK-PREMORTEM - [Platform: External] [Files: docs/sessions/active/Session-20260116-TASK-PREMORTEM-11ec2f.md, docs/ACTIVE_SESSIONS.md]
 - Session-20260123-ROADMAP-INGEST-dfb370: ROADMAP-INGEST - [Platform: External] [Files: docs/roadmaps/MASTER_ROADMAP.md, docs/roadmap/PR_TO_TASK_INDEX.md, docs/roadmap/TEST_REPORT_TO_TASK_INDEX.md, docs/roadmap/NOTHING_LOST_PROOF.md]
 - Session-20260123-TASK-PR290-292-830061: PR-290/PR-292 Consolidation Review - [Platform: External] [Files: docs/sessions/active/Session-20260123-TASK-PR290-292-830061.md, docs/ACTIVE_SESSIONS.md]
+- Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6: JAN-26-CHECKPOINT-REPORT - [Platform: External] [Files: jan-26-checkpoint/ai-parsable-report.json, docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6.md, docs/ACTIVE_SESSIONS.md]
+- Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a: JAN-26-CHECKPOINT-REPORT-FIX - [Platform: External] [Files: jan-26-checkpoint/ai-parsable-report.json, docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a.md, docs/ACTIVE_SESSIONS.md]

--- a/docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6.md
+++ b/docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6.md
@@ -1,0 +1,21 @@
+# Session: JAN-26-CHECKPOINT-REPORT - Jan 26 checkpoint report
+
+**Status**: In Progress
+**Started**: 2026-01-26
+**Agent Type**: External (ChatGPT)
+**Platform**: ChatGPT
+**Files**: docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6.md, docs/ACTIVE_SESSIONS.md, jan-26-checkpoint/ai-parsable-report.json
+
+## Progress
+
+- [x] Locate jan-26-checkpoint folder
+- [x] Review contents and produce AI-parsable report
+- [ ] Validate required checks
+
+## Notes
+
+Session registered per external agent protocol.
+
+## Updates
+
+- Report generated at jan-26-checkpoint/ai-parsable-report.json

--- a/docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a.md
+++ b/docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a.md
@@ -1,0 +1,23 @@
+# Session: JAN-26-CHECKPOINT-REPORT-FIX - Update AI-parsable report
+
+**Status**: In Progress
+**Started**: 2026-01-26
+**Agent Type**: External (ChatGPT)
+**Platform**: ChatGPT
+**Files**: docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a.md, docs/ACTIVE_SESSIONS.md, jan-26-checkpoint/ai-parsable-report.json
+
+## Progress
+
+- [x] Review jan-26-checkpoint artifacts and gaps
+- [x] Update AI-parsable report with missing artifact notes and release blockers
+- [ ] Run required checks
+
+## Notes
+
+Session registered per external agent protocol.
+
+## Updates
+
+- Updated jan-26-checkpoint/ai-parsable-report.json with artifact inventory and derived blockers.
+
+- Ran pnpm typecheck (missing script), pnpm lint (fails), pnpm test (4 failing suites).

--- a/jan-26-checkpoint/ai-parsable-report.json
+++ b/jan-26-checkpoint/ai-parsable-report.json
@@ -1,0 +1,583 @@
+{
+  "report_metadata": {
+    "generated_at": "2026-01-26",
+    "source_folder": "jan-26-checkpoint",
+    "intent": "AI-parsable consolidation of Jan 26 QA checkpoint findings and followups",
+    "version": "2"
+  },
+  "source_files": {
+    "readme": "jan-26-checkpoint/README.md",
+    "team_action_prompt": "jan-26-checkpoint/TEAM_ACTION_PROMPT.md",
+    "all_findings": "jan-26-checkpoint/findings/all_findings.json",
+    "golden_flow_status": "jan-26-checkpoint/findings/golden_flow_status.json",
+    "release_blockers": "jan-26-checkpoint/findings/release_blockers.json",
+    "session_notes": "jan-26-checkpoint/evidence/session_notes.md",
+    "screenshots": [
+      "jan-26-checkpoint/evidence/screenshots/about:blank_2026-01-26_18-27-15_4805.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-13-55_6873.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-17_5328.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-29_1779.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-42_1785.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-55_1077.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-08_7010.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-21_8218.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-35_2562.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-44_9960.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-52_6959.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-00_7817.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-20_8683.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-28_1655.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-36_9618.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-46_1299.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-59_2801.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-08_4765.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-21_2083.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-34_2502.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-47_3100.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-00_5916.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-05_1043.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-18_9217.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-33_3250.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-38_3604.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-51_2550.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-09_4835.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-22_1987.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-35_1257.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-48_6380.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-02_2737.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-26_6600.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-41_1199.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-54_1135.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-08_9285.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-35_8073.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-50_4138.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-11_2838.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-25_1037.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-31_6344.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-37_6048.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-57_9627.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-23-20_5416.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-23-44_3008.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-27-24_6864.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-27-49_7664.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-03_7635.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-17_7857.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-31_2142.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-45_3205.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-50_5510.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-58_5429.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-14_3287.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-19_8340.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-36_7369.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-49_2860.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-04_7280.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-30_2684.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-44_3283.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-56_7961.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-10_9942.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-41_6265.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-55_3555.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-18_6700.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-44_5203.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-57_1982.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-06_8830.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-11_1061.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-16_9904.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-25_4188.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-37_8299.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-34-02_2427.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-34-16_3437.webp"
+    ]
+  },
+  "artifact_inventory": {
+    "existing_files": [
+      "jan-26-checkpoint/README.md",
+      "jan-26-checkpoint/TEAM_ACTION_PROMPT.md",
+      "jan-26-checkpoint/ai-parsable-report.json",
+      "jan-26-checkpoint/evidence/screenshots/about:blank_2026-01-26_18-27-15_4805.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-13-55_6873.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-17_5328.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-29_1779.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-42_1785.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-14-55_1077.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-08_7010.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-21_8218.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-35_2562.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-44_9960.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-15-52_6959.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-00_7817.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-20_8683.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-28_1655.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-36_9618.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-46_1299.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-16-59_2801.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-08_4765.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-21_2083.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-34_2502.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-17-47_3100.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-00_5916.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-05_1043.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-18_9217.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-33_3250.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-38_3604.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-18-51_2550.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-09_4835.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-22_1987.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-35_1257.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-19-48_6380.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-02_2737.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-26_6600.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-41_1199.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-20-54_1135.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-08_9285.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-35_8073.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-21-50_4138.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-11_2838.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-25_1037.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-31_6344.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-37_6048.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-22-57_9627.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-23-20_5416.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-23-44_3008.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-27-24_6864.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-27-49_7664.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-03_7635.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-17_7857.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-31_2142.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-45_3205.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-50_5510.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-28-58_5429.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-14_3287.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-19_8340.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-36_7369.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-29-49_2860.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-04_7280.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-30_2684.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-44_3283.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-30-56_7961.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-10_9942.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-41_6265.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-31-55_3555.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-18_6700.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-44_5203.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-32-57_1982.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-06_8830.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-11_1061.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-16_9904.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-25_4188.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-33-37_8299.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-34-02_2427.webp",
+      "jan-26-checkpoint/evidence/screenshots/terp-app-b9s35_ondig_2026-01-26_18-34-16_3437.webp",
+      "jan-26-checkpoint/evidence/session_notes.md",
+      "jan-26-checkpoint/findings/all_findings.json",
+      "jan-26-checkpoint/findings/golden_flow_status.json",
+      "jan-26-checkpoint/findings/release_blockers.json"
+    ],
+    "missing_expected_files": [
+      "jan-26-checkpoint/test-results/critical_path_results.json"
+    ]
+  },
+  "audit_summary": {
+    "audit_date": "2026-01-26",
+    "auditor": "Manus AI",
+    "environment": "https://terp-app-b9s35.ondigitalocean.app",
+    "overall_status": "RED",
+    "core_functionality": "BLOCKED",
+    "data_integrity": "CRITICAL",
+    "security_rbac": "NEEDS_REVIEW",
+    "finding_counts": {
+      "total": 14,
+      "critical": 6,
+      "positive": 4,
+      "by_severity": {
+        "P0": 5,
+        "P1": 6,
+        "INFO": 2,
+        "P2": 1
+      }
+    },
+    "golden_flow_status_counts": {
+      "BLOCKED": 5,
+      "PARTIAL": 2,
+      "NOT TESTED": 1
+    }
+  },
+  "golden_flows": [
+    {
+      "id": "GF-003",
+      "title": "Order-to-Cash",
+      "status": "BLOCKED",
+      "blocker": "P0: SQL error on inventory load."
+    },
+    {
+      "id": "GF-002",
+      "title": "Procure-to-Pay",
+      "status": "BLOCKED",
+      "blocker": "P0: Product dropdown is empty."
+    },
+    {
+      "id": "GF-007",
+      "title": "Inventory Management",
+      "status": "BLOCKED",
+      "blocker": "P0: Inventory page shows 0 batches."
+    },
+    {
+      "id": "GF-001",
+      "title": "Direct Intake",
+      "status": "BLOCKED",
+      "blocker": "P1: Form fields are not visible."
+    },
+    {
+      "id": "GF-008",
+      "title": "Sample Request",
+      "status": "BLOCKED",
+      "blocker": "P1: Product selector is broken."
+    },
+    {
+      "id": "GF-004",
+      "title": "Invoice & Payment",
+      "status": "PARTIAL",
+      "blocker": "P1: PDF download causes browser timeout."
+    },
+    {
+      "id": "GF-006",
+      "title": "Client Ledger Review",
+      "status": "PARTIAL",
+      "blocker": "P2: Data inconsistencies (Top Debtors)."
+    },
+    {
+      "id": "GF-005",
+      "title": "Pick & Pack",
+      "status": "NOT TESTED",
+      "blocker": "Blocked by inability to create orders."
+    }
+  ],
+  "findings": [
+    {
+      "id": "FINDING-01",
+      "timestamp": "2026-01-26T18:16:00Z",
+      "severity": "P0",
+      "type": "BUG",
+      "title": "Clients Page Fails to Load for Sales Rep",
+      "flow": "GF-003",
+      "description": "The Clients page shows 'Failed to load clients' error when logged in as QA Sales Rep.",
+      "impact": "BLOCKER for Sales Order flow - cannot select customers.",
+      "steps_to_reproduce": [
+        "Log in as qa.salesrep@terp.test",
+        "Navigate to /clients",
+        "Observe 'Failed to load clients' error"
+      ],
+      "expected_behavior": "Clients list should load with all accessible clients.",
+      "actual_behavior": "Error message displayed, no clients shown.",
+      "workaround": "Use Super Admin role instead."
+    },
+    {
+      "id": "FINDING-02",
+      "timestamp": "2026-01-26T18:18:51Z",
+      "severity": "P0",
+      "type": "BUG",
+      "title": "Client Creation Fails Silently",
+      "flow": "GF-003",
+      "description": "The 'Add New Client' wizard completes all 3 steps but clicking 'Create Client' does nothing.",
+      "impact": "Cannot create new clients, blocking new customer onboarding.",
+      "steps_to_reproduce": [
+        "Navigate to /clients",
+        "Click 'Add Client'",
+        "Fill in Step 1 (Basic Information)",
+        "Click Next",
+        "Fill in Step 2 (Client Types) - Select 'Buyer'",
+        "Click Next",
+        "Step 3 (Tags) - Skip tags",
+        "Click 'Create Client' - NOTHING HAPPENS"
+      ],
+      "expected_behavior": "Client should be created and user redirected to client list or detail page.",
+      "actual_behavior": "Button click has no effect, no error, no loading indicator."
+    },
+    {
+      "id": "FINDING-03",
+      "timestamp": "2026-01-26T18:20:02Z",
+      "severity": "P1",
+      "type": "RBAC",
+      "title": "Clients Load for Super Admin but NOT for Sales Rep",
+      "flow": "GF-003",
+      "description": "When logged in as QA Super Admin, the Clients page loads successfully showing 100 clients. When logged in as QA Sales Rep, the same page shows 'Failed to load clients' error.",
+      "impact": "RBAC failure - Sales Reps cannot perform their core function.",
+      "root_cause_hypothesis": "API permissions for /clients endpoint may not include Sales Rep role."
+    },
+    {
+      "id": "FINDING-04",
+      "timestamp": "2026-01-26T18:21:08Z",
+      "severity": "P0",
+      "type": "BUG",
+      "title": "Inventory Fails to Load with SQL Error",
+      "flow": "GF-003",
+      "description": "After selecting a customer, the order creation page shows a raw SQL query error when trying to load inventory.",
+      "impact": "COMPLETE BLOCKER - Cannot add items to orders. The entire Sales Order flow is broken.",
+      "error_message": "Failed to load inventory: Failed query: select `batches`.`id`, `batches`.`code`... (truncated)",
+      "root_cause": "Malformed SQL query joining batches, products, lots, vendors, and strains tables.",
+      "security_concern": "Raw SQL error exposed to user."
+    },
+    {
+      "id": "FINDING-05",
+      "timestamp": "2026-01-26T18:22:37Z",
+      "severity": "P1",
+      "type": "BUG",
+      "title": "Direct Intake Page Missing Form Fields",
+      "flow": "GF-001",
+      "description": "The Direct Intake page shows 'Items: 2, Qty: 0, Value: $0.00' but there are no visible form fields to enter intake data.",
+      "impact": "Cannot test GF-001 Direct Intake flow.",
+      "expected_behavior": "Form fields should be visible for entering intake data.",
+      "actual_behavior": "Only 'Add Row', 'Remove', and 'Submit All' buttons visible. Clicking 'Add Row' increments counter but shows no fields."
+    },
+    {
+      "id": "FINDING-06",
+      "timestamp": "2026-01-26T18:22:57Z",
+      "severity": "P0",
+      "type": "DATA_INTEGRITY",
+      "title": "Inventory Page Shows 0 Batches Despite Dashboard Showing $13M",
+      "flow": "GF-007",
+      "description": "The Inventory page shows 0 batches and $0.00 value, but the Dashboard showed $13,010,881 inventory value.",
+      "impact": "DATA INTEGRITY ISSUE - System cannot be trusted.",
+      "dashboard_values": {
+        "total_inventory_value": 13010881,
+        "total_units": 30572.21
+      },
+      "inventory_page_values": {
+        "batches": 0,
+        "live": 0,
+        "value": 0
+      },
+      "root_cause_hypothesis": "Same SQL query error as FINDING-04, or dashboard showing cached/hardcoded data."
+    },
+    {
+      "id": "FINDING-07",
+      "timestamp": "2026-01-26T18:27:15Z",
+      "severity": "P1",
+      "type": "BUG",
+      "title": "PDF Download Caused Browser Timeout",
+      "flow": "GF-004",
+      "description": "Clicking 'Download PDF' on an invoice caused the browser to timeout after ~197 seconds.",
+      "impact": "Cannot test PDF generation functionality.",
+      "possible_causes": [
+        "PDF generation taking extremely long time",
+        "Infinite loop in PDF generation",
+        "Server-side PDF generation crash"
+      ]
+    },
+    {
+      "id": "FINDING-08",
+      "timestamp": "2026-01-26T18:29:19Z",
+      "severity": "P1",
+      "type": "BUG",
+      "title": "Purchase Order Product Dropdown Empty",
+      "flow": "GF-002",
+      "description": "The Purchase Order creation form opens correctly and allows selecting a supplier, but the 'Select product' dropdown appears to be empty.",
+      "impact": "Cannot complete GF-002 flow without products to add to the PO."
+    },
+    {
+      "id": "FINDING-09",
+      "timestamp": "2026-01-26T18:30:04Z",
+      "severity": "INFO",
+      "type": "POSITIVE",
+      "title": "Products Page Works - 150 Products Exist",
+      "flow": "N/A",
+      "description": "The Products page loads correctly and shows 150 active products across 7 categories.",
+      "categories": [
+        "Pre-Roll",
+        "Concentrate",
+        "Tincture",
+        "Flower",
+        "Vape",
+        "Topical",
+        "Edible"
+      ],
+      "insight": "Products exist (catalog items), but inventory batches do NOT exist (actual stock)."
+    },
+    {
+      "id": "FINDING-10",
+      "timestamp": "2026-01-26T18:31:10Z",
+      "severity": "P0",
+      "type": "BUG",
+      "title": "CRITICAL SQL Error Confirmed - Inventory Query Failure",
+      "flow": "GF-003",
+      "description": "Retry of Sales Order flow confirms the SQL error is persistent and reproducible.",
+      "impact": "Confirms FINDING-04 is a systemic issue, not a transient error."
+    },
+    {
+      "id": "FINDING-11",
+      "timestamp": "2026-01-26T18:31:55Z",
+      "severity": "P1",
+      "type": "BUG",
+      "title": "Add Item Button Blocked by Inventory Failure",
+      "flow": "GF-003",
+      "description": "Clicking 'Add Item' does not open a product selector. The inventory failure error persists and blocks the entire order creation flow.",
+      "impact": "Order has validation errors message appears, preventing order confirmation."
+    },
+    {
+      "id": "FINDING-12",
+      "timestamp": "2026-01-26T18:32:18Z",
+      "severity": "P2",
+      "type": "PARTIAL_PASS",
+      "title": "AR/AP Dashboard Works - POSITIVE",
+      "flow": "GF-006",
+      "description": "The AR/AP (Accounting) dashboard loads correctly and displays financial data.",
+      "data": {
+        "cash_balance": 0,
+        "accounts_receivable": 2497288.62,
+        "accounts_payable": 1753971.17,
+        "net_position": 743317.45
+      },
+      "issues": [
+        "'Top Debtors' shows 'No outstanding balances' despite $2.5M in AR",
+        "'Top Vendors Owed' shows 'Unknown Vendor' for all entries"
+      ],
+      "status": "PARTIAL PASS - Dashboard loads but has data quality issues."
+    },
+    {
+      "id": "FINDING-13",
+      "timestamp": "2026-01-26T18:33:37Z",
+      "severity": "P1",
+      "type": "BUG",
+      "title": "Sample Request Form - Validation Issues",
+      "flow": "GF-008",
+      "description": "The Create Sample Request form shows validation errors. Product field is a text input, not a proper product selector.",
+      "impact": "Cannot complete GF-008 flow - Sample Request creation is broken.",
+      "issues": [
+        "Product field accepts text input but doesn't select from catalog",
+        "No autocomplete/dropdown for product selection",
+        "Form validation fires but UX doesn't guide user to correct issues"
+      ]
+    },
+    {
+      "id": "FINDING-14",
+      "timestamp": "2026-01-26T18:34:16Z",
+      "severity": "INFO",
+      "type": "POSITIVE",
+      "title": "Vendors Page Works - POSITIVE",
+      "flow": "GF-002",
+      "description": "The Vendors page loads correctly and displays 20 active vendors.",
+      "data": {
+        "total_vendors": 20,
+        "active": 20,
+        "value": 0
+      },
+      "note": "All vendors show $0.00 value and 0 orders, consistent with inventory/order issues.",
+      "status": "PASS - Page loads and displays data correctly."
+    }
+  ],
+  "release_blockers": null,
+  "derived_release_blockers": [
+    {
+      "title": "P0: SQL Error on Inventory Load",
+      "priority": "P0",
+      "details": "Core blocker affecting all transactional flows.",
+      "source": "jan-26-checkpoint/README.md"
+    },
+    {
+      "title": "P0: Inventory Data Mismatch",
+      "priority": "P0",
+      "details": "Dashboard shows $13M, Inventory page shows $0.",
+      "source": "jan-26-checkpoint/README.md"
+    },
+    {
+      "title": "P0: Sales Rep Cannot View Clients",
+      "priority": "P0",
+      "details": "RBAC failure.",
+      "source": "jan-26-checkpoint/README.md"
+    },
+    {
+      "title": "P1: Direct Intake Form Broken",
+      "priority": "P1",
+      "details": "No form fields render.",
+      "source": "jan-26-checkpoint/README.md"
+    },
+    {
+      "title": "P1: Invoice PDF Timeout",
+      "priority": "P1",
+      "details": "PDF generation hangs.",
+      "source": "jan-26-checkpoint/README.md"
+    }
+  ],
+  "data_quality_notes": [
+    "release_blockers.json is empty (0 bytes of JSON payload)."
+  ],
+  "suggested_followups": [
+    {
+      "id": "FOLLOWUP-01",
+      "priority": "P0",
+      "title": "Fix inventory SQL query failure blocking GF-003/GF-007",
+      "rationale": "Findings 04/10/11 show malformed inventory query and complete order flow failure.",
+      "evidence": ["FINDING-04", "FINDING-10", "FINDING-11"]
+    },
+    {
+      "id": "FOLLOWUP-02",
+      "priority": "P0",
+      "title": "Investigate inventory data mismatch between dashboard and inventory page",
+      "rationale": "FINDING-06 shows $13M dashboard value vs 0 batches inventory.",
+      "evidence": ["FINDING-06"]
+    },
+    {
+      "id": "FOLLOWUP-03",
+      "priority": "P0",
+      "title": "Resolve clients RBAC/load failures for Sales Rep role",
+      "rationale": "FINDING-01/03 block sales reps from core workflow.",
+      "evidence": ["FINDING-01", "FINDING-03"]
+    },
+    {
+      "id": "FOLLOWUP-04",
+      "priority": "P1",
+      "title": "Fix client creation flow (silent failure in Add Client wizard)",
+      "rationale": "FINDING-02 blocks new client onboarding.",
+      "evidence": ["FINDING-02"]
+    },
+    {
+      "id": "FOLLOWUP-05",
+      "priority": "P1",
+      "title": "Restore Direct Intake form rendering",
+      "rationale": "FINDING-05 shows missing form fields.",
+      "evidence": ["FINDING-05"]
+    },
+    {
+      "id": "FOLLOWUP-06",
+      "priority": "P1",
+      "title": "Investigate invoice PDF generation timeout",
+      "rationale": "FINDING-07 shows ~197s timeout and about:blank.",
+      "evidence": ["FINDING-07"]
+    },
+    {
+      "id": "FOLLOWUP-07",
+      "priority": "P1",
+      "title": "Fix purchase order product dropdown (GF-002)",
+      "rationale": "FINDING-08 indicates product selector is empty.",
+      "evidence": ["FINDING-08"]
+    },
+    {
+      "id": "FOLLOWUP-08",
+      "priority": "P1",
+      "title": "Fix sample request product selector and validation UX",
+      "rationale": "FINDING-13 shows product selector broken and validation issues.",
+      "evidence": ["FINDING-13"]
+    },
+    {
+      "id": "FOLLOWUP-09",
+      "priority": "P2",
+      "title": "Resolve AR/AP dashboard data inconsistencies",
+      "rationale": "FINDING-12 shows data quality issues for Top Debtors and Vendor names.",
+      "evidence": ["FINDING-12"]
+    },
+    {
+      "id": "FOLLOWUP-10",
+      "priority": "P2",
+      "title": "Populate release_blockers.json or remove from expectations",
+      "rationale": "File exists but is empty, preventing automated parsing.",
+      "evidence": ["jan-26-checkpoint/findings/release_blockers.json"]
+    },
+    {
+      "id": "FOLLOWUP-11",
+      "priority": "P2",
+      "title": "Add missing critical_path_results.json artifact",
+      "rationale": "README lists jan-26-checkpoint/test-results/critical_path_results.json but file is missing.",
+      "evidence": ["jan-26-checkpoint/README.md"]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Consolidate and enrich the Jan 26 QA checkpoint artifacts into a single AI-parsable JSON report so downstream automation can consume findings, artifact inventory and suggested follow-ups. 
- Record and register the analysis session(s) in the active sessions log to make the work discoverable and auditable. 
- Surface missing artifacts and data-quality issues (empty `release_blockers.json`, missing `critical_path_results.json`) so teams know release blockers to triage immediately.

### Description
- Added `jan-26-checkpoint/ai-parsable-report.json` containing `artifact_inventory`, `audit_summary`, `golden_flows`, `findings`, `derived_release_blockers`, `data_quality_notes`, and `suggested_followups`. 
- Registered the session by adding `docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-75bbf6.md` and a follow-up session file `docs/sessions/active/Session-20260126-JAN-26-CHECKPOINT-REPORT-FIX-704a4a.md`. 
- Updated `docs/ACTIVE_SESSIONS.md` to include the new session entries so coordination tools and other agents can see the active work. 
- The report explicitly notes missing/empty artifacts (`jan-26-checkpoint/findings/release_blockers.json` empty and `jan-26-checkpoint/test-results/critical_path_results.json` missing) and derives a prioritized list of follow-ups (P0/P1/P2) for engineering and QA teams.

### Testing
- Ran `pnpm typecheck` which failed because the `typecheck` script is not defined in this repo (repo suggests using `pnpm check`).
- Ran `pnpm lint` which executed `eslint` and failed with many existing lint issues (ESLint reported ~2,294 problems, preventing a lint-green result).
- Ran `pnpm test` (Vitest) which executed the test suite; the run completed with most tests passing but returned failures: 4 test suites failed and 7 individual tests failed (summary from run: ~2,387 passed, 7 failed, 17 skipped), including failures in `server/routers/comments.test.ts`, `server/ordersDb.stateMachine.test.ts`, `server/routers/admin-security.test.ts`, and `server/services/orderStateMachine.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f5de925883308d223134bc9e8daf)