### PR TITLE
fix(inventory): Wire InventoryWorkSurface directly, remove broken WorkSurfaceGate

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import DashboardV3 from "./pages/DashboardV3";
-import Inventory from "@/pages/Inventory";
+// Legacy Inventory page removed - now using InventoryWorkSurface directly
 import ProductsPage from "@/pages/ProductsPage";
 import VendorsPage from "@/pages/VendorsPage";
 import UsersPage from "@/pages/UsersPage";
@@ -181,25 +181,11 @@ function Router() {
                 />
                 <Route
                   path="/inventory"
-                  component={withErrorBoundary(() => (
-                    <WorkSurfaceGate
-                      flag="WORK_SURFACE_INVENTORY"
-                      fallback={<Inventory />}
-                    >
-                      <InventoryWorkSurface />
-                    </WorkSurfaceGate>
-                  ))}
+                  component={withErrorBoundary(InventoryWorkSurface)}
                 />
                 <Route
                   path="/inventory/:id"
-                  component={withErrorBoundary(() => (
-                    <WorkSurfaceGate
-                      flag="WORK_SURFACE_INVENTORY"
-                      fallback={<Inventory />}
-                    >
-                      <InventoryWorkSurface />
-                    </WorkSurfaceGate>
-                  ))}
+                  component={withErrorBoundary(InventoryWorkSurface)}
                 />
                 <Route
                   path="/products"


### PR DESCRIPTION
## Summary
Fixes the inventory page showing "No inventory found" despite API returning 300+ items.

## Root Cause
The `WorkSurfaceGate` feature flag check was failing despite the `WORK_SURFACE_INVENTORY` flag being enabled (`systemEnabled: true`, `defaultEnabled: true`). This caused the legacy `Inventory` page to render instead of `InventoryWorkSurface`.

## Changes
- Remove `WorkSurfaceGate` wrapper from `/inventory` and `/inventory/:id` routes
- Wire `InventoryWorkSurface` directly via `withErrorBoundary`
- Remove unused `Inventory` import

## QA Analysis (Codex)
**Verdict: APPROVE WITH NOTES**

### Blast Radius
- Only affects `/inventory` and `/inventory/:id` routes
- Other `WorkSurfaceGate` usages (Invoices, Clients, Orders, etc.) unchanged
- Shared contexts (theme, routing, error boundaries) remain intact

### Risk Assessment
- **Low Risk** - Feature flag was already enabled; we're removing a broken gate
- **Rollback Plan:** Re-add `WorkSurfaceGate` wrapper if issues arise

## Testing
- [x] ESLint passes
- [x] Codex QA analysis approved
- [ ] Manual verification after deployment

## Related
- Fixes inventory display issue identified in production
- Part of Phase 3.5 test/lint signal recovery