### PR TITLE
fix(runtime): graceful fallback for cash/payables schema drift

### DIFF
--- a/server/_core/dbErrors.ts
+++ b/server/_core/dbErrors.ts
@@ -6,6 +6,80 @@
  * file rather than hunting through individual routers.
  */
 
+interface DbErrorSignal {
+  code: string;
+  message: string;
+}
+
+function collectErrorSignals(error: unknown): DbErrorSignal[] {
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+  const signals: DbErrorSignal[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || current === null || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    if (typeof current === "string") {
+      signals.push({ code: "", message: current.toLowerCase() });
+      continue;
+    }
+
+    if (typeof current !== "object") {
+      continue;
+    }
+
+    const obj = current as Record<string, unknown>;
+    const code = String(obj.code ?? obj.errno ?? "").toUpperCase();
+
+    const messageCandidates = [
+      obj.message,
+      obj.sqlMessage,
+      obj.sql,
+      obj.detail,
+      obj.causeMessage,
+    ].filter((value): value is string => typeof value === "string");
+
+    if (messageCandidates.length > 0 || code) {
+      signals.push({
+        code,
+        message: messageCandidates.join(" | ").toLowerCase(),
+      });
+    }
+
+    const nestedCandidates: unknown[] = [
+      obj.cause,
+      obj.originalError,
+      obj.error,
+      obj.parent,
+    ];
+
+    if (Array.isArray(obj.errors)) {
+      nestedCandidates.push(...obj.errors);
+    }
+
+    nestedCandidates.forEach(candidate => {
+      if (candidate !== undefined && candidate !== null) {
+        queue.push(candidate);
+      }
+    });
+  }
+
+  return signals;
+}
+
+function hintsMatch(signals: DbErrorSignal[], hints: string[]): boolean {
+  if (hints.length === 0) return true;
+
+  const loweredHints = hints.map(hint => hint.toLowerCase());
+  return signals.some(signal =>
+    loweredHints.some(hint => signal.message.includes(hint))
+  );
+}
+
 /**
  * Detect MySQL "table does not exist" errors.
  *
@@ -16,20 +90,50 @@ export function isMissingTableError(
   error: unknown,
   tableHints: string[] = []
 ): boolean {
-  const errorObj = error as Record<string, unknown> | null;
-  const code = String(errorObj?.code ?? errorObj?.errno ?? "");
-  const message = String(errorObj?.message ?? "").toLowerCase();
-
-  const missingTableSignal =
-    code === "1146" ||
-    code === "ER_NO_SUCH_TABLE" ||
-    message.includes("er_no_such_table") ||
-    (message.includes("table") &&
-      (message.includes("doesn't exist") ||
-        message.includes("does not exist")));
+  const signals = collectErrorSignals(error);
+  const missingTableSignal = signals.some(({ code, message }) => {
+    return (
+      code === "1146" ||
+      code === "ER_NO_SUCH_TABLE" ||
+      message.includes("er_no_such_table") ||
+      (message.includes("table") &&
+        (message.includes("doesn't exist") ||
+          message.includes("does not exist")))
+    );
+  });
 
   if (!missingTableSignal) return false;
-  if (tableHints.length === 0) return true;
+  return hintsMatch(signals, tableHints);
+}
 
-  return tableHints.some(hint => message.includes(hint.toLowerCase()));
+/**
+ * Detect schema drift errors (missing tables OR missing columns).
+ *
+ * Useful for graceful runtime fallbacks in partially migrated environments.
+ */
+export function isSchemaDriftError(
+  error: unknown,
+  hints: string[] = []
+): boolean {
+  const signals = collectErrorSignals(error);
+
+  const schemaDriftSignal = signals.some(({ code, message }) => {
+    return (
+      code === "1146" ||
+      code === "ER_NO_SUCH_TABLE" ||
+      code === "1054" ||
+      code === "ER_BAD_FIELD_ERROR" ||
+      message.includes("er_no_such_table") ||
+      message.includes("er_bad_field_error") ||
+      (message.includes("table") &&
+        (message.includes("doesn't exist") ||
+          message.includes("does not exist"))) ||
+      message.includes("unknown column") ||
+      (message.includes("column") && message.includes("does not exist")) ||
+      (message.includes("no such column") && message.includes("sql"))
+    );
+  });
+
+  if (!schemaDriftSignal) return false;
+  return hintsMatch(signals, hints);
 }

--- a/server/routers/cashAudit.ts
+++ b/server/routers/cashAudit.ts
@@ -24,7 +24,7 @@ import {
 import { eq, and, sql, inArray, desc, gte, lte } from "drizzle-orm";
 import { logger } from "../_core/logger";
 import { createSafeUnifiedResponse } from "../_core/pagination";
-import { isMissingTableError } from "../_core/dbErrors";
+import { isSchemaDriftError } from "../_core/dbErrors";
 
 // ============================================================================
 // MEET-001: Dashboard Available Money API
@@ -56,7 +56,7 @@ export const cashAuditRouter = router({
 
         totalCashOnHand = Number(cashOnHandResult[0]?.total || 0);
       } catch (error) {
-        if (!isMissingTableError(error, ["cash_locations"])) {
+        if (!isSchemaDriftError(error, ["cash_locations"])) {
           throw error;
         }
 
@@ -83,7 +83,7 @@ export const cashAuditRouter = router({
           totalCashOnHand = Number(fallbackResult[0]?.total || 0);
         } catch (fallbackError) {
           if (
-            !isMissingTableError(fallbackError, [
+            !isSchemaDriftError(fallbackError, [
               "bankaccounts",
               "bank_accounts",
             ])
@@ -120,7 +120,7 @@ export const cashAuditRouter = router({
 
         scheduledPayables = Number(scheduledPayablesResult[0]?.total || 0);
       } catch (error) {
-        if (!isMissingTableError(error, ["bills"])) {
+        if (!isSchemaDriftError(error, ["bills"])) {
           throw error;
         }
 

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -13,7 +13,7 @@ import {
   calculateSalesComparison,
 } from "../dashboardHelpers";
 import { logger } from "../_core/logger";
-import { isMissingTableError } from "../_core/dbErrors";
+import { isMissingTableError, isSchemaDriftError } from "../_core/dbErrors";
 import {
   batches,
   clients,
@@ -884,7 +884,12 @@ export const dashboardRouter = router({
             return b.oldestDueDays - a.oldestDueDays;
           });
         } catch (error) {
-          if (!isMissingTableError(error, ["vendor_payables"])) {
+          if (
+            !isSchemaDriftError(error, [
+              "vendor_payables",
+              "vendor_payable_status",
+            ])
+          ) {
             throw error;
           }
 


### PR DESCRIPTION
## Summary
- improve shared DB error detection to inspect wrapped MySQL errors (including unknown column)
- use schema-drift-aware fallback handling in `cashAudit.getCashDashboard`
- use schema-drift-aware fallback handling in `dashboard.getVendorsNeedingPayment` so legacy path is used instead of returning 500

## Validation
- `pnpm exec vitest run server/_core/dbErrors.test.ts`
- `pnpm exec vitest run server/routers/dashboard.pagination.test.ts`
- `pnpm check`
