### PR TITLE
feat(ci): Add automatic PR preview deployments

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,57 @@
+name: PR Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Delete Preview App
+    runs-on: ubuntu-latest
+    # Skip cleanup for dependabot PRs (they don't have previews)
+    if: github.actor != 'dependabot[bot]'
+    
+    steps:
+      - name: Delete preview app
+        uses: digitalocean/app_action/delete@v2
+        with:
+          from_pr_preview: "true"
+          ignore_not_found: "true"
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Comment on PR about cleanup
+        uses: actions/github-script@v7
+        if: success()
+        with:
+          script: |
+            // Find existing preview comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Preview Deployment')
+            );
+            
+            if (botComment) {
+              const wasMerged = context.payload.pull_request.merged;
+              const status = wasMerged ? '✅ Merged' : '🚫 Closed';
+              
+              const body = `## 🧹 Preview Deployment Cleaned Up
+
+| Status | Action |
+|--------|--------|
+| ${status} | Preview app deleted |
+
+The preview environment has been automatically cleaned up.`;
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            }

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,129 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    # Skip preview for dependabot PRs to save resources
+    if: github.actor != 'dependabot[bot]'
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy PR Preview to DigitalOcean
+        id: deploy
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          deploy_pr_preview: "true"
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          print_build_logs: "true"
+          print_deploy_logs: "true"
+
+      - name: Comment on PR with preview URL
+        uses: actions/github-script@v7
+        if: success()
+        with:
+          script: |
+            const app = ${{ steps.deploy.outputs.app }};
+            const liveUrl = app.live_url;
+            
+            // Find existing bot comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Preview Deployment')
+            );
+            
+            const body = `## 🚀 Preview Deployment
+
+| Status | URL |
+|--------|-----|
+| ✅ **Live** | [${liveUrl}](${liveUrl}) |
+
+### Details
+- **App Name:** \`${app.spec.name}\`
+- **Commit:** \`${context.sha.substring(0, 7)}\`
+- **Updated:** ${new Date().toISOString()}
+
+---
+<details>
+<summary>QA Checklist</summary>
+
+- [ ] Routes load correctly
+- [ ] No console errors
+- [ ] Forms submit properly
+- [ ] Data displays correctly
+
+</details>`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+
+      - name: Comment on PR with failure details
+        uses: actions/github-script@v7
+        if: failure()
+        env:
+          BUILD_LOGS: ${{ steps.deploy.outputs.build_logs }}
+          DEPLOY_LOGS: ${{ steps.deploy.outputs.deploy_logs }}
+        with:
+          script: |
+            const { BUILD_LOGS, DEPLOY_LOGS } = process.env;
+            
+            const body = `## ❌ Preview Deployment Failed
+
+The preview deployment failed. Check the logs below for details.
+
+**Action Run:** [View Logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+
+<details>
+<summary>Build Logs</summary>
+
+\`\`\`
+${BUILD_LOGS || 'No build logs available'}
+\`\`\`
+
+</details>
+
+<details>
+<summary>Deploy Logs</summary>
+
+\`\`\`
+${DEPLOY_LOGS || 'No deploy logs available'}
+\`\`\`
+
+</details>`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });

--- a/docs/PREVIEW_DEPLOYMENTS.md
+++ b/docs/PREVIEW_DEPLOYMENTS.md
@@ -1,0 +1,132 @@
+# Preview Deployments
+
+This document describes how automatic preview deployments work for the TERP project.
+
+## Overview
+
+Every pull request to `main` automatically gets a preview deployment on DigitalOcean App Platform. This allows QA testing of changes before merging.
+
+## How It Works
+
+### On PR Open/Update
+
+1. GitHub Actions triggers `.github/workflows/preview-deploy.yml`
+2. The `digitalocean/app_action` creates a unique preview app for the PR
+3. A comment is posted on the PR with the live preview URL
+4. The preview updates automatically when new commits are pushed
+
+### On PR Close/Merge
+
+1. GitHub Actions triggers `.github/workflows/preview-cleanup.yml`
+2. The preview app is automatically deleted
+3. The PR comment is updated to reflect cleanup status
+
+## Preview App Naming
+
+Preview apps are automatically named using the pattern:
+
+```
+terp-pr-{PR_NUMBER}
+```
+
+For example, PR #380 would create an app named `terp-pr-380`.
+
+## Configuration
+
+### Required Secret
+
+The following secret must be configured in the GitHub repository:
+
+| Secret Name                 | Description                                                               |
+| --------------------------- | ------------------------------------------------------------------------- |
+| `DIGITALOCEAN_ACCESS_TOKEN` | DigitalOcean Personal Access Token with read/write access to App Platform |
+
+### Setting Up the Secret
+
+1. Go to [DigitalOcean API Tokens](https://cloud.digitalocean.com/account/api/tokens)
+2. Click "Generate New Token"
+3. Name it `github-actions-terp` (or similar)
+4. Select **Read** and **Write** scopes
+5. Copy the token
+6. Go to GitHub repo → Settings → Secrets and variables → Actions
+7. Click "New repository secret"
+8. Name: `DIGITALOCEAN_ACCESS_TOKEN`
+9. Value: Paste the token
+10. Click "Add secret"
+
+## Preview App Spec Modifications
+
+When deployed as a preview, the app spec is automatically modified:
+
+- **Name**: Changed to `terp-pr-{PR_NUMBER}`
+- **Branch**: Changed to the PR's source branch
+- **Domains**: Removed (uses default DO domain)
+- **Alerts**: Removed (to avoid notification spam)
+- **Database**: Uses the same production database (be careful with migrations!)
+
+## Database Considerations
+
+⚠️ **Important**: Preview apps connect to the **same production database** as the main app.
+
+### Safe Practices
+
+- Preview deployments should NOT run destructive migrations
+- Test data changes should be reversible
+- Use feature flags for new features that require schema changes
+
+### For Schema Changes
+
+1. Create the migration in a separate PR first
+2. Merge the migration PR to main
+3. Then create the feature PR that uses the new schema
+
+## Costs
+
+Preview apps incur DigitalOcean charges while running:
+
+- Instance: `apps-d-1vcpu-2gb` (~$12/month prorated)
+- Apps are automatically deleted when PRs are closed
+- Dependabot PRs skip preview deployment to save costs
+
+## Troubleshooting
+
+### Preview Deployment Failed
+
+Check the GitHub Actions logs for details:
+
+1. Go to the PR → Checks tab
+2. Click on "Deploy Preview"
+3. Review build and deploy logs
+
+Common issues:
+
+- **Build failure**: TypeScript errors, missing dependencies
+- **Deploy failure**: Health check timeout, environment variable issues
+
+### Preview Not Updating
+
+If the preview doesn't update after pushing:
+
+1. Check if the workflow is running (Actions tab)
+2. Verify the `DIGITALOCEAN_ACCESS_TOKEN` secret is valid
+3. Check DigitalOcean App Platform for any quota limits
+
+### Manual Cleanup
+
+If a preview app wasn't automatically deleted:
+
+```bash
+# List all apps
+doctl apps list
+
+# Delete by app ID
+doctl apps delete <app-id>
+```
+
+Or use the DigitalOcean control panel to manually delete the app.
+
+## Related Files
+
+- `.github/workflows/preview-deploy.yml` - Deploy workflow
+- `.github/workflows/preview-cleanup.yml` - Cleanup workflow
+- `.do/app.yaml` - Base app specification


### PR DESCRIPTION
## Summary
Adds automatic preview deployments for pull requests using DigitalOcean App Platform.

## Features
- 🚀 Automatic preview app creation on PR open/update
- 💬 Preview URL posted as PR comment
- 🧹 Automatic cleanup when PR is closed/merged
- 🤖 Skips dependabot PRs to save costs

## Files Added
- `.github/workflows/preview-deploy.yml` - Deploy workflow
- `.github/workflows/preview-cleanup.yml` - Cleanup workflow
- `docs/PREVIEW_DEPLOYMENTS.md` - Setup documentation

## Required Setup ✅
- [x] `DIGITALOCEAN_ACCESS_TOKEN` secret configured

## How It Works
1. PR opened → Preview app deployed → Comment with URL
2. PR updated → Preview app redeployed → Comment updated
3. PR closed/merged → Preview app deleted → Comment updated

## Testing
This PR itself will trigger the preview deployment workflow once merged.