### PR TITLE
docs: update roadmap with recent QA infrastructure completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,12 +120,22 @@ pnpm build          # Build verification
 pnpm roadmap:validate
 pnpm validate:sessions
 
+# Schema verification (runs in CI, optional locally)
+pnpm test:schema    # Requires DATABASE_URL - verifies schema matches DB
+
 # Deployment verification
 ./scripts/watch-deploy.sh
 ./scripts/check-deployment-status.sh $(git rev-parse HEAD | cut -c1-7)
 curl https://terp-app-b9s35.ondigitalocean.app/health
 ./scripts/terp-logs.sh run 100 | grep -i "error"
 ```
+
+**Schema Verification Notes:**
+- `pnpm test:schema` runs integration tests against a real database
+- Tests auto-validate ALL tables/columns from `drizzle/schema.ts`
+- Uses `COLUMNS_PENDING_MIGRATION` array for known pending migrations (e.g., `products.strainId`)
+- Runs automatically on PRs via `.github/workflows/schema-validation.yml`
+- See `tests/integration/schema-verification.test.ts` for implementation
 
 ### Output Template
 


### PR DESCRIPTION
Updates to MASTER_ROADMAP.md (v7.3):
- Mark QA-INFRA-001 complete: Schema verification tests added
- Mark QA-INFRA-002 complete: Schema drift PR workflow enabled
- Add QA-INFRA-005: Tech debt for safeProductSelect removal
- Update QA-INFRA-004 status (blockers resolved)
- Add Customer Feedback section (Jan 29, 2026 meeting)
  - 9 actionable items from cleaned meeting analysis
  - NOW priority: MEET-002, 004, 008, 026
  - NEXT priority: MEET-006, 013, 020, 029, 031

Updates to CLAUDE.md:
- Add schema verification command to verification section
- Document COLUMNS_PENDING_MIGRATION pattern
- Reference schema-verification.test.ts implementation

https://claude.ai/code/session_01FvAohtFyaii4Qde1B6XpeK