### PR TITLE
fix(inventory): restore linting, centralize safeProductSelect, add default inputs & test gating

### DIFF
--- a/docs/ACTIVE_SESSIONS.md
+++ b/docs/ACTIVE_SESSIONS.md
@@ -13,6 +13,8 @@
 | Session ID                      | Task                                       | Branch | Module | Status      | Started    | ETA |
 | ------------------------------- | ------------------------------------------ | ------ | ------ | ----------- | ---------- | --- |
 | Session-20260130-TASK-ID-a20d2e | Execute Inventory Troubleshooting Playbook | work   | docs   | In Progress | 2026-01-30 | -   |
+| Session-20260130-TASK-ID-757025 | Fix inventory playbook issues + tests      | work   | core   | In Progress | 2026-01-30 | -   |
+| Session-20260130-TASK-ID-425fd9 | Address inventory playbook PR feedback     | work   | core   | In Progress | 2026-01-30 | -   |
 
 > **Note:** All parallel team sessions (Teams A-F) completed as part of the Golden Flow Wave execution (Jan 26-28, 2026). Work was consolidated into PRs #341-346.
 

--- a/docs/sessions/active/Session-20260130-TASK-ID-425fd9.md
+++ b/docs/sessions/active/Session-20260130-TASK-ID-425fd9.md
@@ -1,0 +1,17 @@
+# Session: TASK-ID - Address inventory playbook PR feedback
+
+**Status**: In Progress
+**Started**: 2026-01-30
+**Agent Type**: External (ChatGPT)
+**Platform**: ChatGPT
+**Files**: server/inventoryDb.ts, server/routers/inventory.ts, server/routers/comments.test.ts, server/inventoryDb.test.ts, server/routers/inventory.test.ts, package.json, scripts/lint-changed.mjs
+
+## Progress
+
+- [ ] Review PR feedback and required fixes
+- [ ] Apply code/test/tooling updates
+- [ ] Run verification checks
+
+## Notes
+
+Continuing inventory playbook fixes with QA protocol review.

--- a/docs/sessions/active/Session-20260130-TASK-ID-757025.md
+++ b/docs/sessions/active/Session-20260130-TASK-ID-757025.md
@@ -1,0 +1,18 @@
+# Session: Fix inventory playbook issues and test failures
+
+**Status**: In Progress
+**Started**: 2026-01-30
+**Agent Type**: External (ChatGPT)
+**Platform**: ChatGPT
+**Files**: server/inventoryDb.ts, server/services/spreadsheetViewService.ts, server/routers/comments.test.ts, package.json, docs/sessions/active/Session-20260130-TASK-ID-757025.md, docs/ACTIVE_SESSIONS.md
+
+## Progress
+
+- [x] Register session
+- [x] Fix inventory playbook execution blockers
+- [x] Fix lint/test tooling to validate new code only
+- [x] Run required checks
+
+## Notes
+
+Tracking fixes for inventory playbook execution and test/lint gating.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "NODE_ENV=production node dist/index.js",
     "start:production": "NODE_ENV=production node --max-old-space-size=896 dist/index.js",
     "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint client/src server --ext .ts,.tsx",
     "lint:fix": "eslint client/src server --ext .ts,.tsx --fix",
     "check:dashboard": "tsx scripts/check-dashboard-data.ts",

--- a/server/inventoryDb.ts
+++ b/server/inventoryDb.ts
@@ -35,6 +35,20 @@ import {
 } from "../drizzle/schema";
 import { isValidStatusTransition, type BatchStatus } from "./inventoryUtils";
 
+const safeProductSelect = {
+  id: products.id,
+  brandId: products.brandId,
+  strainId: sql<number | null>`NULL`,
+  nameCanonical: products.nameCanonical,
+  deletedAt: products.deletedAt,
+  category: products.category,
+  subcategory: products.subcategory,
+  uomSellable: products.uomSellable,
+  description: products.description,
+  createdAt: products.createdAt,
+  updatedAt: products.updatedAt,
+};
+
 // ============================================================================
 // VENDOR QUERIES (DEPRECATED - Use Supplier functions below)
 // ============================================================================
@@ -877,7 +891,7 @@ export async function getBatchesWithDetails(
   const query = db
     .select({
       batch: batches,
-      product: products,
+      product: safeProductSelect,
       brand: brands,
       lot: lots,
       // BUG-122: Removed deprecated vendor field - use supplierClient instead
@@ -940,7 +954,7 @@ export async function searchBatches(
   const result = await db
     .select({
       batch: batches,
-      product: products,
+      product: safeProductSelect,
       brand: brands,
       lot: lots,
       supplierClient: clients,


### PR DESCRIPTION
### Motivation
- Prevent runtime SQL failures and test flakes caused by schema drift around `products.strainId` and make inventory list endpoints accept omitted payloads. 
- Reduce CI/developer noise by restoring repository linting to run full ESLint and by gating DB-dependent tests behind explicit environment checks.
- Improve test robustness and traceability for inventory list behavior used by multiple UI surfaces.

### Description
- Centralized a safe product projection `safeProductSelect` in `server/inventoryDb.ts` that projects `strainId` as `NULL` and uses it for `getBatchesWithDetails` and `searchBatches` to avoid referencing a missing `products.strainId` column. 
- Replaced the custom changed-files lint runner with the standard repo `lint` script (`package.json`) and removed `scripts/lint-changed.mjs`. 
- Added `enhancedInventoryInputSchema` and wired `inventory.getEnhanced` to use it, and provided a sensible default for `inventory.list` input via `listQuerySchema.default(...)` so omitted inputs do not fail validation. 
- Hardened tests and test mocks: updated `server/inventoryDb.test.ts` and `server/routers/inventory.test.ts` to assert safe-product selection and default-list behavior, tightened typings in test builders, and simplified `server/routers/comments.test.ts` DB gating to rely on `DATABASE_URL`. 
- Minor hygiene: restored `typecheck` script in `package.json`, fixed a `sql(...).as(...)` misuse, and added documentation/reporting files recording the inventory data-surfacing analysis and session registration. 

### Testing
- Ran `pnpm typecheck` which completed successfully with no new TypeScript errors. 
- Ran `pnpm lint` (ESLint) and applied autofixes where appropriate; final lint check passed. 
- Ran `pnpm test` (Vitest): executed the full test suite; inventory-related unit/integration tests and the modified router/db tests ran and the inventory selection/assertion tests now pass while DB-dependent integration tests are skipped unless `DATABASE_URL` is provided (gated by the updated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf8bba7ac83308ba78aff67f52461)