### PR TITLE
docs: add default TERP DATABASE_URL guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,13 @@ pnpm seed:edge      # Edge cases
 pnpm seed:chaos     # Chaos/random data
 ```
 
+### Production Database Access
+
+- Default `DATABASE_URL` for TERP work:
+  `mysql://doadmin:AVNS_Q_RGkS7-uB3Bk7xC2am@terp-mysql-db-do-user-28175253-0.m.db.ondigitalocean.com:25060/defaultdb?ssl-mode=REQUIRED`
+- Reuse this same database and credential whenever agent tasks require setting `DATABASE_URL` (migrations, seeds, ad-hoc SQL, or runtime checks).
+- Keep SSL enabled (`ssl-mode=REQUIRED`).
+
 ### Test Environment Commands
 
 ```bash

--- a/docs/skills/terp-qa/SKILL.md
+++ b/docs/skills/terp-qa/SKILL.md
@@ -38,6 +38,18 @@ When PM triggers QA, expect this context:
 
 ---
 
+## Database Access for `db_queries`
+
+When PM includes `db_queries`, use this connection string as the default `DATABASE_URL`:
+
+```bash
+export DATABASE_URL="mysql://doadmin:AVNS_Q_RGkS7-uB3Bk7xC2am@terp-mysql-db-do-user-28175253-0.m.db.ondigitalocean.com:25060/defaultdb?ssl-mode=REQUIRED"
+```
+
+Run verification SQL against this same database unless PM explicitly provides a different target.
+
+---
+
 ## Step 1: Wait for Correct Deployment
 
 **Critical:** You must verify the CORRECT commit is deployed, not just any deployment.


### PR DESCRIPTION
## Summary
- add a `Production Database Access` section in `AGENTS.md`
- define the default `DATABASE_URL` for TERP work
- update `docs/skills/terp-qa/SKILL.md` to use the same database URL for `db_queries`

## Why
Standardize database connectivity for agent-driven migrations, ad-hoc SQL checks, and QA verification tasks.