### PR TITLE
fix(TER-185): Client-list controls - New/Edit/Archive trigger correct mutations

### DIFF
--- a/client/src/components/clients/AddClientWizard.tsx
+++ b/client/src/components/clients/AddClientWizard.tsx
@@ -119,11 +119,15 @@ export function AddClientWizard({
   // Create client mutation
   // BUG-071 FIX: Enhanced error handling with detailed messages
   // TER-38 FIX: Use tRPC error codes for reliable error detection
+  const utils = trpc.useContext();
   const createClientMutation = trpc.clients.create.useMutation({
     onSuccess: data => {
       toast.success("Client created successfully", {
         description: `${formData.name} has been added to your client list`,
       });
+      // TER-185: Invalidate client list so new client appears immediately
+      utils.clients.list.invalidate();
+      utils.clients.count.invalidate();
       onOpenChange(false);
       resetForm();
       if (onSuccess && data) onSuccess(data as number);


### PR DESCRIPTION
## Summary

Fixes **TER-185**: Client-list controls (New / Edit / Archive) must trigger correct mutations.

### Changes

**AddClientWizard.tsx** (+4 lines, targeted fix):
- Added `utils.clients.list.invalidate()` and `utils.clients.count.invalidate()` in the `onSuccess` handler so the client list refreshes immediately after creating a new client
- Original 4-step wizard preserved intact

**ClientsWorkSurface.tsx** (+50 lines):
- **Edit**: Added `else` branch to surface validation errors via `toast.error()` when save fails validation
- **Archive**: Replaced simple `onMutate` with full optimistic update pattern:
  - Cancels in-flight queries
  - Removes client from cache immediately (handles both array and unified response shapes)
  - Rolls back on error with `context.previousData`
  - Moves `invalidate()` to `onSettled` for guaranteed refresh

### Review Notes
- Codex initially rewrote AddClientWizard destructively (1095→165 lines); caught in PM review and reverted to original with targeted fix only
- TypeScript check passes clean (0 errors)
- Pre-existing eslint `@typescript-eslint/no-explicit-any` warnings remain (not introduced by this PR)

### Ticket
- [TER-185](https://linear.app/terpcorp/issue/TER-185)