### PR TITLE
fix: deploy reliability - DB warmup + connection timeout

### DIFF
--- a/server/_core/connectionPool.ts
+++ b/server/_core/connectionPool.ts
@@ -114,6 +114,7 @@ export function getConnectionPool(config?: PoolConfig): mysql.Pool {
     uri: cleanDatabaseUrl,
     ...poolConfig,
     ...sslConfig,
+    connectTimeout: 10000, // 10s connect timeout - fail fast rather than hang indefinitely
     // FIX-006: TiDB ENUM compatibility fix
     // TiDB returns ENUM columns with type code 0xf7 (247) in binary protocol
     // instead of STRING type with ENUM flag like MySQL does.


### PR DESCRIPTION
## Root Cause

Deployment `2b4c4f21` (commit `f5094f3b`) failed health checks because:

1. The schema fingerprint check from PR #360 was the right optimization, but the single-attempt query failed with `ETIMEDOUT` when the managed MySQL DB was slow to establish connections during deployment
2. When the fingerprint fails, autoMigrate falls through to 80 sequential DB operations
3. Each operation takes ~10s under connection contention (as seen in deploy logs: each ⚠️ line spaced exactly 10s apart)
4. 80 operations × 10s = 800s, far exceeding the 240s health check window

## Deploy log evidence
```
06:01:46 ❌ CRITICAL: Database health check failed - ETIMEDOUT
06:01:47 ℹ️  Schema fingerprint check failed - running full migrations: Failed query...
06:01:57 ℹ️  Matching/needs tables not found
06:02:07 ℹ️  client_needs table already exists
...each step 10s apart...
06:05:41 ERROR failed health checks after 11 attempts
```

## Changes

### 1. `server/_core/connectionPool.ts` — Add `connectTimeout: 10000`
- mysql2 pool had NO connection timeout (defaults to infinite)
- Now fails fast at 10s instead of hanging indefinitely

### 2. `server/autoMigrate.ts` — Fingerprint retries 3× with DB warmup
- Sends `SELECT 1` warmup query before fingerprint check
- Retries with 3s/6s backoff on connection failures
- Only falls through to full migrations after 3 failed attempts
- Handles the cold-connection scenario from ETIMEDOUT

## Expected behavior after merge
- On deploy: DB warmup succeeds → fingerprint finds 7/7 canaries → skips 80 migrations → server starts in <30s
- If DB is genuinely slow: 3 retries (0s + 3s + 6s = ~20s total) before falling through
- Worst case: falls through but with connectTimeout preventing 10s+ hangs per query