### PR TITLE
test(runtime): final hardening for schema-drift fallback paths

### DIFF
--- a/server/routers/cashAudit.ts
+++ b/server/routers/cashAudit.ts
@@ -56,7 +56,13 @@ export const cashAuditRouter = router({
 
         totalCashOnHand = Number(cashOnHandResult[0]?.total || 0);
       } catch (error) {
-        if (!isSchemaDriftError(error, ["cash_locations"])) {
+        if (
+          !isSchemaDriftError(error, [
+            "cash_locations",
+            "current_balance",
+            "is_active",
+          ])
+        ) {
           throw error;
         }
 
@@ -86,6 +92,8 @@ export const cashAuditRouter = router({
             !isSchemaDriftError(fallbackError, [
               "bankaccounts",
               "bank_accounts",
+              "currentbalance",
+              "isactive",
             ])
           ) {
             throw fallbackError;

--- a/server/routers/dashboard.pagination.test.ts
+++ b/server/routers/dashboard.pagination.test.ts
@@ -520,6 +520,26 @@ describe("Dashboard Pagination (RF-002)", () => {
       expect(result.hasMore).toBe(false);
       expect(payablesService.listPayables).toHaveBeenCalledTimes(1);
     });
+
+    it("should gracefully fallback when drift is wrapped as a failed query", async () => {
+      // Arrange
+      vi.mocked(payablesService.listPayables).mockRejectedValue({
+        message:
+          "Failed query: select `vendor_payables`.`vendor_payable_status` from `vendor_payables`",
+      });
+
+      // Act
+      const result = await caller.dashboard.getVendorsNeedingPayment({
+        limit: 10,
+        offset: 0,
+      });
+
+      // Assert
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+      expect(payablesService.listPayables).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("pagination edge cases", () => {


### PR DESCRIPTION
## Summary
- add regression test coverage for `dashboard.getVendorsNeedingPayment` when schema drift surfaces as a wrapped `Failed query` message
- expand `cashAudit.getCashDashboard` drift hint matching to include the cash-location column names used by the failing query path

## Validation
- `pnpm exec vitest run server/routers/dashboard.pagination.test.ts server/_core/dbErrors.test.ts`
- `pnpm check`
