### PR TITLE
fix(inventory): INV-FILTER-003 - remove redundant client-side filters

### DIFF
--- a/server/routers/inventory.ts
+++ b/server/routers/inventory.ts
@@ -323,20 +323,8 @@ export const inventoryRouter = router({
           );
         }
 
-        // Apply status filter
-        if (input.status && input.status.length > 0) {
-          const statusFilter = input.status;
-          filteredItems = filteredItems.filter(item =>
-            statusFilter.includes(item.status)
-          );
-        }
-
-        // Apply category filter
-        if (input.category) {
-          filteredItems = filteredItems.filter(
-            item => item.category === input.category
-          );
-        }
+        // INV-FILTER-003: Removed redundant status filter (now handled by DB in getBatchesWithDetails)
+        // INV-FILTER-003: Removed redundant category filter (now handled by DB in getBatchesWithDetails)
 
         // Apply stock status filter
         if (input.stockStatus && input.stockStatus !== "ALL") {


### PR DESCRIPTION
## Summary

Removes client-side filtering for status and category that is now handled at the database level by `getBatchesWithDetails` (INV-FILTER-002).

## Changes

### server/routers/inventory.ts
- Removed redundant status filter (lines 317-322)
- Removed redundant category filter (lines 324-328)
- Added comments documenting the removal

## Remaining Client-Side Filters

These filters must remain client-side as they depend on computed values:
- `search`: Text search across multiple fields
- `stockStatus`: Computed from onHand, reserved, quarantine, hold quantities
- `ageBracket`: Computed from receivedDate
- `minAge/maxAge`: Computed from receivedDate
- `batchId`: Text search on batch code

## Testing

- [x] Pre-commit hooks pass (ESLint + Prettier)
- [x] No forbidden patterns introduced
- [ ] Manual verification: Confirm filters still work correctly

## Related

- Fixes: INV-FILTER-003
- Depends on: INV-FILTER-002 (PR #369)
- Part of: Inventory Filter Chain Fix (S0-CRITICAL)

## Priority

**P2 MEDIUM**