### PR TITLE
docs: CTO triage report and session registration for lint/test sweep

### DIFF
--- a/docs/reports/CTO_LINT_TEST_TRIAGE_2026-02-02.md
+++ b/docs/reports/CTO_LINT_TEST_TRIAGE_2026-02-02.md
@@ -1,0 +1,57 @@
+# CTO Triage: Lint/Test Findings (2026-02-02)
+
+## Executive Summary
+
+- The repo-wide lint sweep reports **1842 errors** and **264 warnings**, dominated by type-safety violations (`any`), React lint issues, and key/unused-variable violations.
+- The test run fails in two suites: a DB-dependent comments router test (MySQL connection refused) and an integration test that imports Jest globals inside Vitest.
+- These are systemic quality blockers; remediation should be staged by blast radius, with test infrastructure fixes first, then lint debt reduction in focused batches.
+
+## Top Risks (Severity Ordered)
+
+1. **Test infrastructure instability (P0)**
+   - `server/routers/comments.test.ts` attempts real DB writes and fails when `DATABASE_URL` is unreachable.
+   - `tests/integration/data-integrity.test.ts` imports `@jest/globals`, which is incompatible with Vitest.
+   - Impact: CI cannot be trusted to gate regressions; local dev runs are inconsistent.
+
+2. **Type-safety regressions (P1)**
+   - Large volume of `@typescript-eslint/no-explicit-any` violations and non-null assertions.
+   - Impact: makes runtime error detection harder and violates project non-negotiables.
+
+3. **React correctness & maintainability (P1)**
+   - `react/no-array-index-key` usage and `React` undefined (no-undef) in several JSX files.
+   - Impact: destabilizes UI behavior, hurts reconciliation correctness, and breaks lint gate.
+
+4. **Hygiene & operational noise (P2)**
+   - Excess unused variables and console usage warnings.
+   - Impact: hides real issues and drives warning fatigue.
+
+## Triage Plan
+
+### Phase 0: Restore test signal (Immediate)
+
+- **Normalize test runners**: migrate `tests/integration/data-integrity.test.ts` from Jest globals to Vitest APIs or move it to a Jest-only runner if required.
+- **Stabilize DB tests**: adopt a test database strategy (containerized MySQL or a deterministic mock layer) for `server/routers/comments.test.ts` and any other DB-dependent suites.
+- **Outcome**: `pnpm test` should reliably pass or fail for real regressions.
+
+### Phase 1: Reduce blocking lint debt (Short term)
+
+- **Bulk eliminate `any`** by prioritizing core/shared modules and top-level hooks/services first.
+- **Fix React undefined** by standardizing the JSX runtime configuration and importing React where required.
+- **Replace index keys** where stateful lists exist; tolerate in static/immutable lists only with explicit justification.
+
+### Phase 2: Tighten hygiene (Mid term)
+
+- Sweep unused vars and console warnings in large batches, likely per folder/module.
+- Enforce linting in CI with a clear error budget to prevent future drift.
+
+## Recommended Owners / Streams
+
+- **Test Infra Stream**: Backend + QA (fix Jest/Vitest mismatch, DB strategy).
+- **Type Debt Stream**: Core platform engineers (eradicate `any` + non-null assertions).
+- **UI Lint Stream**: Frontend engineers (React lint violations, key usage).
+
+## Success Criteria
+
+- `pnpm test` completes without infra-related failures in clean environments.
+- Lint errors reduced by >80% in the first two sprints, with explicit tracking for remaining hotspots.
+- CI gates enforced on lint/test so drift cannot re-accumulate.

--- a/docs/sessions/completed/Session-20260202-TASK-ID-59f155.md
+++ b/docs/sessions/completed/Session-20260202-TASK-ID-59f155.md
@@ -1,0 +1,20 @@
+# Session: TASK-ID - Run linter across codebase
+
+**Status**: Complete
+**Started**: 2026-02-02 22:45:00 UTC
+**Agent**: ChatGPT
+**Mode**: SAFE
+**Task**: Run linting on entire codebase per user request.
+**Files**: docs/sessions/active/Session-20260202-TASK-ID-59f155.md, docs/ACTIVE_SESSIONS.md
+
+## Checklist
+
+- [x] Register session
+- [x] Run linting command(s)
+- [x] Capture results
+
+## Progress Notes
+
+- `pnpm lint` reported 1842 errors and 264 warnings across client and server sources.
+- `pnpm typecheck` completed successfully.
+- `pnpm test` failed due to a DB connection error in `server/routers/comments.test.ts` and Jest globals usage in `tests/integration/data-integrity.test.ts`.

--- a/docs/sessions/completed/Session-20260202-TASK-ID-6328af.md
+++ b/docs/sessions/completed/Session-20260202-TASK-ID-6328af.md
@@ -1,0 +1,19 @@
+# Session: TASK-ID - CTO triage of lint/test findings
+
+**Status**: Complete
+**Started**: 2026-02-02 23:10:00 UTC
+**Agent**: ChatGPT
+**Mode**: SAFE
+**Task**: Triage lint/test findings from repo-wide sweep as CTO.
+**Files**: docs/sessions/active/Session-20260202-TASK-ID-6328af.md, docs/ACTIVE_SESSIONS.md, docs/reports/CTO_LINT_TEST_TRIAGE_2026-02-02.md
+
+## Checklist
+
+- [x] Register session
+- [x] Produce CTO triage notes
+- [x] Archive session
+
+## Progress Notes
+
+- Captured CTO-level triage plan and prioritization in docs/reports/CTO_LINT_TEST_TRIAGE_2026-02-02.md.
+- Validation run: pnpm typecheck passed; pnpm lint failed with 1842 errors/264 warnings; pnpm test failed in comments router (DB ECONNREFUSED) and data-integrity (Jest globals in Vitest).


### PR DESCRIPTION
### Motivation

- Triage repo-wide lint and test failures discovered during a quality sweep and capture an actionable CTO-level remediation plan.  
- Register and document an active session per project protocols and move it to completed once triage is delivered.

### Description

- Added a CTO triage report at `docs/reports/CTO_LINT_TEST_TRIAGE_2026-02-02.md` that summarizes top risks, phased remediation, owners, and success criteria.  
- Registered the session (`Session-20260202-TASK-ID-6328af`) in `docs/ACTIVE_SESSIONS.md` and created the session note under `docs/sessions/active/` then archived it to `docs/sessions/completed/`.  
- Updated `docs/sessions/completed/Session-20260202-TASK-ID-59f155.md` with the lint run summary and results from the sweep.

### Testing

- Ran `pnpm typecheck` which passed with no TypeScript errors.  
- Ran `pnpm lint` which failed and reported **1842 errors** and **264 warnings** (frontend and backend ESLint violations).  
- Ran `pnpm test` which failed with two infra-related failures: `server/routers/comments.test.ts` (MySQL `ECONNREFUSED`) and `tests/integration/data-integrity.test.ts` (incompatible `@jest/globals` usage under Vitest).  
- Ran `pnpm validate:sessions` which passed, and `pnpm roadmap:validate` which failed due to parse issues in `docs/roadmaps/MASTER_ROADMAP.md` (missing `Prompt` fields and invalid `Priority` values).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981287ba6cc8330844249fd863e2fc8)