### PR TITLE
fix(schema): add missing clients table columns (GF-PHASE0-003)

### DIFF
--- a/server/autoMigrate.ts
+++ b/server/autoMigrate.ts
@@ -522,6 +522,68 @@ export async function runAutoMigrations() {
       }
     }
 
+    // GF-PHASE0-003 FIX: Add businessType column (FEAT-001)
+    // This column exists in schema.ts but was never migrated to production
+    // Causes inventory.getEnhanced to fail with "Unknown column 'businessType'" error
+    try {
+      await db.execute(
+        sql`ALTER TABLE clients ADD COLUMN businessType ENUM('RETAIL', 'WHOLESALE', 'DISPENSARY', 'DELIVERY', 'MANUFACTURER', 'DISTRIBUTOR', 'OTHER') NULL`
+      );
+      console.info("  ✅ Added businessType column to clients");
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (errMsg.includes("Duplicate column")) {
+        console.info("  ℹ️  clients.businessType already exists");
+      } else {
+        console.info("  ⚠️  clients.businessType:", errMsg);
+      }
+    }
+
+    // GF-PHASE0-003 FIX: Add preferredContact column (FEAT-001)
+    try {
+      await db.execute(
+        sql`ALTER TABLE clients ADD COLUMN preferredContact ENUM('EMAIL', 'PHONE', 'TEXT', 'ANY') NULL`
+      );
+      console.info("  ✅ Added preferredContact column to clients");
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (errMsg.includes("Duplicate column")) {
+        console.info("  ℹ️  clients.preferredContact already exists");
+      } else {
+        console.info("  ⚠️  clients.preferredContact:", errMsg);
+      }
+    }
+
+    // GF-PHASE0-003 FIX: Add payment_terms column (FEAT-001)
+    try {
+      await db.execute(
+        sql`ALTER TABLE clients ADD COLUMN payment_terms INT DEFAULT 30`
+      );
+      console.info("  ✅ Added payment_terms column to clients");
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (errMsg.includes("Duplicate column")) {
+        console.info("  ℹ️  clients.payment_terms already exists");
+      } else {
+        console.info("  ⚠️  clients.payment_terms:", errMsg);
+      }
+    }
+
+    // GF-PHASE0-003 FIX: Add referred_by_client_id column (referral tracking)
+    try {
+      await db.execute(
+        sql`ALTER TABLE clients ADD COLUMN referred_by_client_id INT NULL`
+      );
+      console.info("  ✅ Added referred_by_client_id column to clients");
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (errMsg.includes("Duplicate column")) {
+        console.info("  ℹ️  clients.referred_by_client_id already exists");
+      } else {
+        console.info("  ⚠️  clients.referred_by_client_id:", errMsg);
+      }
+    }
+
     // FIX-002: Add version column to batches table for optimistic locking (DATA-005)
     try {
       await db.execute(


### PR DESCRIPTION
## Summary

Fixes the Inventory page showing 0 batches when database has 300+ valid batches.

## Root Cause

The `inventory.getEnhanced` API fails with a 500 error because `getBatchesWithDetails()` joins the `clients` table, but the production database is missing columns that exist in the Drizzle schema:

- `businessType` (ENUM)
- `preferredContact` (ENUM)
- `payment_terms` (INT)
- `referred_by_client_id` (INT)

This causes the error: `Unknown column 'businessType' in 'field list'`

## Why Dashboard Works But Inventory Fails

- **Dashboard** (`getDashboardStats`): Only queries `batches` and `products` tables - no `clients` join
- **Inventory** (`getEnhanced` → `getBatchesWithDetails`): Joins `clients` table via `lots.supplierClientId`, triggering the schema drift error

## Fix

Add auto-migration for these columns in `autoMigrate.ts`, following the same pattern used for other schema drift fixes (PR #318).

## Testing

After merge and deployment:
1. Navigate to Inventory page
2. Verify batches are displayed (should show 300+ batches)
3. Verify inventory value matches Dashboard (~$13M)

## Related

- Closes: GF-PHASE0-003
- Related: BUG-110, PR #318