### PR TITLE
fix: deploy reliability - memory, health checks, startup optimization

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -32,11 +32,11 @@ services:
     # Server startup takes ~55s including migrations, so 60s delay is safe with margin
     health_check:
       http_path: /health/live
-      initial_delay_seconds: 60 # Reduced from 180s - server ready in ~55s
+      initial_delay_seconds: 120 # Reduced from 180s - server ready in ~55s
       period_seconds: 15 # Reduced probe frequency to minimize noise
       timeout_seconds: 5
       success_threshold: 1
-      failure_threshold: 5
+      failure_threshold: 8
 
     # HTTP configuration
     http_port: 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,4 @@ EXPOSE 3000
 #
 # NOTE: If upgrading to basic-s or larger, update NODE_MEMORY_LIMIT env var
 # in .do/app.yaml and increase --max-old-space-size accordingly.
-CMD ["node", "--expose-gc", "--max-old-space-size=384", "dist/index.js"]
+CMD ["node", "--expose-gc", "--max-old-space-size=1536", "dist/index.js"]


### PR DESCRIPTION
## Root Cause

DigitalOcean deployment `d82ac507` failed because the health check window (135s) was exceeded when `autoMigrations` ran 80 sequential DB operations under contention from 8 rapid-fire deployments.

## Changes (4 files)

### 1. `Dockerfile` — Memory config fix
- `--max-old-space-size=384` → `1536` (matches 2GB `apps-d-1vcpu-2gb` instance)
- Was wasting 75% of available memory due to stale config from 512MB era

### 2. `.do/app.yaml` — Health check window expansion
- `initial_delay_seconds`: 60 → 120
- `failure_threshold`: 5 → 8
- Total tolerance: 135s → 240s (120 + 8×15)

### 3. `server/autoMigrate.ts` — Schema fingerprint fast-path
- Single query checks 7 canary tables/columns representing latest schema
- If all present, skips all 80 migration operations entirely
- Normal startup: **80 DB calls → 1 check query** (97.5% reduction)
- Falls through to full migrations for new deployments/schema drift

### 4. `server/_core/index.ts` — Startup timing instrumentation
- Logs `[STARTUP +Xs]` at each phase: migrations, seeds, express, listen
- Enables future debugging of slow-start deployments

## Expected Impact
- Normal startup: 80 DB calls → 1 DB call
- Health check tolerance: 135s → 240s
- Memory utilization: 384MB → 1536MB heap
- Deployment reliability: Eliminates timeout failures under normal conditions