### PR TITLE
fix(inventory): INV-PARTY-001 - rename getBatchesByVendor to getBatchesBySupplier

### DIFF
--- a/server/routers/inventory.ts
+++ b/server/routers/inventory.ts
@@ -1317,29 +1317,36 @@ export const inventoryRouter = router({
 
   // Get batches by vendor
   // _Requirements: 7.1_
-  getBatchesByVendor: protectedProcedure
+  // INV-PARTY-001: Renamed from getBatchesByVendor to align with party model
+  getBatchesBySupplier: protectedProcedure
     .use(requirePermission("inventory:read"))
-    .input(z.object({ vendorId: z.number() }))
+    .input(z.object({ supplierClientId: z.number() }))
     .query(async ({ input }) => {
       try {
-        inventoryLogger.operationStart("getBatchesByVendor", {
-          vendorId: input.vendorId,
+        inventoryLogger.operationStart("getBatchesBySupplier", {
+          supplierClientId: input.supplierClientId,
         });
 
-        const result = await inventoryDb.getBatchesByVendor(input.vendorId);
+        const result = await inventoryDb.getBatchesBySupplier(
+          input.supplierClientId
+        );
 
-        inventoryLogger.operationSuccess("getBatchesByVendor", {
-          vendorId: input.vendorId,
+        inventoryLogger.operationSuccess("getBatchesBySupplier", {
+          supplierClientId: input.supplierClientId,
           batchCount: result.length,
         });
 
         // BUG-034: Standardized pagination response
         return createSafeUnifiedResponse(result, result?.length || 0, 50, 0);
       } catch (error) {
-        inventoryLogger.operationFailure("getBatchesByVendor", error as Error, {
-          vendorId: input.vendorId,
-        });
-        handleError(error, "inventory.getBatchesByVendor");
+        inventoryLogger.operationFailure(
+          "getBatchesBySupplier",
+          error as Error,
+          {
+            supplierClientId: input.supplierClientId,
+          }
+        );
+        handleError(error, "inventory.getBatchesBySupplier");
         throw error;
       }
     }),


### PR DESCRIPTION
## Summary

Aligns the inventory API with the party model by replacing deprecated vendor references with supplier client references.

## Changes

### server/routers/inventory.ts
- Renamed `getBatchesByVendor` to `getBatchesBySupplier`
- Changed input from `vendorId` to `supplierClientId`
- Updated all logger calls to use new naming

### server/inventoryDb.ts
- Renamed `getBatchesByVendor` to `getBatchesBySupplier`
- Changed parameter from `vendorId` to `supplierClientId`
- Now joins via `lots.supplierClientId` -> `clients.id` (party model)
- Uses `safeProductSelect` for strainId safety
- Returns `supplierClient` instead of `vendor` in result

## Testing

- [x] Pre-commit hooks pass (ESLint + Prettier)
- [x] No forbidden patterns introduced
- [ ] Manual verification: Call getBatchesBySupplier with a valid supplierClientId

## Related

- Fixes: INV-PARTY-001
- Part of: Inventory Filter Chain Fix (S0-CRITICAL)
- Roadmap: `docs/roadmaps/MASTER_ROADMAP.md` (v7.6)

## Priority

**P1 HIGH**