### PR TITLE
fix(runtime): catch drizzle failed-query schema drift wrappers

### DIFF
--- a/server/_core/dbErrors.test.ts
+++ b/server/_core/dbErrors.test.ts
@@ -119,4 +119,12 @@ describe("isSchemaDriftError", () => {
     const error = { code: "1045", message: "Access denied for user" };
     expect(isSchemaDriftError(error)).toBe(false);
   });
+
+  it("detects drift from drizzle failed-query wrapper when hint matches", () => {
+    const error = {
+      message:
+        "Failed query: select `vendor_payables`.`vendor_payable_status` from `vendor_payables` where `vendor_payables`.`deleted_at` is null",
+    };
+    expect(isSchemaDriftError(error, ["vendor_payable_status"])).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- update `isSchemaDriftError` to detect Drizzle's top-level `Failed query:` errors when hints match
- add regression test for failed-query wrapper detection

## Validation
- `pnpm exec vitest run server/_core/dbErrors.test.ts`
- `pnpm check`
