### PR TITLE
Consolidate workspaces and unify legacy routes into workspace homes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,11 @@
-import { lazy, Suspense, type FC } from "react";
+import {
+  lazy,
+  Suspense,
+  type FC,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/NotFound";
@@ -7,9 +14,6 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import DashboardHomePage from "./pages/DashboardHomePage";
-// Legacy Inventory page removed - now using InventoryWorkSurface directly
-import ProductsPage from "@/pages/ProductsPage";
-import VendorsPage from "@/pages/VendorsPage";
 import UsersPage from "@/pages/UsersPage";
 import { AppShell } from "./components/layout/AppShell";
 import Settings from "@/pages/Settings";
@@ -24,8 +28,11 @@ import BankTransactions from "@/pages/accounting/BankTransactions";
 import Expenses from "@/pages/accounting/Expenses";
 import CashLocations from "@/pages/CashLocations";
 import ClientProfilePage from "@/pages/ClientProfilePage";
-import CreditSettingsPage from "@/pages/CreditSettingsPage";
-import CreditsPage from "@/pages/CreditsPage"; // NAV-017: Credits management page
+import CreditsWorkspacePage from "@/pages/CreditsWorkspacePage";
+import DemandSupplyWorkspacePage from "@/pages/DemandSupplyWorkspacePage";
+import InventoryWorkspacePage from "@/pages/InventoryWorkspacePage";
+import RelationshipsWorkspacePage from "@/pages/RelationshipsWorkspacePage";
+import SalesWorkspacePage from "@/pages/SalesWorkspacePage";
 import PricingRulesPage from "@/pages/PricingRulesPage";
 import PricingProfilesPage from "@/pages/PricingProfilesPage";
 import SalesSheetCreatorPage from "@/pages/SalesSheetCreatorPage";
@@ -33,29 +40,21 @@ import SharedSalesSheetPage from "@/pages/SharedSalesSheetPage";
 import { NotificationPreferencesPage } from "@/pages/settings/NotificationPreferences";
 import OrderCreatorPage from "@/pages/OrderCreatorPage";
 // Work Surface components - legacy pages removed, using WorkSurface directly
-import OrdersWorkSurface from "@/components/work-surface/OrdersWorkSurface";
 import InvoicesWorkSurface from "@/components/work-surface/InvoicesWorkSurface";
 import InventoryWorkSurface from "@/components/work-surface/InventoryWorkSurface";
-import ClientsWorkSurface from "@/components/work-surface/ClientsWorkSurface";
 import PurchaseOrdersWorkSurface from "@/components/work-surface/PurchaseOrdersWorkSurface";
 import PickPackWorkSurface from "@/components/work-surface/PickPackWorkSurface";
 import ClientLedgerWorkSurface from "@/components/work-surface/ClientLedgerWorkSurface";
-import QuotesWorkSurface from "@/components/work-surface/QuotesWorkSurface";
 import DirectIntakeWorkSurface from "@/components/work-surface/DirectIntakeWorkSurface";
 import ComponentShowcase from "@/pages/ComponentShowcase";
 import CogsSettingsPage from "@/pages/CogsSettingsPage";
 import FeatureFlagsPage from "@/pages/settings/FeatureFlagsPage";
 import AdminSetupPage from "@/pages/AdminSetupPage";
-import NeedsManagementPage from "@/pages/NeedsManagementPage";
-import InterestListPage from "@/pages/InterestListPage";
-import VendorSupplyPage from "@/pages/VendorSupplyPage";
 import VendorRedirect from "@/components/VendorRedirect";
-import ReturnsPage from "@/pages/ReturnsPage";
 import SampleManagement from "@/pages/SampleManagement";
 import LocationsPage from "@/pages/LocationsPage";
 import IntakeReceipts from "@/pages/IntakeReceipts"; // FEAT-008: Intake Verification System
 import FarmerVerification from "@/pages/FarmerVerification"; // FEAT-008: Public farmer verification
-import MatchmakingServicePage from "@/pages/MatchmakingServicePage";
 import Login from "@/pages/Login";
 import Help from "@/pages/Help";
 import VIPPortalConfigPage from "@/pages/VIPPortalConfigPage";
@@ -88,7 +87,8 @@ import { QuickAddTaskModal } from "@/components/todos/QuickAddTaskModal";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { CommandPalette } from "@/components/CommandPalette";
 import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
-import { useState } from "react";
+import { resolveRelationshipsTab } from "@/lib/navigation/consolidation";
+import { trackLegacyRouteRedirect } from "@/lib/navigation/routeUsageTelemetry";
 import { useLocation, Redirect, useSearch } from "wouter";
 import { VersionChecker } from "@/components/VersionChecker";
 import { PageErrorBoundary } from "@/components/common/PageErrorBoundary";
@@ -101,13 +101,85 @@ const withErrorBoundary = (Component: FC<any>) => () => (
   </PageErrorBoundary>
 );
 
+function useTrackLegacyRedirect(params: {
+  from: string;
+  to: string;
+  tab?: string;
+  search?: string;
+}) {
+  const { from, to, tab, search } = params;
+  const trackedDestinationsRef = useRef<Set<string>>(new Set());
+
+  useLayoutEffect(() => {
+    const destinationKey = `${from}|${to}`;
+    if (trackedDestinationsRef.current.has(destinationKey)) {
+      return;
+    }
+
+    trackLegacyRouteRedirect({ from, to, tab, search });
+    trackedDestinationsRef.current.add(destinationKey);
+  }, [from, to, tab, search]);
+}
+
 // QA-003 FIX: Helper component for legacy route redirects that preserves query params
-const RedirectWithSearch = (to: string) => {
+const RedirectWithSearch = (from: string, to: string) => {
   const RedirectComponent: FC = () => {
     const search = useSearch();
-    return <Redirect to={`${to}${search || ""}`} />;
+    const destination = `${to}${search || ""}`;
+
+    useTrackLegacyRedirect({
+      from,
+      to: destination,
+      search: search || undefined,
+    });
+
+    return <Redirect to={destination} />;
   };
   return RedirectComponent;
+};
+
+// Helper for legacy route consolidation that preserves existing query params
+const RedirectWithTab = (from: string, to: string, tab: string) => {
+  const RedirectComponent: FC = () => {
+    const search = useSearch();
+    const params = new URLSearchParams(search);
+
+    params.set("tab", tab);
+
+    const query = params.toString();
+    const destination = `${to}${query ? `?${query}` : ""}`;
+
+    useTrackLegacyRedirect({
+      from,
+      to: destination,
+      tab: params.get("tab") ?? undefined,
+      search: search || undefined,
+    });
+
+    return <Redirect to={destination} />;
+  };
+
+  return RedirectComponent;
+};
+
+// Legacy compatibility: route old client/vendor list entry points into consolidated Relationships workspace.
+const RedirectClientsToRelationships: FC = () => {
+  const search = useSearch();
+  const params = new URLSearchParams(search);
+  const resolvedTab = resolveRelationshipsTab(search);
+  params.set("tab", resolvedTab);
+
+  const query = params.toString();
+  const destination = `/relationships${query ? `?${query}` : ""}`;
+
+  useTrackLegacyRedirect({
+    from: "/clients",
+    to: destination,
+    tab: resolvedTab,
+    search: search || undefined,
+  });
+
+  return <Redirect to={destination} />;
 };
 
 // MEET-049 FIX: Helper for lazy-loaded components (adds Suspense)
@@ -174,8 +246,20 @@ function Router() {
                   component={withErrorBoundary(DashboardHomePage)}
                 />
                 <Route
+                  path="/sales"
+                  component={withErrorBoundary(SalesWorkspacePage)}
+                />
+                <Route
+                  path="/relationships"
+                  component={withErrorBoundary(RelationshipsWorkspacePage)}
+                />
+                <Route
+                  path="/demand-supply"
+                  component={withErrorBoundary(DemandSupplyWorkspacePage)}
+                />
+                <Route
                   path="/inventory"
-                  component={withErrorBoundary(InventoryWorkSurface)}
+                  component={withErrorBoundary(InventoryWorkspacePage)}
                 />
                 <Route
                   path="/inventory/:id"
@@ -183,7 +267,11 @@ function Router() {
                 />
                 <Route
                   path="/products"
-                  component={withErrorBoundary(ProductsPage)}
+                  component={RedirectWithTab(
+                    "/products",
+                    "/inventory",
+                    "products"
+                  )}
                 />
                 {/* Accounting - redirect /accounting to /accounting/dashboard */}
                 <Route
@@ -237,7 +325,7 @@ function Router() {
                 />
                 <Route
                   path="/clients"
-                  component={withErrorBoundary(ClientsWorkSurface)}
+                  component={RedirectClientsToRelationships}
                 />
                 <Route
                   path="/clients/:id"
@@ -270,7 +358,7 @@ function Router() {
                 />
                 <Route
                   path="/orders"
-                  component={withErrorBoundary(OrdersWorkSurface)}
+                  component={RedirectWithTab("/orders", "/sales", "orders")}
                 />
                 <Route
                   path="/pick-pack"
@@ -290,7 +378,7 @@ function Router() {
                 />
                 <Route
                   path="/quotes"
-                  component={withErrorBoundary(QuotesWorkSurface)}
+                  component={RedirectWithTab("/quotes", "/sales", "quotes")}
                 />
                 <Route
                   path="/settings/cogs"
@@ -314,28 +402,56 @@ function Router() {
                 />
                 <Route
                   path="/credit-settings"
-                  component={withErrorBoundary(CreditSettingsPage)}
+                  component={RedirectWithTab(
+                    "/credit-settings",
+                    "/credits",
+                    "settings"
+                  )}
                 />
                 {/* NAV-017: Credits management page */}
                 <Route
+                  path="/credits/manage"
+                  component={RedirectWithTab(
+                    "/credits/manage",
+                    "/credits",
+                    "credits"
+                  )}
+                />
+                <Route
                   path="/credits"
-                  component={withErrorBoundary(CreditsPage)}
+                  component={withErrorBoundary(CreditsWorkspacePage)}
                 />
                 <Route
                   path="/needs"
-                  component={withErrorBoundary(NeedsManagementPage)}
+                  component={RedirectWithTab(
+                    "/needs",
+                    "/demand-supply",
+                    "needs"
+                  )}
                 />
                 <Route
                   path="/interest-list"
-                  component={withErrorBoundary(InterestListPage)}
+                  component={RedirectWithTab(
+                    "/interest-list",
+                    "/demand-supply",
+                    "interest-list"
+                  )}
                 />
                 <Route
                   path="/vendor-supply"
-                  component={withErrorBoundary(VendorSupplyPage)}
+                  component={RedirectWithTab(
+                    "/vendor-supply",
+                    "/demand-supply",
+                    "vendor-supply"
+                  )}
                 />
                 <Route
                   path="/vendors"
-                  component={withErrorBoundary(VendorsPage)}
+                  component={RedirectWithTab(
+                    "/vendors",
+                    "/relationships",
+                    "suppliers"
+                  )}
                 />
                 <Route
                   path="/vendors/:id"
@@ -347,7 +463,7 @@ function Router() {
                 />
                 <Route
                   path="/returns"
-                  component={withErrorBoundary(ReturnsPage)}
+                  component={RedirectWithTab("/returns", "/sales", "returns")}
                 />
                 <Route
                   path="/samples"
@@ -369,7 +485,11 @@ function Router() {
                 />
                 <Route
                   path="/matchmaking"
-                  component={withErrorBoundary(MatchmakingServicePage)}
+                  component={RedirectWithTab(
+                    "/matchmaking",
+                    "/demand-supply",
+                    "matchmaking"
+                  )}
                 />
                 <Route
                   path="/live-shopping"
@@ -455,35 +575,47 @@ function Router() {
                 {/* QA-003 FIX: Preserve query parameters during redirect */}
                 <Route
                   path="/invoices"
-                  component={RedirectWithSearch("/accounting/invoices")}
+                  component={RedirectWithSearch(
+                    "/invoices",
+                    "/accounting/invoices"
+                  )}
                 />
                 <Route
                   path="/client-needs"
-                  component={RedirectWithSearch("/needs")}
+                  component={RedirectWithSearch("/client-needs", "/needs")}
                 />
                 <Route
                   path="/ar-ap"
-                  component={RedirectWithSearch("/accounting")}
+                  component={RedirectWithSearch("/ar-ap", "/accounting")}
                 />
                 <Route
                   path="/reports"
-                  component={RedirectWithSearch("/analytics")}
+                  component={RedirectWithSearch("/reports", "/analytics")}
                 />
                 <Route
                   path="/pricing-rules"
-                  component={RedirectWithSearch("/pricing/rules")}
+                  component={RedirectWithSearch(
+                    "/pricing-rules",
+                    "/pricing/rules"
+                  )}
                 />
                 <Route
                   path="/system-settings"
-                  component={RedirectWithSearch("/settings")}
+                  component={RedirectWithSearch(
+                    "/system-settings",
+                    "/settings"
+                  )}
                 />
                 <Route
                   path="/feature-flags"
-                  component={RedirectWithSearch("/settings/feature-flags")}
+                  component={RedirectWithSearch(
+                    "/feature-flags",
+                    "/settings/feature-flags"
+                  )}
                 />
                 <Route
                   path="/todo-lists"
-                  component={RedirectWithSearch("/todos")}
+                  component={RedirectWithSearch("/todo-lists", "/todos")}
                 />
 
                 <Route path="/404" component={withErrorBoundary(NotFound)} />

--- a/client/src/components/CommandPalette.tsx
+++ b/client/src/components/CommandPalette.tsx
@@ -18,19 +18,21 @@ import {
   ListTodo,
   HelpCircle,
   Plus,
-  Heart,
   DollarSign,
   Trophy, // NAV-014: Leaderboard
-  Target, // NAV-014: Client Needs
-  GitMerge, // NAV-014: Matchmaking
-  ClipboardList, // NAV-014: Quotes
-  RotateCcw, // NAV-014: Returns
-  Store, // NAV-014: Vendor Supply
+  GitMerge, // Consolidated demand/supply workspace
   Tag, // NAV-014: Pricing Rules
   Workflow, // NAV-014: Workflow Queue
   CreditCard, // NAV-017: Credits
   Clock, // MEET-048: Time Clock
 } from "lucide-react";
+import {
+  CREDITS_WORKSPACE,
+  DEMAND_SUPPLY_WORKSPACE,
+  INVENTORY_WORKSPACE,
+  RELATIONSHIPS_WORKSPACE,
+  SALES_WORKSPACE,
+} from "@/config/workspaces";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -55,18 +57,18 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           },
         },
         {
-          id: "orders",
-          label: "Orders",
+          id: "sales",
+          label: `${SALES_WORKSPACE.title} Workspace`,
           icon: ShoppingCart,
           shortcut: "O",
           action: () => {
-            setLocation("/orders");
+            setLocation("/sales");
             onOpenChange(false);
           },
         },
         {
           id: "inventory",
-          label: "Inventory",
+          label: `${INVENTORY_WORKSPACE.title} Workspace`,
           icon: Package,
           shortcut: "I",
           action: () => {
@@ -75,12 +77,21 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           },
         },
         {
-          id: "clients",
-          label: "Clients",
+          id: "relationships",
+          label: `${RELATIONSHIPS_WORKSPACE.title} Workspace`,
           icon: Users,
           shortcut: "C",
           action: () => {
-            setLocation("/clients");
+            setLocation("/relationships");
+            onOpenChange(false);
+          },
+        },
+        {
+          id: "demand-supply",
+          label: `${DEMAND_SUPPLY_WORKSPACE.title} Workspace`,
+          icon: GitMerge,
+          action: () => {
+            setLocation("/demand-supply");
             onOpenChange(false);
           },
         },
@@ -105,20 +116,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           },
         },
         {
-          id: "interest-list",
-          label: "Interest List",
-          icon: Heart,
-          action: () => {
-            setLocation("/interest-list");
-            onOpenChange(false);
-          },
-        },
-        {
           id: "invoices",
           label: "Invoices",
           icon: DollarSign,
           action: () => {
-            setLocation("/accounting?tab=invoices");
+            setLocation("/accounting/invoices");
             onOpenChange(false);
           },
         },
@@ -144,52 +146,6 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           },
         },
         {
-          // QA-002 FIX: Changed path from /client-needs to /needs
-          id: "client-needs",
-          label: "Client Needs",
-          icon: Target,
-          action: () => {
-            setLocation("/needs");
-            onOpenChange(false);
-          },
-        },
-        {
-          id: "matchmaking",
-          label: "Matchmaking",
-          icon: GitMerge,
-          action: () => {
-            setLocation("/matchmaking");
-            onOpenChange(false);
-          },
-        },
-        {
-          id: "quotes",
-          label: "Quotes",
-          icon: ClipboardList,
-          action: () => {
-            setLocation("/quotes");
-            onOpenChange(false);
-          },
-        },
-        {
-          id: "returns",
-          label: "Returns",
-          icon: RotateCcw,
-          action: () => {
-            setLocation("/returns");
-            onOpenChange(false);
-          },
-        },
-        {
-          id: "vendor-supply",
-          label: "Vendor Supply",
-          icon: Store,
-          action: () => {
-            setLocation("/vendor-supply");
-            onOpenChange(false);
-          },
-        },
-        {
           // QA-003 FIX: Changed path from /pricing-rules to /pricing/rules
           id: "pricing-rules",
           label: "Pricing Rules",
@@ -211,7 +167,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         {
           // NAV-017: Credits management page
           id: "credits",
-          label: "Credits",
+          label: `${CREDITS_WORKSPACE.title} Workspace`,
           icon: CreditCard,
           action: () => {
             setLocation("/credits");

--- a/client/src/components/KeyboardShortcutsModal.tsx
+++ b/client/src/components/KeyboardShortcutsModal.tsx
@@ -49,12 +49,28 @@ const shortcuts: KeyboardShortcut[] = [
 
   // In Command Palette
   { keys: ["D"], description: "Go to Dashboard", category: "Command Palette" },
-  { keys: ["O"], description: "Go to Orders", category: "Command Palette" },
-  { keys: ["I"], description: "Go to Inventory", category: "Command Palette" },
-  { keys: ["C"], description: "Go to Clients", category: "Command Palette" },
+  {
+    keys: ["O"],
+    description: "Go to Sales workspace",
+    category: "Command Palette",
+  },
+  {
+    keys: ["I"],
+    description: "Go to Inventory workspace",
+    category: "Command Palette",
+  },
+  {
+    keys: ["C"],
+    description: "Go to Relationships workspace",
+    category: "Command Palette",
+  },
   { keys: ["L"], description: "Go to Calendar", category: "Command Palette" },
   { keys: ["T"], description: "Go to Todo Lists", category: "Command Palette" },
-  { keys: ["S"], description: "Go to Settings", category: "Command Palette" },
+  {
+    keys: ["S"],
+    description: "Go to System Settings",
+    category: "Command Palette",
+  },
 ];
 
 interface KeyboardShortcutsModalProps {
@@ -88,14 +104,14 @@ export function KeyboardShortcutsModal({
                   .filter(s => s.category === category)
                   .map((shortcut) => (
                     <div
-                      key={`shortcut-${category}-${shortcut.description}`}
+                      key={`shortcut-${category}-${shortcut.description}-${shortcut.keys.join("+")}`}
                       className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-muted/50"
                     >
                       <span className="text-sm">{shortcut.description}</span>
                       <div className="flex items-center gap-1">
                         {shortcut.keys.map((k) => (
                           <span
-                            key={`key-${k}`}
+                            key={`${category}-${shortcut.description}-key-${k}`}
                             className="flex items-center gap-1"
                           >
                             <Kbd>{k}</Kbd>

--- a/client/src/components/layout/AppSidebar.test.tsx
+++ b/client/src/components/layout/AppSidebar.test.tsx
@@ -92,20 +92,17 @@ describe("AppSidebar navigation", () => {
   });
 
   it("highlights active navigation item", () => {
-    mockLocation = "/orders";
+    mockLocation = "/sales";
     render(
       <ThemeProvider>
         <Sidebar open />
       </ThemeProvider>
     );
 
-    // TER-196: "Orders" renamed to "Sales" — find the nav link with aria-current
-    const salesLinks = screen.getAllByRole("link", { name: /Sales/i });
-    const activeLink = salesLinks.find(
-      link => link.getAttribute("aria-current") === "page"
-    );
-    expect(activeLink).toBeDefined();
-    expect(activeLink).toHaveAttribute("aria-current", "page");
+    const salesLink = screen.getByRole("link", {
+      name: /Manage orders, quotes, and returns/i,
+    });
+    expect(salesLink).toHaveAttribute("aria-current", "page");
   });
 
   it("shows user actions", () => {

--- a/client/src/config/navigation.consolidation.test.ts
+++ b/client/src/config/navigation.consolidation.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Consolidated navigation information architecture checks.
+ */
+
+import { describe, it, expect } from "vitest";
+import { navigationItems } from "./navigation";
+
+const paths = navigationItems.map(item => item.path);
+
+describe("consolidated navigation IA", () => {
+  it("includes the new consolidated workspace entry points", () => {
+    expect(paths).toContain("/sales");
+    expect(paths).toContain("/relationships");
+    expect(paths).toContain("/demand-supply");
+    expect(paths).toContain("/inventory");
+    expect(paths).toContain("/credits");
+  });
+
+  it("removes legacy split navigation entry points from the sidebar", () => {
+    expect(paths).not.toContain("/quotes");
+    expect(paths).not.toContain("/returns");
+    expect(paths).not.toContain("/needs");
+    expect(paths).not.toContain("/interest-list");
+    expect(paths).not.toContain("/vendor-supply");
+    expect(paths).not.toContain("/matchmaking");
+    expect(paths).not.toContain("/products");
+    expect(paths).not.toContain("/vendors");
+    expect(paths).not.toContain("/credit-settings");
+  });
+});

--- a/client/src/config/navigation.ts
+++ b/client/src/config/navigation.ts
@@ -2,7 +2,6 @@ import {
   LayoutDashboard,
   ShoppingCart,
   FileText,
-  Package,
   PackageCheck,
   Beaker,
   Truck,
@@ -18,17 +17,11 @@ import {
   Video,
   Flag,
   Layers,
-  Heart,
   PackageOpen,
   CheckSquare,
-  Building2,
   Camera,
   Trophy, // NAV-006: Leaderboard
-  Target, // NAV-007: Client Needs
-  GitMerge, // NAV-008: Matchmaking
-  ClipboardList, // NAV-009: Quotes
-  RotateCcw, // NAV-010: Returns
-  Store, // NAV-011: Vendor Supply
+  GitMerge, // Consolidated demand/supply workspace
   Tag, // NAV-012: Pricing Rules
   Workflow, // NAV-013: Workflow Queue
   Clock, // MEET-048: Time Clock
@@ -37,6 +30,13 @@ import {
   MapPin, // TERP-0005: Locations
   type LucideIcon,
 } from "lucide-react";
+import {
+  CREDITS_WORKSPACE,
+  DEMAND_SUPPLY_WORKSPACE,
+  INVENTORY_WORKSPACE,
+  RELATIONSHIPS_WORKSPACE,
+  SALES_WORKSPACE,
+} from "@/config/workspaces";
 
 export type NavigationGroupKey = "sales" | "inventory" | "finance" | "admin";
 
@@ -69,16 +69,27 @@ export const navigationItems: NavigationItem[] = [
     group: "sales",
     ariaLabel: "Notifications and messages inbox",
   },
-  { name: "Clients", path: "/clients", icon: Users, group: "sales" },
-  // TER-196: Renamed "Orders" to "Sales" per user interview feedback
-  { name: "Sales", path: "/orders", icon: ShoppingCart, group: "sales" },
-  // NAV-001: Added Interest List for tracking client product interests
+
   {
-    name: "Interest List",
-    path: "/interest-list",
-    icon: Heart,
+    name: SALES_WORKSPACE.title,
+    path: "/sales",
+    icon: ShoppingCart,
     group: "sales",
-    ariaLabel: "Track client product interests and convert to orders",
+    ariaLabel: SALES_WORKSPACE.description,
+  },
+  {
+    name: DEMAND_SUPPLY_WORKSPACE.title,
+    path: "/demand-supply",
+    icon: GitMerge,
+    group: "sales",
+    ariaLabel: DEMAND_SUPPLY_WORKSPACE.description,
+  },
+  {
+    name: RELATIONSHIPS_WORKSPACE.title,
+    path: "/relationships",
+    icon: Users,
+    group: "sales",
+    ariaLabel: RELATIONSHIPS_WORKSPACE.description,
   },
   // NAV-002: Added Pick & Pack for order fulfillment workflow
   // TERP-0005: Moved from Sales to Inventory group
@@ -121,48 +132,13 @@ export const navigationItems: NavigationItem[] = [
     group: "sales",
     ariaLabel: "Sales performance leaderboard",
   },
-  // NAV-007: Client Needs for tracking customer requirements
-  // QA-002 FIX: Changed path from /client-needs to /needs to match App.tsx route
-  {
-    name: "Client Needs",
-    path: "/needs",
-    icon: Target,
-    group: "sales",
-    ariaLabel: "Track client product needs and requirements",
-  },
-  // NAV-008: Matchmaking for product-client matching
-  {
-    name: "Matchmaking",
-    path: "/matchmaking",
-    icon: GitMerge,
-    group: "sales",
-    ariaLabel: "Match products with client needs",
-  },
-  // NAV-009: Quotes for quote management
-  {
-    name: "Quotes",
-    path: "/quotes",
-    icon: ClipboardList,
-    group: "sales",
-    ariaLabel: "Manage sales quotes",
-  },
-  // NAV-010: Returns for order returns processing
-  {
-    name: "Returns",
-    path: "/returns",
-    icon: RotateCcw,
-    group: "sales",
-    ariaLabel: "Process order returns",
-  },
-
-  { name: "Products", path: "/products", icon: Package, group: "inventory" },
   {
     // MEET-053: User-friendly terminology - "Inventory" instead of "Batches"
-    name: "Inventory",
+    name: INVENTORY_WORKSPACE.title,
     path: "/inventory",
     icon: PackageCheck,
     group: "inventory",
-    ariaLabel: "View and manage inventory items",
+    ariaLabel: INVENTORY_WORKSPACE.description,
   },
   // NAV-003: Added Photography Queue for product photography workflow
   {
@@ -179,22 +155,6 @@ export const navigationItems: NavigationItem[] = [
     icon: Truck,
     ariaLabel: "Purchase order queue",
     group: "inventory",
-  },
-  // NAV-004: Added Vendors for vendor management and inventory visibility
-  {
-    name: "Vendors",
-    path: "/vendors",
-    icon: Building2,
-    group: "inventory",
-    ariaLabel: "Vendor management with products and inventory",
-  },
-  // NAV-011: Vendor Supply for tracking vendor inventory
-  {
-    name: "Vendor Supply",
-    path: "/vendor-supply",
-    icon: Store,
-    group: "inventory",
-    ariaLabel: "Track vendor supply and availability",
   },
   {
     name: "Spreadsheet View",
@@ -215,20 +175,11 @@ export const navigationItems: NavigationItem[] = [
 
   { name: "AR/AP", path: "/accounting", icon: CreditCard, group: "finance" },
   {
-    // QA-W2-008: Use Coins icon to avoid duplicate with AR/AP
-    // FEAT-016: Renamed from "Credits" to "Credit Settings" for clarity
-    name: "Credit Settings",
-    path: "/credit-settings",
+    name: CREDITS_WORKSPACE.title,
+    path: "/credits",
     icon: Coins,
     group: "finance",
-  },
-  // NAV-017: Credits management page - issue, apply, void credits
-  {
-    name: "Credits",
-    path: "/credits",
-    icon: CreditCard,
-    group: "finance",
-    ariaLabel: "Issue and manage customer credits",
+    ariaLabel: CREDITS_WORKSPACE.description,
   },
   { name: "Reports", path: "/analytics", icon: BarChart3, group: "finance" },
   // NAV-012: Pricing Rules for managing pricing strategies

--- a/client/src/config/workspaces.ts
+++ b/client/src/config/workspaces.ts
@@ -1,0 +1,70 @@
+export interface WorkspaceTabConfig<T extends string = string> {
+  value: T;
+  label: string;
+}
+
+export interface WorkspaceConfig<T extends string = string> {
+  title: string;
+  homePath: string;
+  description: string;
+  tabs: readonly WorkspaceTabConfig<T>[];
+}
+
+export const SALES_WORKSPACE = {
+  title: "Sales",
+  homePath: "/sales",
+  description:
+    "Manage orders, quotes, and returns in a unified sales workspace.",
+  tabs: [
+    { value: "orders", label: "Orders" },
+    { value: "quotes", label: "Quotes" },
+    { value: "returns", label: "Returns" },
+  ],
+} as const satisfies WorkspaceConfig<"orders" | "quotes" | "returns">;
+
+export const DEMAND_SUPPLY_WORKSPACE = {
+  title: "Demand & Supply",
+  homePath: "/demand-supply",
+  description:
+    "Manage needs, interests, matchmaking, and supplier availability in one workspace.",
+  tabs: [
+    { value: "matchmaking", label: "Matchmaking" },
+    { value: "needs", label: "Client Needs" },
+    { value: "interest-list", label: "Interest List" },
+    { value: "vendor-supply", label: "Vendor Supply" },
+  ],
+} as const satisfies WorkspaceConfig<
+  "matchmaking" | "needs" | "interest-list" | "vendor-supply"
+>;
+
+export const RELATIONSHIPS_WORKSPACE = {
+  title: "Relationships",
+  homePath: "/relationships",
+  description: "Manage buyers and suppliers from one consolidated workspace.",
+  tabs: [
+    { value: "clients", label: "Clients" },
+    { value: "suppliers", label: "Suppliers" },
+  ],
+} as const satisfies WorkspaceConfig<"clients" | "suppliers">;
+
+export const INVENTORY_WORKSPACE = {
+  title: "Inventory",
+  homePath: "/inventory",
+  description:
+    "Inventory is the primary workspace. Product catalog is available as a supporting tab.",
+  tabs: [
+    { value: "inventory", label: "Inventory" },
+    { value: "products", label: "Products" },
+  ],
+} as const satisfies WorkspaceConfig<"inventory" | "products">;
+
+export const CREDITS_WORKSPACE = {
+  title: "Credits",
+  homePath: "/credits",
+  description:
+    "Handle credit operations and credit configuration in one place.",
+  tabs: [
+    { value: "credits", label: "Credits" },
+    { value: "settings", label: "Settings" },
+  ],
+} as const satisfies WorkspaceConfig<"credits" | "settings">;

--- a/client/src/hooks/useQueryTabState.test.ts
+++ b/client/src/hooks/useQueryTabState.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for query-backed tab state synchronization.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useQueryTabState } from "./useQueryTabState";
+
+let mockPath = "/sales";
+let mockSearch = "";
+const mockSetLocation = vi.fn();
+
+vi.mock("wouter", () => ({
+  useLocation: () => [mockPath, mockSetLocation],
+  useSearch: () => mockSearch,
+}));
+
+describe("useQueryTabState", () => {
+  beforeEach(() => {
+    mockSetLocation.mockClear();
+    mockPath = "/sales";
+    mockSearch = "";
+  });
+
+  it("uses default tab when query has no tab", () => {
+    const { result } = renderHook(() =>
+      useQueryTabState({
+        defaultTab: "orders",
+        validTabs: ["orders", "quotes", "returns"] as const,
+      })
+    );
+
+    expect(result.current.activeTab).toBe("orders");
+  });
+
+  it("uses query tab when it is valid", () => {
+    mockSearch = "?tab=quotes";
+
+    const { result } = renderHook(() =>
+      useQueryTabState({
+        defaultTab: "orders",
+        validTabs: ["orders", "quotes", "returns"] as const,
+      })
+    );
+
+    expect(result.current.activeTab).toBe("quotes");
+  });
+
+  it("falls back to default tab when query tab is invalid", () => {
+    mockSearch = "?tab=invalid";
+
+    const { result } = renderHook(() =>
+      useQueryTabState({
+        defaultTab: "orders",
+        validTabs: ["orders", "quotes", "returns"] as const,
+      })
+    );
+
+    expect(result.current.activeTab).toBe("orders");
+  });
+
+  it("sets a non-default tab while preserving existing query params", () => {
+    mockSearch = "?status=open";
+
+    const { result } = renderHook(() =>
+      useQueryTabState({
+        defaultTab: "orders",
+        validTabs: ["orders", "quotes", "returns"] as const,
+      })
+    );
+
+    act(() => {
+      result.current.setActiveTab("quotes");
+    });
+
+    expect(mockSetLocation).toHaveBeenCalledWith(
+      "/sales?status=open&tab=quotes"
+    );
+  });
+
+  it("removes tab query when selecting the default tab", () => {
+    mockSearch = "?tab=quotes&status=open";
+
+    const { result } = renderHook(() =>
+      useQueryTabState({
+        defaultTab: "orders",
+        validTabs: ["orders", "quotes", "returns"] as const,
+      })
+    );
+
+    act(() => {
+      result.current.setActiveTab("orders");
+    });
+
+    expect(mockSetLocation).toHaveBeenCalledWith("/sales?status=open");
+  });
+});

--- a/client/src/hooks/useQueryTabState.ts
+++ b/client/src/hooks/useQueryTabState.ts
@@ -1,0 +1,43 @@
+import { useCallback, useMemo } from "react";
+import { useLocation, useSearch } from "wouter";
+
+interface UseQueryTabStateOptions<T extends string> {
+  defaultTab: T;
+  validTabs: readonly T[];
+}
+
+export function useQueryTabState<T extends string>({
+  defaultTab,
+  validTabs,
+}: UseQueryTabStateOptions<T>) {
+  const [location, setLocation] = useLocation();
+  const search = useSearch();
+
+  const activeTab = useMemo(() => {
+    const params = new URLSearchParams(search);
+    const tab = params.get("tab");
+
+    if (tab && validTabs.includes(tab as T)) {
+      return tab as T;
+    }
+
+    return defaultTab;
+  }, [defaultTab, search, validTabs]);
+
+  const setActiveTab = useCallback(
+    (nextTab: T) => {
+      const params = new URLSearchParams(search);
+      if (nextTab === defaultTab) {
+        params.delete("tab");
+      } else {
+        params.set("tab", nextTab);
+      }
+
+      const nextSearch = params.toString();
+      setLocation(`${location}${nextSearch ? `?${nextSearch}` : ""}`);
+    },
+    [defaultTab, location, search, setLocation]
+  );
+
+  return { activeTab, setActiveTab };
+}

--- a/client/src/hooks/useWorkspaceHomeTelemetry.ts
+++ b/client/src/hooks/useWorkspaceHomeTelemetry.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "wouter";
+import { trackWorkspaceHomeVisit } from "@/lib/navigation/routeUsageTelemetry";
+
+export function useWorkspaceHomeTelemetry(workspace: string, tab: string) {
+  const [location] = useLocation();
+  const trackedKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const dedupeKey = `${workspace}|${location}|${tab}`;
+    if (trackedKeysRef.current.has(dedupeKey)) {
+      return;
+    }
+
+    trackWorkspaceHomeVisit({
+      workspace,
+      path: location,
+      tab,
+    });
+
+    trackedKeysRef.current.add(dedupeKey);
+  }, [location, tab, workspace]);
+}

--- a/client/src/lib/navigation/consolidation.test.ts
+++ b/client/src/lib/navigation/consolidation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveRelationshipsTab } from "./consolidation";
+
+describe("resolveRelationshipsTab", () => {
+  it("defaults to clients when no tab or seller filter exists", () => {
+    expect(resolveRelationshipsTab("")).toBe("clients");
+    expect(resolveRelationshipsTab("?hasDebt=true")).toBe("clients");
+  });
+
+  it("keeps valid explicit tabs", () => {
+    expect(resolveRelationshipsTab("?tab=clients")).toBe("clients");
+    expect(resolveRelationshipsTab("?tab=suppliers")).toBe("suppliers");
+  });
+
+  it("routes seller-oriented legacy filters to suppliers", () => {
+    expect(resolveRelationshipsTab("?clientTypes=seller")).toBe("suppliers");
+    expect(resolveRelationshipsTab("?clientTypes=buyer,seller")).toBe(
+      "suppliers"
+    );
+  });
+
+  it("falls back from invalid tab values using seller filter detection", () => {
+    expect(resolveRelationshipsTab("?tab=unknown&clientTypes=seller")).toBe(
+      "suppliers"
+    );
+    expect(resolveRelationshipsTab("?tab=unknown")).toBe("clients");
+  });
+});

--- a/client/src/lib/navigation/consolidation.ts
+++ b/client/src/lib/navigation/consolidation.ts
@@ -1,0 +1,18 @@
+export type RelationshipsTab = "clients" | "suppliers";
+
+export function resolveRelationshipsTab(search: string): RelationshipsTab {
+  const params = new URLSearchParams(search);
+  const currentTab = params.get("tab");
+
+  if (currentTab === "clients" || currentTab === "suppliers") {
+    return currentTab;
+  }
+
+  const clientTypes = params.get("clientTypes")?.toLowerCase() ?? "";
+  const hasSellerFilter = clientTypes
+    .split(",")
+    .map(value => value.trim())
+    .includes("seller");
+
+  return hasSellerFilter ? "suppliers" : "clients";
+}

--- a/client/src/lib/navigation/routeUsageTelemetry.test.ts
+++ b/client/src/lib/navigation/routeUsageTelemetry.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRouteUsageEvents,
+  getLegacyRouteUsageAudit,
+  getLegacyRouteUsageSummary,
+  getRouteUsageEvents,
+  LEGACY_ROUTE_PATHS,
+  trackLegacyRouteRedirect,
+  trackWorkspaceHomeVisit,
+} from "./routeUsageTelemetry";
+
+describe("routeUsageTelemetry", () => {
+  beforeEach(() => {
+    clearRouteUsageEvents();
+  });
+
+  it("tracks legacy route redirects", () => {
+    trackLegacyRouteRedirect({
+      from: "/quotes",
+      to: "/sales?tab=quotes",
+      tab: "quotes",
+      search: "?draft=true",
+    });
+
+    const events = getRouteUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "legacy_route_redirect",
+      properties: {
+        from: "/quotes",
+        to: "/sales?tab=quotes",
+        tab: "quotes",
+        search: "?draft=true",
+      },
+    });
+  });
+
+  it("tracks workspace home visits", () => {
+    trackWorkspaceHomeVisit({
+      workspace: "sales",
+      path: "/sales",
+      tab: "orders",
+    });
+
+    const events = getRouteUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: "workspace_home_visit",
+      properties: {
+        workspace: "sales",
+        path: "/sales",
+        tab: "orders",
+      },
+    });
+  });
+
+  it("summarizes legacy route usage counts by source route", () => {
+    trackLegacyRouteRedirect({ from: "/quotes", to: "/sales?tab=quotes" });
+    trackLegacyRouteRedirect({ from: "/quotes", to: "/sales?tab=quotes" });
+    trackLegacyRouteRedirect({
+      from: "/vendors",
+      to: "/relationships?tab=suppliers",
+    });
+
+    const summary = getLegacyRouteUsageSummary();
+    expect(summary["/quotes"]).toBe(2);
+    expect(summary["/vendors"]).toBe(1);
+  });
+
+  it("lists all legacy routes in audit and flags low usage by threshold", () => {
+    trackLegacyRouteRedirect({ from: "/orders", to: "/sales?tab=orders" });
+    trackLegacyRouteRedirect({ from: "/orders", to: "/sales?tab=orders" });
+    trackLegacyRouteRedirect({ from: "/orders", to: "/sales?tab=orders" });
+    trackLegacyRouteRedirect({ from: "/orders", to: "/sales?tab=orders" });
+    trackLegacyRouteRedirect({ from: "/quotes", to: "/sales?tab=quotes" });
+
+    const audit = getLegacyRouteUsageAudit({
+      lookbackDays: 365,
+      lowUsageThreshold: 3,
+    });
+
+    expect(audit).toHaveLength(LEGACY_ROUTE_PATHS.length);
+    expect(audit.find(entry => entry.route === "/orders")).toMatchObject({
+      count: 4,
+      lowUsage: false,
+    });
+    expect(audit.find(entry => entry.route === "/quotes")).toMatchObject({
+      count: 1,
+      lowUsage: true,
+    });
+    expect(audit.find(entry => entry.route === "/matchmaking")).toMatchObject({
+      count: 0,
+      lowUsage: true,
+    });
+  });
+});

--- a/client/src/lib/navigation/routeUsageTelemetry.ts
+++ b/client/src/lib/navigation/routeUsageTelemetry.ts
@@ -1,0 +1,251 @@
+const STORAGE_KEY = "routeUsageEvents";
+const MAX_EVENTS = 500;
+export const LEGACY_ROUTE_PATHS = [
+  "/orders",
+  "/products",
+  "/quotes",
+  "/returns",
+  "/clients",
+  "/vendors",
+  "/needs",
+  "/interest-list",
+  "/vendor-supply",
+  "/matchmaking",
+  "/credit-settings",
+  "/credits/manage",
+  "/invoices",
+  "/client-needs",
+  "/ar-ap",
+  "/reports",
+  "/pricing-rules",
+  "/system-settings",
+  "/feature-flags",
+  "/todo-lists",
+] as const;
+
+export type RouteUsageEventType =
+  | "legacy_route_redirect"
+  | "workspace_home_visit";
+
+export interface RouteUsageEvent {
+  event: RouteUsageEventType;
+  timestamp: string;
+  properties: {
+    from?: string;
+    to?: string;
+    path?: string;
+    workspace?: string;
+    tab?: string;
+    search?: string;
+  };
+}
+
+export interface LegacyRouteUsageAuditEntry {
+  route: string;
+  count: number;
+  lastSeen?: string;
+  lowUsage: boolean;
+}
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function getStorage(): StorageLike | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    // In restricted environments (private browsing, disabled storage), fallback.
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isRouteUsageEvent(value: unknown): value is RouteUsageEvent {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const event = value.event;
+  const timestamp = value.timestamp;
+  const properties = value.properties;
+
+  return (
+    (event === "legacy_route_redirect" || event === "workspace_home_visit") &&
+    typeof timestamp === "string" &&
+    isObject(properties)
+  );
+}
+
+function readEvents(): RouteUsageEvent[] {
+  const storage = getStorage();
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isRouteUsageEvent);
+  } catch {
+    return [];
+  }
+}
+
+function writeEvents(events: RouteUsageEvent[]) {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(events));
+  } catch {
+    // Intentionally silent: telemetry must never break user navigation.
+  }
+}
+
+function appendEvent(event: RouteUsageEvent) {
+  const events = readEvents();
+  events.push(event);
+
+  if (events.length > MAX_EVENTS) {
+    events.splice(0, events.length - MAX_EVENTS);
+  }
+
+  writeEvents(events);
+}
+
+export function trackLegacyRouteRedirect(params: {
+  from: string;
+  to: string;
+  tab?: string;
+  search?: string;
+}) {
+  appendEvent({
+    event: "legacy_route_redirect",
+    timestamp: new Date().toISOString(),
+    properties: {
+      from: params.from,
+      to: params.to,
+      tab: params.tab,
+      search: params.search,
+    },
+  });
+}
+
+export function trackWorkspaceHomeVisit(params: {
+  workspace: string;
+  path: string;
+  tab?: string;
+}) {
+  appendEvent({
+    event: "workspace_home_visit",
+    timestamp: new Date().toISOString(),
+    properties: {
+      workspace: params.workspace,
+      path: params.path,
+      tab: params.tab,
+    },
+  });
+}
+
+export function getRouteUsageEvents(): RouteUsageEvent[] {
+  return readEvents();
+}
+
+export function clearRouteUsageEvents() {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    // Intentionally silent.
+  }
+}
+
+export function getLegacyRouteUsageSummary(): Record<string, number> {
+  const summary: Record<string, number> = {};
+  const events = readEvents().filter(
+    event => event.event === "legacy_route_redirect"
+  );
+
+  events.forEach(event => {
+    const key = event.properties.from ?? "unknown";
+    summary[key] = (summary[key] ?? 0) + 1;
+  });
+
+  return summary;
+}
+
+export function getLegacyRouteUsageAudit(options?: {
+  lookbackDays?: number;
+  lowUsageThreshold?: number;
+  routes?: readonly string[];
+}): LegacyRouteUsageAuditEntry[] {
+  const lookbackDays = options?.lookbackDays ?? 30;
+  const lowUsageThreshold = options?.lowUsageThreshold ?? 3;
+  const routes = options?.routes ?? LEGACY_ROUTE_PATHS;
+  const cutoffMs = Date.now() - lookbackDays * 24 * 60 * 60 * 1000;
+
+  const counters: Record<string, LegacyRouteUsageAuditEntry> = {};
+  routes.forEach(route => {
+    counters[route] = {
+      route,
+      count: 0,
+      lowUsage: true,
+    };
+  });
+
+  readEvents()
+    .filter(event => event.event === "legacy_route_redirect")
+    .forEach(event => {
+      const route = event.properties.from;
+      if (!route || !(route in counters)) {
+        return;
+      }
+
+      const timestampMs = Date.parse(event.timestamp);
+      if (Number.isNaN(timestampMs) || timestampMs < cutoffMs) {
+        return;
+      }
+
+      const current = counters[route];
+      current.count += 1;
+      if (!current.lastSeen || event.timestamp > current.lastSeen) {
+        current.lastSeen = event.timestamp;
+      }
+    });
+
+  return Object.values(counters)
+    .map(entry => ({
+      ...entry,
+      lowUsage: entry.count <= lowUsageThreshold,
+    }))
+    .sort((a, b) => a.route.localeCompare(b.route));
+}

--- a/client/src/pages/ConsolidatedWorkspaces.test.tsx
+++ b/client/src/pages/ConsolidatedWorkspaces.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Consolidated workspace page tests
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DemandSupplyWorkspacePage from "./DemandSupplyWorkspacePage";
+import RelationshipsWorkspacePage from "./RelationshipsWorkspacePage";
+import InventoryWorkspacePage from "./InventoryWorkspacePage";
+import SalesWorkspacePage from "./SalesWorkspacePage";
+import CreditsWorkspacePage from "./CreditsWorkspacePage";
+
+let mockActiveTab = "matchmaking";
+const mockSetActiveTab = vi.fn();
+
+vi.mock("@/hooks/useQueryTabState", () => ({
+  useQueryTabState: () => ({
+    activeTab: mockActiveTab,
+    setActiveTab: mockSetActiveTab,
+  }),
+}));
+
+vi.mock("@/pages/NeedsManagementPage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Needs Management {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+vi.mock("@/pages/InterestListPage", () => ({
+  default: () => <div>Interest List</div>,
+}));
+vi.mock("@/pages/MatchmakingServicePage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Matchmaking {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+vi.mock("@/pages/VendorSupplyPage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Vendor Supply {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+vi.mock("@/components/work-surface/ClientsWorkSurface", () => ({
+  default: () => <div>Clients Surface</div>,
+}));
+vi.mock("@/components/work-surface/VendorsWorkSurface", () => ({
+  default: () => <div>Suppliers Surface</div>,
+}));
+vi.mock("@/components/work-surface/InventoryWorkSurface", () => ({
+  default: () => <div>Inventory Surface</div>,
+}));
+vi.mock("@/components/work-surface/ProductsWorkSurface", () => ({
+  default: () => <div>Products Surface</div>,
+}));
+vi.mock("@/components/work-surface/OrdersWorkSurface", () => ({
+  default: () => <div>Orders Surface</div>,
+}));
+vi.mock("@/components/work-surface/QuotesWorkSurface", () => ({
+  default: () => <div>Quotes Surface</div>,
+}));
+vi.mock("@/pages/ReturnsPage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Returns {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+vi.mock("@/pages/CreditsPage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Credits {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+vi.mock("@/pages/CreditSettingsPage", () => ({
+  default: ({ embedded }: { embedded?: boolean }) => (
+    <div>Credit Settings {embedded ? "Embedded" : "Standalone"}</div>
+  ),
+}));
+
+describe("Consolidated workspace pages", () => {
+  beforeEach(() => {
+    mockSetActiveTab.mockClear();
+  });
+
+  it("renders Demand & Supply workspace with embedded content", () => {
+    mockActiveTab = "matchmaking";
+    render(<DemandSupplyWorkspacePage />);
+    expect(
+      screen.getByRole("heading", { name: "Demand & Supply" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Matchmaking Embedded")).toBeInTheDocument();
+  });
+
+  it("renders Relationships workspace", () => {
+    mockActiveTab = "clients";
+    render(<RelationshipsWorkspacePage />);
+    expect(
+      screen.getByRole("heading", { name: "Relationships" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Clients Surface")).toBeInTheDocument();
+  });
+
+  it("renders Inventory workspace with inventory default content", () => {
+    mockActiveTab = "inventory";
+    render(<InventoryWorkspacePage />);
+    expect(
+      screen.getByRole("heading", { name: "Inventory" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Inventory Surface")).toBeInTheDocument();
+  });
+
+  it("renders Sales workspace with quotes tab content", () => {
+    mockActiveTab = "quotes";
+    render(<SalesWorkspacePage />);
+    expect(screen.getByRole("heading", { name: "Sales" })).toBeInTheDocument();
+    expect(screen.getByText("Quotes Surface")).toBeInTheDocument();
+  });
+
+  it("renders Credits workspace with settings content", () => {
+    mockActiveTab = "settings";
+    render(<CreditsWorkspacePage />);
+    expect(
+      screen.getByRole("heading", { name: "Credits" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Credit Settings Embedded")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/CreditSettingsPage.tsx
+++ b/client/src/pages/CreditSettingsPage.tsx
@@ -4,9 +4,15 @@
  * 2. Visibility & Enforcement - Control UI visibility and enforcement behavior
  */
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect, type MouseEvent } from "react";
 import { trpc } from "@/lib/trpc";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Badge } from "@/components/ui/badge";
@@ -21,13 +27,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
-import { AlertCircle, Check, Info, RotateCcw, Save, Eye, Shield, Sliders } from "lucide-react";
+  AlertCircle,
+  Check,
+  Info,
+  RotateCcw,
+  Save,
+  Eye,
+  Shield,
+  Sliders,
+} from "lucide-react";
 import { BackButton } from "@/components/common/BackButton";
 import { FormSkeleton } from "@/components/ui/skeleton-loaders";
 import { toast } from "sonner";
@@ -57,7 +67,13 @@ const DEFAULT_VISIBILITY: VisibilitySettings = {
   alertThresholdPercent: 90,
 };
 
-export default function CreditSettingsPage() {
+interface CreditSettingsPageProps {
+  embedded?: boolean;
+}
+
+export default function CreditSettingsPage({
+  embedded = false,
+}: CreditSettingsPageProps) {
   // Signal weights state
   const [weights, setWeights] = useState({
     revenueMomentumWeight: 20,
@@ -70,18 +86,26 @@ export default function CreditSettingsPage() {
   const [hasWeightChanges, setHasWeightChanges] = useState(false);
 
   // Visibility settings state
-  const [visibility, setVisibility] = useState<VisibilitySettings>(DEFAULT_VISIBILITY);
+  const [visibility, setVisibility] =
+    useState<VisibilitySettings>(DEFAULT_VISIBILITY);
   const [hasVisibilityChanges, setHasVisibilityChanges] = useState(false);
 
   // UX-001: Warn before leaving with unsaved changes
   useBeforeUnloadWarning(hasWeightChanges || hasVisibilityChanges);
 
   // Fetch current weight settings
-  const { data: settings, isLoading: weightsLoading, refetch: refetchWeights } = trpc.credit.getSettings.useQuery();
+  const {
+    data: settings,
+    isLoading: weightsLoading,
+    refetch: refetchWeights,
+  } = trpc.credit.getSettings.useQuery();
 
   // Fetch visibility settings
-  const { data: visibilityData, isLoading: visibilityLoading, refetch: refetchVisibility } = 
-    trpc.credit.getVisibilitySettings.useQuery({});
+  const {
+    data: visibilityData,
+    isLoading: visibilityLoading,
+    refetch: refetchVisibility,
+  } = trpc.credit.getVisibilitySettings.useQuery({});
 
   // Update weight settings mutation
   const updateWeightsMutation = trpc.credit.updateSettings.useMutation({
@@ -90,22 +114,23 @@ export default function CreditSettingsPage() {
       setHasWeightChanges(false);
       refetchWeights();
     },
-    onError: (error) => {
+    onError: error => {
       toast.error(`Error: ${error.message || "Failed to save settings"}`);
     },
   });
 
   // Update visibility settings mutation
-  const updateVisibilityMutation = trpc.credit.updateVisibilitySettings.useMutation({
-    onSuccess: () => {
-      toast.success("Visibility settings saved successfully!");
-      setHasVisibilityChanges(false);
-      refetchVisibility();
-    },
-    onError: (error) => {
-      toast.error(`Error: ${error.message || "Failed to save settings"}`);
-    },
-  });
+  const updateVisibilityMutation =
+    trpc.credit.updateVisibilitySettings.useMutation({
+      onSuccess: () => {
+        toast.success("Visibility settings saved successfully!");
+        setHasVisibilityChanges(false);
+        refetchVisibility();
+      },
+      onError: error => {
+        toast.error(`Error: ${error.message || "Failed to save settings"}`);
+      },
+    });
 
   // Initialize weights from settings
   useEffect(() => {
@@ -126,11 +151,15 @@ export default function CreditSettingsPage() {
     if (visibilityData) {
       setVisibility({
         showCreditInClientList: visibilityData.showCreditInClientList ?? true,
-        showCreditBannerInOrders: visibilityData.showCreditBannerInOrders ?? true,
-        showCreditWidgetInProfile: visibilityData.showCreditWidgetInProfile ?? true,
+        showCreditBannerInOrders:
+          visibilityData.showCreditBannerInOrders ?? true,
+        showCreditWidgetInProfile:
+          visibilityData.showCreditWidgetInProfile ?? true,
         showSignalBreakdown: visibilityData.showSignalBreakdown ?? true,
         showAuditLog: visibilityData.showAuditLog ?? true,
-        creditEnforcementMode: (visibilityData.creditEnforcementMode as EnforcementMode) ?? "WARNING",
+        creditEnforcementMode:
+          (visibilityData.creditEnforcementMode as EnforcementMode) ??
+          "WARNING",
         warningThresholdPercent: visibilityData.warningThresholdPercent ?? 75,
         alertThresholdPercent: visibilityData.alertThresholdPercent ?? 90,
       });
@@ -139,11 +168,11 @@ export default function CreditSettingsPage() {
 
   // Weight handlers
   const handleWeightChange = (key: keyof typeof weights, value: number) => {
-    setWeights((prev) => ({ ...prev, [key]: value }));
+    setWeights(prev => ({ ...prev, [key]: value }));
     setHasWeightChanges(true);
   };
 
-  const handleSaveWeights = async (e: React.MouseEvent) => {
+  const handleSaveWeights = async (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     const sum = Object.values(weights).reduce((a, b) => a + b, 0);
@@ -154,7 +183,7 @@ export default function CreditSettingsPage() {
     await updateWeightsMutation.mutateAsync(weights);
   };
 
-  const handleResetWeights = (e: React.MouseEvent) => {
+  const handleResetWeights = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (settings) {
@@ -170,7 +199,7 @@ export default function CreditSettingsPage() {
     }
   };
 
-  const handleResetWeightsToDefaults = (e: React.MouseEvent) => {
+  const handleResetWeightsToDefaults = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setWeights({
@@ -189,21 +218,23 @@ export default function CreditSettingsPage() {
     key: K,
     value: VisibilitySettings[K]
   ) => {
-    setVisibility((prev) => ({ ...prev, [key]: value }));
+    setVisibility(prev => ({ ...prev, [key]: value }));
     setHasVisibilityChanges(true);
   };
 
-  const handleSaveVisibility = (e: React.MouseEvent) => {
+  const handleSaveVisibility = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (visibility.warningThresholdPercent >= visibility.alertThresholdPercent) {
+    if (
+      visibility.warningThresholdPercent >= visibility.alertThresholdPercent
+    ) {
       toast.error("Warning threshold must be less than alert threshold");
       return;
     }
     updateVisibilityMutation.mutate({ settings: visibility });
   };
 
-  const handleResetVisibilityToDefaults = (e: React.MouseEvent) => {
+  const handleResetVisibilityToDefaults = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setVisibility(DEFAULT_VISIBILITY);
@@ -214,7 +245,9 @@ export default function CreditSettingsPage() {
   if (weightsLoading || visibilityLoading) {
     return (
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
-        <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+        {!embedded && (
+          <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+        )}
         <FormSkeleton fields={6} />
       </div>
     );
@@ -224,18 +257,56 @@ export default function CreditSettingsPage() {
   const weightsValid = Math.abs(weightsSum - 100) < 0.01;
 
   const signals = [
-    { name: "Revenue Momentum", key: "revenueMomentumWeight" as const, value: weights.revenueMomentumWeight, description: "Growth rate of recent vs historical revenue.", impact: "Rewards clients with increasing order volumes." },
-    { name: "Cash Collection Strength", key: "cashCollectionWeight" as const, value: weights.cashCollectionWeight, description: "Speed and reliability of payment collection.", impact: "Rewards clients who pay invoices quickly." },
-    { name: "Profitability Quality", key: "profitabilityWeight" as const, value: weights.profitabilityWeight, description: "Profit margin quality and stability.", impact: "Rewards clients with strong margins." },
-    { name: "Debt Aging Risk", key: "debtAgingWeight" as const, value: weights.debtAgingWeight, description: "Age and management of outstanding debt.", impact: "Penalizes clients with old, unpaid invoices." },
-    { name: "Repayment Velocity", key: "repaymentVelocityWeight" as const, value: weights.repaymentVelocityWeight, description: "Rate of debt repayment vs new charges.", impact: "Rewards clients actively paying down balance." },
-    { name: "Tenure & Relationship", key: "tenureWeight" as const, value: weights.tenureWeight, description: "Length and depth of business relationship.", impact: "Rewards long-term clients." },
+    {
+      name: "Revenue Momentum",
+      key: "revenueMomentumWeight" as const,
+      value: weights.revenueMomentumWeight,
+      description: "Growth rate of recent vs historical revenue.",
+      impact: "Rewards clients with increasing order volumes.",
+    },
+    {
+      name: "Cash Collection Strength",
+      key: "cashCollectionWeight" as const,
+      value: weights.cashCollectionWeight,
+      description: "Speed and reliability of payment collection.",
+      impact: "Rewards clients who pay invoices quickly.",
+    },
+    {
+      name: "Profitability Quality",
+      key: "profitabilityWeight" as const,
+      value: weights.profitabilityWeight,
+      description: "Profit margin quality and stability.",
+      impact: "Rewards clients with strong margins.",
+    },
+    {
+      name: "Debt Aging Risk",
+      key: "debtAgingWeight" as const,
+      value: weights.debtAgingWeight,
+      description: "Age and management of outstanding debt.",
+      impact: "Penalizes clients with old, unpaid invoices.",
+    },
+    {
+      name: "Repayment Velocity",
+      key: "repaymentVelocityWeight" as const,
+      value: weights.repaymentVelocityWeight,
+      description: "Rate of debt repayment vs new charges.",
+      impact: "Rewards clients actively paying down balance.",
+    },
+    {
+      name: "Tenure & Relationship",
+      key: "tenureWeight" as const,
+      value: weights.tenureWeight,
+      description: "Length and depth of business relationship.",
+      impact: "Rewards long-term clients.",
+    },
   ];
 
   return (
     <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-4xl">
-      <BackButton label="Back to Dashboard" to="/" className="mb-4" />
-      
+      {!embedded && (
+        <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+      )}
+
       <div>
         <h1 className="text-2xl sm:text-3xl font-bold">Credit Settings</h1>
         <p className="text-muted-foreground mt-2">
@@ -262,9 +333,13 @@ export default function CreditSettingsPage() {
               <div className="flex gap-3">
                 <Info className="h-5 w-5 text-blue-600 flex-shrink-0 mt-0.5" />
                 <div className="text-sm">
-                  <p className="font-medium text-blue-900 dark:text-blue-100">How Credit Weights Work</p>
+                  <p className="font-medium text-blue-900 dark:text-blue-100">
+                    How Credit Weights Work
+                  </p>
                   <p className="text-blue-800 dark:text-blue-200 mt-1">
-                    Each signal is scored 0-100. The score is multiplied by its weight to calculate contribution to the credit health score. All weights must sum to 100%.
+                    Each signal is scored 0-100. The score is multiplied by its
+                    weight to calculate contribution to the credit health score.
+                    All weights must sum to 100%.
                   </p>
                 </div>
               </div>
@@ -274,40 +349,95 @@ export default function CreditSettingsPage() {
           <Card>
             <CardHeader>
               <CardTitle>Signal Weights</CardTitle>
-              <CardDescription>Adjust the importance of each financial signal</CardDescription>
+              <CardDescription>
+                Adjust the importance of each financial signal
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
-              {signals.map((signal) => (
-                <div key={signal.key} className="space-y-3 pb-6 border-b last:border-b-0">
+              {signals.map(signal => (
+                <div
+                  key={signal.key}
+                  className="space-y-3 pb-6 border-b last:border-b-0"
+                >
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
-                      <div className="font-medium text-sm sm:text-base">{signal.name}</div>
-                      <div className="text-xs text-muted-foreground mt-1">{signal.description}</div>
+                      <div className="font-medium text-sm sm:text-base">
+                        {signal.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {signal.description}
+                      </div>
                     </div>
-                    <div className="text-2xl font-bold shrink-0">{signal.value}%</div>
+                    <div className="text-2xl font-bold shrink-0">
+                      {signal.value}%
+                    </div>
                   </div>
-                  <Slider value={[signal.value]} onValueChange={(v) => handleWeightChange(signal.key, v[0])} max={100} step={1} />
-                  <div className="text-xs text-muted-foreground"><span className="font-medium">Impact:</span> {signal.impact}</div>
+                  <Slider
+                    value={[signal.value]}
+                    onValueChange={v => handleWeightChange(signal.key, v[0])}
+                    max={100}
+                    step={1}
+                  />
+                  <div className="text-xs text-muted-foreground">
+                    <span className="font-medium">Impact:</span> {signal.impact}
+                  </div>
                 </div>
               ))}
 
-              <div className={`flex items-center justify-between p-4 rounded-lg ${weightsValid ? "bg-green-50 dark:bg-green-950 border border-green-200" : "bg-red-50 dark:bg-red-950 border border-red-200"}`}>
+              <div
+                className={`flex items-center justify-between p-4 rounded-lg ${weightsValid ? "bg-green-50 dark:bg-green-950 border border-green-200" : "bg-red-50 dark:bg-red-950 border border-red-200"}`}
+              >
                 <div className="flex items-center gap-2">
-                  {weightsValid ? <Check className="h-5 w-5 text-green-600" /> : <AlertCircle className="h-5 w-5 text-red-600" />}
+                  {weightsValid ? (
+                    <Check className="h-5 w-5 text-green-600" />
+                  ) : (
+                    <AlertCircle className="h-5 w-5 text-red-600" />
+                  )}
                   <span className="font-medium">Total Weight</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={`text-2xl font-bold ${weightsValid ? "text-green-600" : "text-red-600"}`}>{weightsSum.toFixed(0)}%</span>
-                  {weightsValid ? <Badge className="bg-green-600">Valid</Badge> : <Badge variant="destructive">Must equal 100%</Badge>}
+                  <span
+                    className={`text-2xl font-bold ${weightsValid ? "text-green-600" : "text-red-600"}`}
+                  >
+                    {weightsSum.toFixed(0)}%
+                  </span>
+                  {weightsValid ? (
+                    <Badge className="bg-green-600">Valid</Badge>
+                  ) : (
+                    <Badge variant="destructive">Must equal 100%</Badge>
+                  )}
                 </div>
               </div>
 
               <div className="flex flex-col sm:flex-row gap-2 pt-4">
-                <Button onClick={handleSaveWeights} disabled={!weightsValid || !hasWeightChanges || updateWeightsMutation.isPending} className="flex-1">
-                  <Save className="h-4 w-4 mr-2" />{updateWeightsMutation.isPending ? "Saving..." : "Save Changes"}
+                <Button
+                  onClick={handleSaveWeights}
+                  disabled={
+                    !weightsValid ||
+                    !hasWeightChanges ||
+                    updateWeightsMutation.isPending
+                  }
+                  className="flex-1"
+                >
+                  <Save className="h-4 w-4 mr-2" />
+                  {updateWeightsMutation.isPending
+                    ? "Saving..."
+                    : "Save Changes"}
                 </Button>
-                <Button onClick={handleResetWeights} disabled={!hasWeightChanges} variant="outline"><RotateCcw className="h-4 w-4 mr-2" />Reset</Button>
-                <Button onClick={handleResetWeightsToDefaults} variant="outline">Reset to Defaults</Button>
+                <Button
+                  onClick={handleResetWeights}
+                  disabled={!hasWeightChanges}
+                  variant="outline"
+                >
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  Reset
+                </Button>
+                <Button
+                  onClick={handleResetWeightsToDefaults}
+                  variant="outline"
+                >
+                  Reset to Defaults
+                </Button>
               </div>
             </CardContent>
           </Card>
@@ -318,7 +448,9 @@ export default function CreditSettingsPage() {
           {hasVisibilityChanges && (
             <div className="flex items-center gap-2 p-3 bg-yellow-50 dark:bg-yellow-950 border border-yellow-200 rounded-lg">
               <AlertCircle className="h-4 w-4 text-yellow-600" />
-              <span className="text-sm text-yellow-800 dark:text-yellow-200">You have unsaved changes</span>
+              <span className="text-sm text-yellow-800 dark:text-yellow-200">
+                You have unsaved changes
+              </span>
             </div>
           )}
 
@@ -330,32 +462,84 @@ export default function CreditSettingsPage() {
                   <Eye className="h-5 w-5" />
                   <CardTitle>Visibility Settings</CardTitle>
                 </div>
-                <CardDescription>Control which credit information is displayed</CardDescription>
+                <CardDescription>
+                  Control which credit information is displayed
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="flex items-center justify-between">
-                  <div><Label>Credit in Client List</Label><p className="text-xs text-muted-foreground">Show credit indicator in clients table</p></div>
-                  <Switch checked={visibility.showCreditInClientList} onCheckedChange={(c) => updateVisibilitySetting("showCreditInClientList", c)} />
+                  <div>
+                    <Label>Credit in Client List</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show credit indicator in clients table
+                    </p>
+                  </div>
+                  <Switch
+                    checked={visibility.showCreditInClientList}
+                    onCheckedChange={c =>
+                      updateVisibilitySetting("showCreditInClientList", c)
+                    }
+                  />
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between">
-                  <div><Label>Credit Banner in Orders</Label><p className="text-xs text-muted-foreground">Show credit status when creating orders</p></div>
-                  <Switch checked={visibility.showCreditBannerInOrders} onCheckedChange={(c) => updateVisibilitySetting("showCreditBannerInOrders", c)} />
+                  <div>
+                    <Label>Credit Banner in Orders</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show credit status when creating orders
+                    </p>
+                  </div>
+                  <Switch
+                    checked={visibility.showCreditBannerInOrders}
+                    onCheckedChange={c =>
+                      updateVisibilitySetting("showCreditBannerInOrders", c)
+                    }
+                  />
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between">
-                  <div><Label>Credit Widget in Profile</Label><p className="text-xs text-muted-foreground">Show credit card on client profiles</p></div>
-                  <Switch checked={visibility.showCreditWidgetInProfile} onCheckedChange={(c) => updateVisibilitySetting("showCreditWidgetInProfile", c)} />
+                  <div>
+                    <Label>Credit Widget in Profile</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show credit card on client profiles
+                    </p>
+                  </div>
+                  <Switch
+                    checked={visibility.showCreditWidgetInProfile}
+                    onCheckedChange={c =>
+                      updateVisibilitySetting("showCreditWidgetInProfile", c)
+                    }
+                  />
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between">
-                  <div><Label>Signal Breakdown</Label><p className="text-xs text-muted-foreground">Show calculation details</p></div>
-                  <Switch checked={visibility.showSignalBreakdown} onCheckedChange={(c) => updateVisibilitySetting("showSignalBreakdown", c)} />
+                  <div>
+                    <Label>Signal Breakdown</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show calculation details
+                    </p>
+                  </div>
+                  <Switch
+                    checked={visibility.showSignalBreakdown}
+                    onCheckedChange={c =>
+                      updateVisibilitySetting("showSignalBreakdown", c)
+                    }
+                  />
                 </div>
                 <Separator />
                 <div className="flex items-center justify-between">
-                  <div><Label>Audit Log</Label><p className="text-xs text-muted-foreground">Show credit change history</p></div>
-                  <Switch checked={visibility.showAuditLog} onCheckedChange={(c) => updateVisibilitySetting("showAuditLog", c)} />
+                  <div>
+                    <Label>Audit Log</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show credit change history
+                    </p>
+                  </div>
+                  <Switch
+                    checked={visibility.showAuditLog}
+                    onCheckedChange={c =>
+                      updateVisibilitySetting("showAuditLog", c)
+                    }
+                  />
                 </div>
               </CardContent>
             </Card>
@@ -367,23 +551,65 @@ export default function CreditSettingsPage() {
                   <Shield className="h-5 w-5" />
                   <CardTitle>Enforcement Settings</CardTitle>
                 </div>
-                <CardDescription>Configure credit limit enforcement during orders</CardDescription>
+                <CardDescription>
+                  Configure credit limit enforcement during orders
+                </CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
                 <div className="space-y-3">
                   <Label>Enforcement Mode</Label>
-                  <Select value={visibility.creditEnforcementMode} onValueChange={(v: EnforcementMode) => updateVisibilitySetting("creditEnforcementMode", v)}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                  <Select
+                    value={visibility.creditEnforcementMode}
+                    onValueChange={(v: EnforcementMode) =>
+                      updateVisibilitySetting("creditEnforcementMode", v)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="WARNING"><div className="flex items-center gap-2"><Badge variant="outline" className="bg-yellow-50 text-yellow-700">Warning</Badge>Show warning, allow order</div></SelectItem>
-                      <SelectItem value="SOFT_BLOCK"><div className="flex items-center gap-2"><Badge variant="outline" className="bg-orange-50 text-orange-700">Soft Block</Badge>Require override reason</div></SelectItem>
-                      <SelectItem value="HARD_BLOCK"><div className="flex items-center gap-2"><Badge variant="outline" className="bg-red-50 text-red-700">Hard Block</Badge>Block order completely</div></SelectItem>
+                      <SelectItem value="WARNING">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="bg-yellow-50 text-yellow-700"
+                          >
+                            Warning
+                          </Badge>
+                          Show warning, allow order
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="SOFT_BLOCK">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="bg-orange-50 text-orange-700"
+                          >
+                            Soft Block
+                          </Badge>
+                          Require override reason
+                        </div>
+                      </SelectItem>
+                      <SelectItem value="HARD_BLOCK">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="bg-red-50 text-red-700"
+                          >
+                            Hard Block
+                          </Badge>
+                          Block order completely
+                        </div>
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                   <p className="text-xs text-muted-foreground">
-                    {visibility.creditEnforcementMode === "WARNING" && "Orders exceeding credit show warning but can proceed."}
-                    {visibility.creditEnforcementMode === "SOFT_BLOCK" && "Orders exceeding credit require a reason to proceed."}
-                    {visibility.creditEnforcementMode === "HARD_BLOCK" && "Orders exceeding credit are blocked completely."}
+                    {visibility.creditEnforcementMode === "WARNING" &&
+                      "Orders exceeding credit show warning but can proceed."}
+                    {visibility.creditEnforcementMode === "SOFT_BLOCK" &&
+                      "Orders exceeding credit require a reason to proceed."}
+                    {visibility.creditEnforcementMode === "HARD_BLOCK" &&
+                      "Orders exceeding credit are blocked completely."}
                   </p>
                 </div>
 
@@ -393,16 +619,46 @@ export default function CreditSettingsPage() {
                   <Label>Utilization Thresholds</Label>
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
-                      <span className="text-sm flex items-center gap-2"><div className="w-3 h-3 rounded-full bg-yellow-500" />Warning</span>
+                      <span className="text-sm flex items-center gap-2">
+                        <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                        Warning
+                      </span>
                       <div className="flex items-center gap-2">
-                        <Input type="number" min={0} max={99} value={visibility.warningThresholdPercent} onChange={(e) => updateVisibilitySetting("warningThresholdPercent", parseInt(e.target.value) || 0)} className="w-20 text-right" />
+                        <Input
+                          type="number"
+                          min={0}
+                          max={99}
+                          value={visibility.warningThresholdPercent}
+                          onChange={e =>
+                            updateVisibilitySetting(
+                              "warningThresholdPercent",
+                              parseInt(e.target.value) || 0
+                            )
+                          }
+                          className="w-20 text-right"
+                        />
                         <span className="text-sm text-muted-foreground">%</span>
                       </div>
                     </div>
                     <div className="flex items-center justify-between">
-                      <span className="text-sm flex items-center gap-2"><div className="w-3 h-3 rounded-full bg-red-500" />Alert</span>
+                      <span className="text-sm flex items-center gap-2">
+                        <div className="w-3 h-3 rounded-full bg-red-500" />
+                        Alert
+                      </span>
                       <div className="flex items-center gap-2">
-                        <Input type="number" min={1} max={100} value={visibility.alertThresholdPercent} onChange={(e) => updateVisibilitySetting("alertThresholdPercent", parseInt(e.target.value) || 0)} className="w-20 text-right" />
+                        <Input
+                          type="number"
+                          min={1}
+                          max={100}
+                          value={visibility.alertThresholdPercent}
+                          onChange={e =>
+                            updateVisibilitySetting(
+                              "alertThresholdPercent",
+                              parseInt(e.target.value) || 0
+                            )
+                          }
+                          className="w-20 text-right"
+                        />
                         <span className="text-sm text-muted-foreground">%</span>
                       </div>
                     </div>
@@ -413,12 +669,32 @@ export default function CreditSettingsPage() {
                 <div className="p-4 bg-muted/50 rounded-lg space-y-2">
                   <p className="text-sm font-medium">Threshold Preview</p>
                   <div className="relative h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-                    <div className="absolute left-0 top-0 h-full bg-green-500" style={{ width: `${visibility.warningThresholdPercent}%` }} />
-                    <div className="absolute top-0 h-full bg-yellow-500" style={{ left: `${visibility.warningThresholdPercent}%`, width: `${visibility.alertThresholdPercent - visibility.warningThresholdPercent}%` }} />
-                    <div className="absolute top-0 h-full bg-red-500" style={{ left: `${visibility.alertThresholdPercent}%`, width: `${100 - visibility.alertThresholdPercent}%` }} />
+                    <div
+                      className="absolute left-0 top-0 h-full bg-green-500"
+                      style={{
+                        width: `${visibility.warningThresholdPercent}%`,
+                      }}
+                    />
+                    <div
+                      className="absolute top-0 h-full bg-yellow-500"
+                      style={{
+                        left: `${visibility.warningThresholdPercent}%`,
+                        width: `${visibility.alertThresholdPercent - visibility.warningThresholdPercent}%`,
+                      }}
+                    />
+                    <div
+                      className="absolute top-0 h-full bg-red-500"
+                      style={{
+                        left: `${visibility.alertThresholdPercent}%`,
+                        width: `${100 - visibility.alertThresholdPercent}%`,
+                      }}
+                    />
                   </div>
                   <div className="flex justify-between text-xs text-muted-foreground">
-                    <span>0%</span><span>{visibility.warningThresholdPercent}%</span><span>{visibility.alertThresholdPercent}%</span><span>100%</span>
+                    <span>0%</span>
+                    <span>{visibility.warningThresholdPercent}%</span>
+                    <span>{visibility.alertThresholdPercent}%</span>
+                    <span>100%</span>
                   </div>
                 </div>
               </CardContent>
@@ -426,11 +702,24 @@ export default function CreditSettingsPage() {
           </div>
 
           <div className="flex gap-2 justify-end">
-            <Button variant="outline" onClick={handleResetVisibilityToDefaults} disabled={updateVisibilityMutation.isPending}>
-              <RotateCcw className="h-4 w-4 mr-2" />Reset to Defaults
+            <Button
+              variant="outline"
+              onClick={handleResetVisibilityToDefaults}
+              disabled={updateVisibilityMutation.isPending}
+            >
+              <RotateCcw className="h-4 w-4 mr-2" />
+              Reset to Defaults
             </Button>
-            <Button onClick={handleSaveVisibility} disabled={!hasVisibilityChanges || updateVisibilityMutation.isPending}>
-              <Save className="h-4 w-4 mr-2" />{updateVisibilityMutation.isPending ? "Saving..." : "Save Changes"}
+            <Button
+              onClick={handleSaveVisibility}
+              disabled={
+                !hasVisibilityChanges || updateVisibilityMutation.isPending
+              }
+            >
+              <Save className="h-4 w-4 mr-2" />
+              {updateVisibilityMutation.isPending
+                ? "Saving..."
+                : "Save Changes"}
             </Button>
           </div>
         </TabsContent>

--- a/client/src/pages/CreditsWorkspacePage.tsx
+++ b/client/src/pages/CreditsWorkspacePage.tsx
@@ -1,0 +1,50 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import CreditsPage from "@/pages/CreditsPage";
+import CreditSettingsPage from "@/pages/CreditSettingsPage";
+import { useQueryTabState } from "@/hooks/useQueryTabState";
+import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
+import { CREDITS_WORKSPACE } from "@/config/workspaces";
+
+type CreditsTab = (typeof CREDITS_WORKSPACE.tabs)[number]["value"];
+const CREDITS_TABS = CREDITS_WORKSPACE.tabs.map(
+  tab => tab.value
+) as readonly CreditsTab[];
+
+export default function CreditsWorkspacePage() {
+  const { activeTab, setActiveTab } = useQueryTabState<CreditsTab>({
+    defaultTab: "credits",
+    validTabs: CREDITS_TABS,
+  });
+  useWorkspaceHomeTelemetry("credits", activeTab);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {CREDITS_WORKSPACE.title}
+        </h1>
+        <p className="text-muted-foreground">{CREDITS_WORKSPACE.description}</p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as CreditsTab)}
+      >
+        <TabsList className="grid w-full grid-cols-2 gap-1">
+          {CREDITS_WORKSPACE.tabs.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="credits" className="mt-4">
+          <CreditsPage embedded />
+        </TabsContent>
+        <TabsContent value="settings" className="mt-4">
+          <CreditSettingsPage embedded />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/src/pages/DemandSupplyWorkspacePage.tsx
+++ b/client/src/pages/DemandSupplyWorkspacePage.tsx
@@ -1,0 +1,60 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useQueryTabState } from "@/hooks/useQueryTabState";
+import NeedsManagementPage from "@/pages/NeedsManagementPage";
+import InterestListPage from "@/pages/InterestListPage";
+import MatchmakingServicePage from "@/pages/MatchmakingServicePage";
+import VendorSupplyPage from "@/pages/VendorSupplyPage";
+import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
+import { DEMAND_SUPPLY_WORKSPACE } from "@/config/workspaces";
+
+type DemandSupplyTab = (typeof DEMAND_SUPPLY_WORKSPACE.tabs)[number]["value"];
+const DEMAND_SUPPLY_TABS = DEMAND_SUPPLY_WORKSPACE.tabs.map(
+  tab => tab.value
+) as readonly DemandSupplyTab[];
+
+export default function DemandSupplyWorkspacePage() {
+  const { activeTab, setActiveTab } = useQueryTabState<DemandSupplyTab>({
+    defaultTab: "matchmaking",
+    validTabs: DEMAND_SUPPLY_TABS,
+  });
+  useWorkspaceHomeTelemetry("demand-supply", activeTab);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {DEMAND_SUPPLY_WORKSPACE.title}
+        </h1>
+        <p className="text-muted-foreground">
+          {DEMAND_SUPPLY_WORKSPACE.description}
+        </p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as DemandSupplyTab)}
+      >
+        <TabsList className="grid w-full grid-cols-2 gap-1 sm:grid-cols-4">
+          {DEMAND_SUPPLY_WORKSPACE.tabs.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="matchmaking" className="mt-4">
+          <MatchmakingServicePage embedded />
+        </TabsContent>
+        <TabsContent value="needs" className="mt-4">
+          <NeedsManagementPage embedded />
+        </TabsContent>
+        <TabsContent value="interest-list" className="mt-4">
+          <InterestListPage />
+        </TabsContent>
+        <TabsContent value="vendor-supply" className="mt-4">
+          <VendorSupplyPage embedded />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/src/pages/InventoryWorkspacePage.tsx
+++ b/client/src/pages/InventoryWorkspacePage.tsx
@@ -1,0 +1,52 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import InventoryWorkSurface from "@/components/work-surface/InventoryWorkSurface";
+import ProductsWorkSurface from "@/components/work-surface/ProductsWorkSurface";
+import { useQueryTabState } from "@/hooks/useQueryTabState";
+import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
+import { INVENTORY_WORKSPACE } from "@/config/workspaces";
+
+type InventoryTab = (typeof INVENTORY_WORKSPACE.tabs)[number]["value"];
+const INVENTORY_TABS = INVENTORY_WORKSPACE.tabs.map(
+  tab => tab.value
+) as readonly InventoryTab[];
+
+export default function InventoryWorkspacePage() {
+  const { activeTab, setActiveTab } = useQueryTabState<InventoryTab>({
+    defaultTab: "inventory",
+    validTabs: INVENTORY_TABS,
+  });
+  useWorkspaceHomeTelemetry("inventory", activeTab);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {INVENTORY_WORKSPACE.title}
+        </h1>
+        <p className="text-muted-foreground">
+          {INVENTORY_WORKSPACE.description}
+        </p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as InventoryTab)}
+      >
+        <TabsList className="grid w-full grid-cols-2 gap-1">
+          {INVENTORY_WORKSPACE.tabs.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="inventory" className="mt-4">
+          <InventoryWorkSurface />
+        </TabsContent>
+        <TabsContent value="products" className="mt-4">
+          <ProductsWorkSurface />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/src/pages/MatchmakingServicePage.tsx
+++ b/client/src/pages/MatchmakingServicePage.tsx
@@ -53,7 +53,13 @@ import { toast } from "sonner";
  * - Take action (create quotes, contact clients, reserve supply)
  */
 
-export default function MatchmakingServicePage() {
+interface MatchmakingServicePageProps {
+  embedded?: boolean;
+}
+
+export default function MatchmakingServicePage({
+  embedded = false,
+}: MatchmakingServicePageProps) {
   const [, setLocation] = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("ACTIVE");
@@ -273,7 +279,9 @@ export default function MatchmakingServicePage() {
 
   return (
     <div className="space-y-6 p-6">
-      <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+      {!embedded && (
+        <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+      )}
       {/* Header */}
       <div className="flex flex-col space-y-4">
         <div className="flex items-center justify-between">

--- a/client/src/pages/RelationshipsWorkspacePage.tsx
+++ b/client/src/pages/RelationshipsWorkspacePage.tsx
@@ -1,0 +1,52 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ClientsWorkSurface from "@/components/work-surface/ClientsWorkSurface";
+import VendorsWorkSurface from "@/components/work-surface/VendorsWorkSurface";
+import { useQueryTabState } from "@/hooks/useQueryTabState";
+import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
+import { RELATIONSHIPS_WORKSPACE } from "@/config/workspaces";
+
+type RelationshipTab = (typeof RELATIONSHIPS_WORKSPACE.tabs)[number]["value"];
+const RELATIONSHIP_TABS = RELATIONSHIPS_WORKSPACE.tabs.map(
+  tab => tab.value
+) as readonly RelationshipTab[];
+
+export default function RelationshipsWorkspacePage() {
+  const { activeTab, setActiveTab } = useQueryTabState<RelationshipTab>({
+    defaultTab: "clients",
+    validTabs: RELATIONSHIP_TABS,
+  });
+  useWorkspaceHomeTelemetry("relationships", activeTab);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {RELATIONSHIPS_WORKSPACE.title}
+        </h1>
+        <p className="text-muted-foreground">
+          {RELATIONSHIPS_WORKSPACE.description}
+        </p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as RelationshipTab)}
+      >
+        <TabsList className="grid w-full grid-cols-2 gap-1">
+          {RELATIONSHIPS_WORKSPACE.tabs.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="clients" className="mt-4">
+          <ClientsWorkSurface />
+        </TabsContent>
+        <TabsContent value="suppliers" className="mt-4">
+          <VendorsWorkSurface />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/src/pages/ReturnsPage.tsx
+++ b/client/src/pages/ReturnsPage.tsx
@@ -80,7 +80,11 @@ function deriveGLStatus(
   return "PENDING";
 }
 
-export default function ReturnsPage() {
+interface ReturnsPageProps {
+  embedded?: boolean;
+}
+
+export default function ReturnsPage({ embedded = false }: ReturnsPageProps) {
   const { toast } = useToast();
   const { user } = useAuth();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -209,7 +213,9 @@ export default function ReturnsPage() {
 
   return (
     <div className="p-8">
-      <BackButton label="Back to Orders" to="/orders" className="mb-4" />
+      {!embedded && (
+        <BackButton label="Back to Orders" to="/orders" className="mb-4" />
+      )}
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Returns Management</h1>
         <p className="text-muted-foreground">Process and track order returns</p>

--- a/client/src/pages/SalesWorkspacePage.tsx
+++ b/client/src/pages/SalesWorkspacePage.tsx
@@ -1,0 +1,54 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import OrdersWorkSurface from "@/components/work-surface/OrdersWorkSurface";
+import QuotesWorkSurface from "@/components/work-surface/QuotesWorkSurface";
+import ReturnsPage from "@/pages/ReturnsPage";
+import { useQueryTabState } from "@/hooks/useQueryTabState";
+import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
+import { SALES_WORKSPACE } from "@/config/workspaces";
+
+type SalesTab = (typeof SALES_WORKSPACE.tabs)[number]["value"];
+const SALES_TABS = SALES_WORKSPACE.tabs.map(
+  tab => tab.value
+) as readonly SalesTab[];
+
+export default function SalesWorkspacePage() {
+  const { activeTab, setActiveTab } = useQueryTabState<SalesTab>({
+    defaultTab: "orders",
+    validTabs: SALES_TABS,
+  });
+  useWorkspaceHomeTelemetry("sales", activeTab);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {SALES_WORKSPACE.title}
+        </h1>
+        <p className="text-muted-foreground">{SALES_WORKSPACE.description}</p>
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={value => setActiveTab(value as SalesTab)}
+      >
+        <TabsList className="grid w-full grid-cols-3 gap-1">
+          {SALES_WORKSPACE.tabs.map(tab => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="orders" className="mt-4">
+          <OrdersWorkSurface />
+        </TabsContent>
+        <TabsContent value="quotes" className="mt-4">
+          <QuotesWorkSurface />
+        </TabsContent>
+        <TabsContent value="returns" className="mt-4">
+          <ReturnsPage embedded />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/client/src/pages/VendorSupplyPage.tsx
+++ b/client/src/pages/VendorSupplyPage.tsx
@@ -69,7 +69,13 @@ const initialFormState: SupplyFormState = {
  * Central page for managing vendor supply items
  */
 
-export default function VendorSupplyPage() {
+interface VendorSupplyPageProps {
+  embedded?: boolean;
+}
+
+export default function VendorSupplyPage({
+  embedded = false,
+}: VendorSupplyPageProps) {
   const [, setLocation] = useLocation();
 
   // Initialize filters from URL parameters
@@ -202,11 +208,13 @@ export default function VendorSupplyPage() {
 
   return (
     <div className="space-y-6 p-6">
-      <BackButton
-        label="Back to Suppliers"
-        to="/clients?clientTypes=seller"
-        className="mb-4"
-      />
+      {!embedded && (
+        <BackButton
+          label="Back to Suppliers"
+          to="/clients?clientTypes=seller"
+          className="mb-4"
+        />
+      )}
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary

This PR completes the workspace consolidation and route-unification work by:

- Consolidating legacy split areas into unified workspace homes:
  - `/sales` (orders, quotes, returns)
  - `/demand-supply` (matchmaking, needs, interest list, vendor supply)
  - `/relationships` (clients, suppliers)
  - `/inventory` (inventory + products tab)
  - `/credits` (credits + settings tab)
- Redirecting legacy entry routes into those workspace homes while preserving query context.
- Explicitly redirecting `/orders` to `/sales?tab=orders` for full sales-entry unification.
- Standardizing workspace header/title/tab metadata via shared config.
- Updating command palette/sidebar naming so each sidebar click maps to one workspace home pattern.

## Route telemetry and legacy cleanup support

Added route-usage telemetry to support safe deprecation of legacy routes after observed low usage:

- Tracks legacy redirects (`legacy_route_redirect`)
- Tracks workspace home visits (`workspace_home_visit`)
- Includes legacy-route audit helper with low-usage thresholds:
  - `getLegacyRouteUsageAudit({ lookbackDays, lowUsageThreshold })`

## Additional updates

- Embedded-mode support in component pages used inside consolidated workspace tabs.
- Consolidation helper utilities and tests.
- Smoke suite updated to validate the consolidated IA and remain resilient during rollout.

## Validation run

Executed and passed:

- `pnpm check`
- `pnpm test`
- `pnpm build`
- Targeted eslint on touched/new consolidation files
- `pnpm test:smoke:prod` (10/10 passing)

Known pre-existing repo state (unchanged by this PR):

- `pnpm lint` fails globally due existing lint debt outside this change set.
