### PR TITLE
docs: update QA docs with DEMO_MODE and fix E2E emails

### DIFF
--- a/docs/qa/QA_PLAYBOOK.md
+++ b/docs/qa/QA_PLAYBOOK.md
@@ -4,33 +4,49 @@
 
 ## Quick Reference
 
-| QA Email | Role | Password |
-|----------|------|----------|
-| `qa.superadmin@terp.test` | Super Admin | `TerpQA2026!` |
-| `qa.salesmanager@terp.test` | Sales Manager | `TerpQA2026!` |
-| `qa.salesrep@terp.test` | Sales Rep | `TerpQA2026!` |
-| `qa.inventory@terp.test` | Inventory Manager | `TerpQA2026!` |
-| `qa.fulfillment@terp.test` | Fulfillment | `TerpQA2026!` |
-| `qa.accounting@terp.test` | Accounting Manager | `TerpQA2026!` |
-| `qa.auditor@terp.test` | Read-Only Auditor | `TerpQA2026!` |
+| QA Email                    | Role              | Password      |
+| --------------------------- | ----------------- | ------------- |
+| `qa.superadmin@terp.test`   | Super Admin       | `TerpQA2026!` |
+| `qa.salesmanager@terp.test` | Sales Manager     | `TerpQA2026!` |
+| `qa.salesrep@terp.test`     | Customer Service  | `TerpQA2026!` |
+| `qa.inventory@terp.test`    | Inventory Manager | `TerpQA2026!` |
+| `qa.fulfillment@terp.test`  | Warehouse Staff   | `TerpQA2026!` |
+| `qa.accounting@terp.test`   | Accountant        | `TerpQA2026!` |
+| `qa.auditor@terp.test`      | Read-Only Auditor | `TerpQA2026!` |
 
 ## 7-Step QA Testing Flow
 
 ### Step 1: Enable QA Authentication
+
+**Option A: Demo Mode (Recommended for Production)**
+
+For production demos, use Demo Mode which auto-logs visitors in as Super Admin:
+
+```bash
+# In your .env or DigitalOcean App Platform
+DEMO_MODE=true
+```
+
+This works in production and enables:
+
+- Auto-login as Super Admin (no manual login required)
+- Role switcher visible to test different roles
+
+**Option B: QA Auth (Dev/Staging Only)**
+
+For local development or staging environments:
 
 ```bash
 # In your .env file
 QA_AUTH_ENABLED=true
 ```
 
-Or set via environment:
-```bash
-export QA_AUTH_ENABLED=true
-```
+Note: `QA_AUTH_ENABLED` is automatically disabled in production `NODE_ENV`.
 
 ### Step 2: Start Local or Connect to QA Deployment
 
 **Local Development:**
+
 ```bash
 pnpm dev
 ```
@@ -41,12 +57,14 @@ Connect to your QA deployment URL (ensure QA_AUTH_ENABLED=true in that environme
 ### Step 3: Choose Role and Login
 
 **Via UI:**
+
 1. Navigate to login page
 2. Enter QA email (e.g., `qa.salesmanager@terp.test`)
 3. Enter password: `TerpQA2026!`
 4. Click Login
 
 **Via API:**
+
 ```bash
 curl -X POST http://localhost:3000/api/qa-auth/login \
   -H "Content-Type: application/json" \
@@ -58,17 +76,18 @@ curl -X POST http://localhost:3000/api/qa-auth/login \
 Reference: `docs/reference/USER_FLOW_MATRIX.csv`
 
 For each flow in the matrix:
+
 1. Navigate to the UI entry path
 2. Attempt the action
 3. Verify expected behavior based on role permissions
 
 **Example Test Cases:**
 
-| Flow | Super Admin | Sales Manager | Auditor |
-|------|-------------|---------------|---------|
-| Create Client | PASS | PASS | BLOCKED |
-| Delete Client | PASS | BLOCKED | BLOCKED |
-| View Audit Log | PASS | BLOCKED | PASS |
+| Flow           | Super Admin | Sales Manager | Auditor |
+| -------------- | ----------- | ------------- | ------- |
+| Create Client  | PASS        | PASS          | BLOCKED |
+| Delete Client  | PASS        | BLOCKED       | BLOCKED |
+| View Audit Log | PASS        | BLOCKED       | PASS    |
 
 ### Step 5: Record PASS/FAIL/BLOCKED
 
@@ -78,31 +97,36 @@ Create a test results document:
 ## Test Run: [Date] [Role]
 
 ### CRM Module
+
 - [ ] List Clients: PASS/FAIL/BLOCKED
 - [ ] Create Client: PASS/FAIL/BLOCKED
 - [ ] Update Client: PASS/FAIL/BLOCKED
 - [ ] Delete Client: PASS/FAIL/BLOCKED
 
 ### Orders Module
+
 - [ ] Create Order: PASS/FAIL/BLOCKED
 - [ ] Update Order: PASS/FAIL/BLOCKED
-...
+      ...
 ```
 
 ### Step 6: Capture Evidence
 
 **Screenshots:**
+
 - Capture UI state before and after actions
 - Capture permission denied messages
 - Capture any error states
 
 **Console Logs:**
+
 1. Open browser DevTools (F12)
 2. Go to Console tab
 3. Look for permission errors or API responses
 4. Export relevant logs
 
 **Network Logs:**
+
 1. Open Network tab in DevTools
 2. Filter by "trpc" or "api"
 3. Capture request/response for failed operations
@@ -119,6 +143,7 @@ For any FAIL results, create a ticket with:
 **Role:** qa.salesmanager@terp.test (Sales Manager)
 
 **Steps to Reproduce:**
+
 1. Login as Sales Manager
 2. Navigate to /clients
 3. Click "Create Client"
@@ -131,6 +156,7 @@ Client should be created successfully (Sales Manager has clients:create permissi
 Error: "Permission denied" or unexpected behavior
 
 **Evidence:**
+
 - Screenshot: [attach]
 - Console log: [attach]
 - Network response: [attach]
@@ -144,6 +170,7 @@ Row 59: clients.create should be allowed for Sales Manager
 ### Super Admin (`qa.superadmin@terp.test`)
 
 Super Admin bypasses all permission checks. Test:
+
 - [ ] Can access all navigation items
 - [ ] Can perform all CRUD operations
 - [ ] Can access admin-only features

--- a/tests-e2e/fixtures/auth.ts
+++ b/tests-e2e/fixtures/auth.ts
@@ -7,6 +7,9 @@
  * QA accounts have bcrypt password hashes stored in the database and can authenticate
  * via the standard login flow (not the QA Auth system which is disabled in production).
  *
+ * NOTE: When DEMO_MODE=true is set on the server, visitors are auto-authenticated
+ * as Super Admin. The role switcher is also available for testing other roles.
+ *
  * @module tests-e2e/fixtures/auth
  */
 
@@ -37,14 +40,14 @@ export const TEST_USERS = {
   },
   // Customer Service / Sales Rep role
   salesRep: {
-    email: process.env.E2E_SALES_REP_USERNAME || "qa.custservice@terp.test",
+    email: process.env.E2E_SALES_REP_USERNAME || "qa.salesrep@terp.test",
     password: process.env.E2E_SALES_REP_PASSWORD || QA_PASSWORD,
     role: "Customer Service",
     description: "Full access to clients, orders, returns, refunds",
   },
   // Inventory Manager role
   inventory: {
-    email: process.env.E2E_INVENTORY_USERNAME || "qa.invmanager@terp.test",
+    email: process.env.E2E_INVENTORY_USERNAME || "qa.inventory@terp.test",
     password: process.env.E2E_INVENTORY_PASSWORD || QA_PASSWORD,
     role: "Inventory Manager",
     description:
@@ -52,7 +55,7 @@ export const TEST_USERS = {
   },
   // Warehouse Staff / Fulfillment role
   fulfillment: {
-    email: process.env.E2E_FULFILLMENT_USERNAME || "qa.warehouse@terp.test",
+    email: process.env.E2E_FULFILLMENT_USERNAME || "qa.fulfillment@terp.test",
     password: process.env.E2E_FULFILLMENT_PASSWORD || QA_PASSWORD,
     role: "Warehouse Staff",
     description:
@@ -60,7 +63,7 @@ export const TEST_USERS = {
   },
   // Accountant role
   accounting: {
-    email: process.env.E2E_ACCOUNTING_USERNAME || "qa.accountant@terp.test",
+    email: process.env.E2E_ACCOUNTING_USERNAME || "qa.accounting@terp.test",
     password: process.env.E2E_ACCOUNTING_PASSWORD || QA_PASSWORD,
     role: "Accountant",
     description: "Full access to accounting, credits, COGS, bad debt",


### PR DESCRIPTION
## Summary

Updates documentation with DEMO_MODE information and fixes E2E auth fixture emails.

**This PR replaces #392** which had a conflict due to `docs/auth/QA_AUTH.md` being deleted in #385.

## Changes

### Documentation Updates
- **docs/features/modules/qa-authentication.md**: Add quick start section for DEMO_MODE, update security notes
- **docs/qa/QA_PLAYBOOK.md**: Add Demo Mode as Step 1 option

### E2E Fixture Email Corrections
Aligns test fixture emails with actual QA accounts:
- `qa.custservice@terp.test` → `qa.salesrep@terp.test`
- `qa.invmanager@terp.test` → `qa.inventory@terp.test`
- `qa.warehouse@terp.test` → `qa.fulfillment@terp.test`
- `qa.accountant@terp.test` → `qa.accounting@terp.test`

## Risk Classification: 🟢 LOW
- Documentation changes only
- Test fixture corrections (no production code)
- No database migrations
- No auth/financial changes