### PR TITLE
fix(inventory): INV-FILTER-002 - extend DB layer for full filter support

### DIFF
--- a/server/routers/inventory.ts
+++ b/server/routers/inventory.ts
@@ -150,13 +150,17 @@ export const inventoryRouter = router({
         inventoryLogger.operationStart("getEnhanced", { input });
 
         // Get base inventory data
-        // INV-FILTER-001: Pass status and category filters to database layer
+        // INV-FILTER-002: Pass all filters to database layer
         const result = await inventoryDb.getBatchesWithDetails(
           input.pageSize + 1, // Fetch one extra to check for more pages
           input.cursor,
           {
-            status: input.status?.[0], // DB layer expects single string, not array
+            status: input.status, // Array or undefined
             category: input.category,
+            subcategory: input.subcategory,
+            vendor: input.vendor, // Array of vendor names
+            brand: input.brand, // Array of brand names
+            grade: input.grade, // Array of grade values
           }
         );
 


### PR DESCRIPTION
## Summary

Extends `getBatchesWithDetails` to support additional filters at the database level, eliminating client-side filtering for these fields.

## Changes

### server/inventoryDb.ts
- Extended `filters` type to support:
  - `status`: Now accepts both single string and array of statuses
  - `subcategory`: New filter for product subcategory
  - `vendor`: New filter matching against `clients.name` (supplier names)
  - `brand`: New filter matching against `brands.name`
  - `grade`: New filter matching against `batches.grade`
- All array filters use `safeInArray` for SQL safety

### server/routers/inventory.ts
- Updated `getEnhanced` procedure to pass all filters to the database layer

## Testing

- [x] `pnpm check` passes (TypeScript)
- [x] `pnpm lint` passes (ESLint + Prettier)
- [x] No forbidden patterns introduced
- [ ] Manual verification: Apply vendor/brand/grade filters, verify results match

## Related

- Fixes: INV-FILTER-002
- Depends on: INV-FILTER-001 (PR #368)
- Part of: Inventory Filter Chain Fix (S0-CRITICAL)

## Priority

**P1 HIGH**