### PR TITLE
ci: Replace full E2E gates with targeted domain-aware PR validation

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,12 +12,15 @@ permissions:
 
 env:
   DATABASE_URL: mysql://terp_test:terp_test_password@localhost:3307/terp_test
-  ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
 
 jobs:
-  test-and-deploy:
+  # ================================================================
+  # JOB 1: Integration tests + build verification
+  # These validate that the merge didn't break core data operations.
+  # ================================================================
+  test-and-verify:
     runs-on: ubuntu-latest
-    
+
     services:
       mysql:
         image: mysql:8.0
@@ -33,10 +36,10 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -48,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Wait for MySQL
         run: |
           MAX_ATTEMPTS=30
@@ -82,7 +85,7 @@ jobs:
             exit 1
           }
           echo "status=passed" >> $GITHUB_OUTPUT
-      
+
       - name: Run integration tests
         id: integration
         if: steps.schema.outputs.status == 'passed' && steps.seed.outputs.status == 'passed'
@@ -95,33 +98,6 @@ jobs:
           echo "status=passed" >> $GITHUB_OUTPUT
         continue-on-error: true
 
-      - name: Install Playwright browsers
-        if: steps.schema.outputs.status == 'passed' && steps.seed.outputs.status == 'passed'
-        run: pnpm exec playwright install --with-deps
-
-      - name: Run E2E tests with Argos
-        id: e2e
-        if: steps.schema.outputs.status == 'passed' && steps.seed.outputs.status == 'passed'
-        run: |
-          echo "Running E2E tests..."
-          CI=true pnpm playwright test 2>&1 | tee e2e-output.txt || {
-            echo "status=failed" >> $GITHUB_OUTPUT
-            exit 1
-          }
-          echo "status=passed" >> $GITHUB_OUTPUT
-        env:
-          CI: true
-        continue-on-error: true
-      
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-        continue-on-error: true
-      
       - name: Check test coverage
         id: coverage
         run: |
@@ -141,7 +117,7 @@ jobs:
             echo "status=skipped" >> $GITHUB_OUTPUT
           fi
         continue-on-error: true
-      
+
       - name: Post Results Comment
         uses: actions/github-script@v7
         if: always()
@@ -152,22 +128,19 @@ jobs:
               schema: '${{ steps.schema.outputs.status }}',
               seed: '${{ steps.seed.outputs.status }}',
               integration: '${{ steps.integration.outputs.status }}',
-              e2e: '${{ steps.e2e.outputs.status }}',
-              coverage: '${{ steps.coverage.outputs.status }}'
             };
-            
+
             const coveragePct = '${{ steps.coverage.outputs.coverage }}';
-            
-            let allPassed = steps.schema === 'passed' && 
-                           steps.seed === 'passed' && 
-                           steps.integration === 'passed' && 
-                           steps.e2e === 'passed';
-            
-            let body = allPassed ? '## ✅ All Tests Passed\n\n' : '## ❌ Tests Failed\n\n';
+
+            let allPassed = steps.schema === 'passed' &&
+                           steps.seed === 'passed' &&
+                           steps.integration === 'passed';
+
+            let body = allPassed ? '## ✅ Post-Merge Checks Passed\n\n' : '## ❌ Post-Merge Checks Failed\n\n';
             body += `**Commit:** \`${context.sha.substring(0, 7)}\`\n`;
             body += `**Branch:** \`main\`\n\n`;
             body += '---\n\n';
-            
+
             // Schema push results
             body += steps.schema === 'passed' ? '**Database Schema:** ✅ Pushed\n' : '**Database Schema:** ❌ Failed\n';
             if (steps.schema === 'failed' && fs.existsSync('schema-output.txt')) {
@@ -175,7 +148,7 @@ jobs:
               const lastLines = output.split('\n').slice(-30).join('\n');
               body += '<details><summary>View schema errors</summary>\n\n```\n' + lastLines + '\n```\n</details>\n\n';
             }
-            
+
             // Seed results
             body += steps.seed === 'passed' ? '**Database Seed:** ✅ Completed\n' : '**Database Seed:** ❌ Failed\n';
             if (steps.seed === 'failed' && fs.existsSync('seed-output.txt')) {
@@ -183,7 +156,7 @@ jobs:
               const lastLines = output.split('\n').slice(-30).join('\n');
               body += '<details><summary>View seed errors</summary>\n\n```\n' + lastLines + '\n```\n</details>\n\n';
             }
-            
+
             // Integration test results
             body += steps.integration === 'passed' ? '**Integration Tests:** ✅ Passed\n' : '**Integration Tests:** ❌ Failed\n';
             if (steps.integration === 'failed' && fs.existsSync('integration-output.txt')) {
@@ -191,22 +164,17 @@ jobs:
               const lastLines = output.split('\n').slice(-100).join('\n');
               body += '<details><summary>View integration test failures</summary>\n\n```\n' + lastLines + '\n```\n</details>\n\n';
             }
-            
-            // E2E test results
-            body += steps.e2e === 'passed' ? '**E2E Tests:** ✅ Passed\n' : '**E2E Tests:** ❌ Failed\n';
-            if (steps.e2e === 'failed' && fs.existsSync('e2e-output.txt')) {
-              const output = fs.readFileSync('e2e-output.txt', 'utf8');
-              const lastLines = output.split('\n').slice(-100).join('\n');
-              body += '<details><summary>View E2E test failures</summary>\n\n```\n' + lastLines + '\n```\n</details>\n\n';
-            }
-            
+
             // Coverage
             if (coveragePct) {
               body += `**Test Coverage:** ${coveragePct}%\n\n`;
             }
-            
+
+            // E2E note
+            body += '\n**E2E Tests:** Full suite runs nightly. Targeted E2E ran during PR review.\n\n';
+
             body += '---\n\n';
-            
+
             if (!allPassed) {
               body += '## 🚨 Action Required\n\n';
               body += 'The main branch build has failed. **All agents must stop work immediately** and check this status.\n\n';
@@ -228,23 +196,22 @@ jobs:
               body += '**Do not push more changes to main until this is fixed.**';
             } else {
               body += '## 🎉 Build Successful\n\n';
-              body += 'All tests passed! The main branch is healthy.\n\n';
-              body += '📸 [View visual changes in Argos](https://app.argos-ci.com/EvanTenenbaum/TERP)';
+              body += 'All post-merge checks passed! The main branch is healthy.\n';
             }
-            
+
             // Write build status to a file for agent verification
             const statusFile = '.github/BUILD_STATUS.md';
             const timestamp = new Date().toISOString();
-            
+
             const statusContent = `# Latest Build Status\n\n` +
               `**Last Updated:** ${timestamp}\n` +
               `**Commit:** \`${context.sha}\`\n` +
               `**Status:** ${allPassed ? '✅ SUCCESS' : '❌ FAILED'}\n\n` +
               body;
-            
+
             fs.writeFileSync(statusFile, statusContent);
             console.log('✅ Wrote build status to', statusFile);
-            
+
             // Try to post commit comment (best effort)
             try {
               const comment = await github.rest.repos.createCommitComment({
@@ -258,18 +225,11 @@ jobs:
               console.warn('⚠️ Could not post commit comment:', error.message);
               console.log('Build status is available in', statusFile);
             }
-      
+
       - name: Update build status on separate branch
         if: always()
         run: |
-          # Push build status to a separate branch to avoid triggering DigitalOcean deployments
-          # DigitalOcean only monitors 'main' branch, so this won't trigger deployments
-
-          # Save the freshly generated BUILD_STATUS.md BEFORE switching branches.
-          # The prior step wrote it to the working directory but didn't commit it,
-          # so `git checkout main -- ...` would grab the stale committed version.
           if [ ! -f .github/BUILD_STATUS.md ]; then
-            echo "No BUILD_STATUS.md found — skipping update."
             exit 0
           fi
           cp .github/BUILD_STATUS.md /tmp/BUILD_STATUS.md
@@ -277,20 +237,14 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
-          # Fetch to ensure we have remote branches
           git fetch origin build-status:build-status 2>/dev/null || true
 
-          # Checkout build-status branch (create if it doesn't exist).
-          # Use -f because the working tree has the uncommitted BUILD_STATUS.md
-          # written by "Post Results Comment" — without -f, git refuses to switch
-          # when the tracked file differs between branches.
           if git show-ref --verify --quiet refs/heads/build-status; then
             git checkout -f build-status
           else
             git checkout -b build-status
           fi
 
-          # Restore the FRESH file (not from main's committed history)
           mkdir -p .github
           cp /tmp/BUILD_STATUS.md .github/BUILD_STATUS.md
           git add .github/BUILD_STATUS.md || true
@@ -302,9 +256,8 @@ jobs:
             echo "No changes to BUILD_STATUS.md"
           fi
 
-          # Return to main branch for any subsequent steps
           git checkout main
-      
+
       - name: Create fallback issue if comment failed
         uses: actions/github-script@v7
         if: failure() && steps.schema.outputs.status != ''
@@ -314,18 +267,16 @@ jobs:
               schema: '${{ steps.schema.outputs.status }}',
               seed: '${{ steps.seed.outputs.status }}',
               integration: '${{ steps.integration.outputs.status }}',
-              e2e: '${{ steps.e2e.outputs.status }}',
             };
-            
-            let allPassed = steps.schema === 'passed' && 
-                           steps.seed === 'passed' && 
-                           steps.integration === 'passed' && 
-                           steps.e2e === 'passed';
-            
-            const title = allPassed 
+
+            let allPassed = steps.schema === 'passed' &&
+                           steps.seed === 'passed' &&
+                           steps.integration === 'passed';
+
+            const title = allPassed
               ? `✅ Build ${context.sha.substring(0, 7)} succeeded (comment posting failed)`
               : `❌ Build ${context.sha.substring(0, 7)} failed`;
-            
+
             const body = `## Build Status Notification\n\n` +
               `⚠️ **This issue was created because the automated commit comment failed to post.**\n\n` +
               `**Commit:** \`${context.sha}\`\n` +
@@ -334,10 +285,9 @@ jobs:
               `### Test Results\n\n` +
               `- Database Schema: ${steps.schema === 'passed' ? '✅' : '❌'} ${steps.schema}\n` +
               `- Database Seed: ${steps.seed === 'passed' ? '✅' : '❌'} ${steps.seed}\n` +
-              `- Integration Tests: ${steps.integration === 'passed' ? '✅' : '❌'} ${steps.integration}\n` +
-              `- E2E Tests: ${steps.e2e === 'passed' ? '✅' : '❌'} ${steps.e2e}\n\n` +
+              `- Integration Tests: ${steps.integration === 'passed' ? '✅' : '❌'} ${steps.integration}\n\n` +
               `**Action Required:** Fix the workflow permissions to allow commit comments.`;
-            
+
             try {
               await github.rest.issues.create({
                 owner: context.repo.owner,
@@ -350,31 +300,20 @@ jobs:
             } catch (error) {
               console.error('❌ Failed to create fallback issue:', error.message);
             }
-      
+
       - name: Fail if any test failed
-        if: steps.schema.outputs.status == 'failed' || steps.seed.outputs.status == 'failed' || steps.integration.outputs.status == 'failed' || steps.e2e.outputs.status == 'failed'
+        if: steps.schema.outputs.status == 'failed' || steps.seed.outputs.status == 'failed' || steps.integration.outputs.status == 'failed'
         run: |
           echo "❌ One or more tests failed. See the commit comment for details."
           exit 1
-      
+
       - name: Verify DigitalOcean deployment
         id: deploy
         if: success()
         run: |
-          # DigitalOcean auto-deploys on push to main (configured in .do/app.yaml).
-          # This step verifies a FRESH deployment is live by checking the /health
-          # endpoint's "uptime" field — a low uptime (< 300s) means the server
-          # recently restarted, i.e. a new deployment replaced the old one.
-          #
-          # Why not just curl /health/live?  That endpoint returns 200 as long as
-          # any instance is running — including the OLD deployment before DO swaps
-          # it out.  Checking uptime avoids that false-positive.
-
           APP_URL="https://terp-app-b9s35.ondigitalocean.app"
 
           echo "Waiting for DigitalOcean auto-deploy to start..."
-          # DO needs time to detect the push and begin the build.
-          # initial_delay_seconds=120 in .do/app.yaml, plus build time.
           sleep 60
 
           MAX_ATTEMPTS=20
@@ -382,7 +321,6 @@ jobs:
           while [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; do
             ATTEMPTS=$((ATTEMPTS + 1))
 
-            # /health returns { status, uptime, ... } and always 200 (see server/_core/index.ts)
             RESPONSE=$(curl -sf "${APP_URL}/health" 2>/dev/null) || {
               echo "App unreachable (attempt $ATTEMPTS/$MAX_ATTEMPTS) — deploy may be in progress"
               sleep 30
@@ -393,7 +331,7 @@ jobs:
             STATUS=$(echo "$RESPONSE" | jq -r '.status // empty' 2>/dev/null)
 
             if [ -n "$UPTIME" ]; then
-              UPTIME_INT=${UPTIME%.*}  # truncate decimals
+              UPTIME_INT=${UPTIME%.*}
               if [ "$UPTIME_INT" -lt 300 ] 2>/dev/null; then
                 echo "✅ Fresh deployment verified (uptime: ${UPTIME_INT}s, status: ${STATUS})"
                 echo "deployment_status=verified" >> $GITHUB_OUTPUT
@@ -411,4 +349,4 @@ jobs:
           echo "⚠️ Could not confirm fresh deployment after $MAX_ATTEMPTS attempts (~10 min)"
           echo "The deploy may still be in progress. Check DigitalOcean dashboard."
           echo "deployment_status=unverified" >> $GITHUB_OUTPUT
-          exit 0  # Don't fail the build
+          exit 0

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -1,0 +1,185 @@
+name: Nightly Full E2E Suite
+
+on:
+  schedule:
+    # Run every night at 3:00 AM UTC (10 PM ET)
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Which E2E suite to run'
+        required: true
+        default: 'full'
+        type: choice
+        options:
+          - full
+          - critical-paths
+          - golden-flows
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  DATABASE_URL: mysql://terp_test:terp_test_password@localhost:3307/terp_test
+  ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+
+jobs:
+  nightly-e2e:
+    runs-on: ubuntu-latest
+    # Guard: only run on schedule or manual dispatch
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 45
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root_password
+          MYSQL_DATABASE: terp_test
+          MYSQL_USER: terp_test
+          MYSQL_PASSWORD: terp_test_password
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for MySQL
+        run: |
+          MAX_ATTEMPTS=30
+          ATTEMPTS=0
+          until mysqladmin ping -h 127.0.0.1 -P 3307 --silent 2>/dev/null; do
+            ATTEMPTS=$((ATTEMPTS + 1))
+            if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+              echo "MySQL failed to start after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Push schema and seed
+        run: pnpm drizzle-kit push --force && pnpm seed:light
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Determine suite
+        id: suite
+        run: |
+          SUITE="${{ github.event.inputs.suite || 'full' }}"
+          echo "suite=$SUITE" >> $GITHUB_OUTPUT
+
+      - name: Run E2E tests
+        id: e2e
+        run: |
+          SUITE="${{ steps.suite.outputs.suite }}"
+
+          case "$SUITE" in
+            critical-paths)
+              echo "Running critical-paths E2E suite..."
+              pnpm exec playwright test tests-e2e/critical-paths/ --reporter=list 2>&1 | tee e2e-output.txt
+              ;;
+            golden-flows)
+              echo "Running golden-flows E2E suite..."
+              pnpm exec playwright test tests-e2e/golden-flows/ --reporter=list 2>&1 | tee e2e-output.txt
+              ;;
+            full)
+              echo "Running FULL E2E suite..."
+              CI=true pnpm playwright test 2>&1 | tee e2e-output.txt
+              ;;
+          esac
+
+          EXIT_CODE=$?
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "status=passed" >> $GITHUB_OUTPUT
+          else
+            echo "status=failed" >> $GITHUB_OUTPUT
+          fi
+          exit $EXIT_CODE
+        env:
+          CI: true
+        continue-on-error: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-e2e-report-${{ steps.suite.outputs.suite }}
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload test results JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-e2e-results-${{ steps.suite.outputs.suite }}
+          path: test-results.json
+          retention-days: 30
+
+      - name: Create issue on failure
+        if: steps.e2e.outputs.status == 'failed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const suite = '${{ steps.suite.outputs.suite }}';
+
+            let failureDetails = '';
+            if (fs.existsSync('e2e-output.txt')) {
+              const output = fs.readFileSync('e2e-output.txt', 'utf8');
+              const lastLines = output.split('\n').slice(-80).join('\n');
+              failureDetails = `\n\n<details><summary>Test output (last 80 lines)</summary>\n\n\`\`\`\n${lastLines}\n\`\`\`\n</details>`;
+            }
+
+            const title = `🌙 Nightly E2E Failure: ${suite} suite — ${new Date().toISOString().split('T')[0]}`;
+            const body = `## Nightly E2E Test Failure\n\n` +
+              `**Suite:** ${suite}\n` +
+              `**Date:** ${new Date().toISOString()}\n` +
+              `**Commit:** \`${context.sha.substring(0, 7)}\`\n` +
+              `**Workflow Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n` +
+              `The nightly E2E test suite detected failures that may not have been caught by targeted PR tests.\n\n` +
+              `**Action Required:**\n` +
+              `1. Review the Playwright report artifact\n` +
+              `2. Identify which tests failed and which recent merges may have caused them\n` +
+              `3. Create a fix PR\n` +
+              failureDetails;
+
+            try {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['ci/cd', 'e2e-failure', 'automated']
+              });
+              console.log('✅ Created nightly failure issue');
+            } catch (error) {
+              console.error('❌ Failed to create issue:', error.message);
+            }
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## Nightly E2E Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Suite:** ${{ steps.suite.outputs.suite }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ${{ steps.e2e.outputs.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${GITHUB_SHA:0:7}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -10,18 +10,21 @@ permissions:
   pull-requests: write
 
 jobs:
+  # ================================================================
+  # JOB 1: Fast checks — always runs, no DB needed (~2 min)
+  # ================================================================
   quality-gate:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142  # v2
         with:
           egress-policy: audit
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Required for git diff to compare with main
+          fetch-depth: 0
 
       - name: Extract Task ID
         id: extract_task
@@ -33,16 +36,21 @@ jobs:
             echo "task_id=" >> $GITHUB_OUTPUT
           fi
 
-      # =================================================================
+      # ---------------------------------------------------------------
       # SECURITY PATTERN ENFORCEMENT (Only checks CHANGED files)
-      # =================================================================
+      # ---------------------------------------------------------------
       - name: Get Changed Files
         id: changed_files
         run: |
-          # Get list of changed .ts/.tsx files in this PR
           CHANGED=$(git diff --name-only origin/main...HEAD -- '*.ts' '*.tsx' 2>/dev/null || true)
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          # Also get ALL changed files (not just TS) for domain mapping
+          ALL_CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          echo "all_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$ALL_CHANGED" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Check for Forbidden Security Patterns
@@ -51,14 +59,12 @@ jobs:
           VIOLATIONS=""
           CHANGED_FILES="${{ steps.changed_files.outputs.files }}"
 
-          # Skip if no TypeScript files changed
           if [ -z "$CHANGED_FILES" ]; then
             echo "has_violations=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           # Pattern 1: Fallback user ID (BUG-PATTERN: POST-002)
-          # Matches: ctx.user?.id || 1, ctx.user.id || 1, ctx.user?.id ?? 1, etc.
           FALLBACK_MATCHES=""
           for file in $CHANGED_FILES; do
             if [ -f "$file" ]; then
@@ -69,11 +75,14 @@ jobs:
             fi
           done
           if [ -n "$FALLBACK_MATCHES" ]; then
-            VIOLATIONS="${VIOLATIONS}### ❌ Fallback User ID Pattern\n\nFound forbidden pattern \`ctx.user?.id || 1\`. Use \`getAuthenticatedUserId(ctx)\` instead.\n\n\`\`\`\n${FALLBACK_MATCHES}\`\`\`\n\n"
+            MSG="### ❌ Fallback User ID Pattern\n\n"
+            MSG+="Found forbidden pattern \`ctx.user?.id || 1\`. "
+            MSG+="Use \`getAuthenticatedUserId(ctx)\` instead.\n\n"
+            MSG+="\`\`\`\n${FALLBACK_MATCHES}\`\`\`\n\n"
+            VIOLATIONS="${VIOLATIONS}${MSG}"
           fi
 
           # Pattern 2: Actor from input (BUG-PATTERN: POST-003)
-          # Only blocks NEW code in routers (legacy Db files are grandfathered)
           ACTOR_INPUT=""
           for file in $CHANGED_FILES; do
             if [[ "$file" == server/routers/* ]] && [ -f "$file" ]; then
@@ -87,7 +96,6 @@ jobs:
             VIOLATIONS="${VIOLATIONS}### ❌ Actor Attribution from Input\n\nFound \`createdBy: input.createdBy\` - actor must come from \`ctx.user.id\`, not input.\n\n\`\`\`\n${ACTOR_INPUT}\`\`\`\n\n"
           fi
 
-          # Save violations for comment
           if [ -n "$VIOLATIONS" ]; then
             echo "has_violations=true" >> $GITHUB_OUTPUT
             VIOLATIONS="${VIOLATIONS//'%'/'%25'}"
@@ -117,9 +125,9 @@ jobs:
           fi
 
           ROADMAP_FILE=""
-          if grep -q "${TASK_ID}" docs/roadmaps/MASTER_ROADMAP.md; then
+          if grep -q "${TASK_ID}" docs/roadmaps/MASTER_ROADMAP.md 2>/dev/null; then
             ROADMAP_FILE="docs/roadmaps/MASTER_ROADMAP.md"
-          elif grep -q "${TASK_ID}" docs/roadmaps/TESTING_ROADMAP.md; then
+          elif grep -q "${TASK_ID}" docs/roadmaps/TESTING_ROADMAP.md 2>/dev/null; then
             echo "status=testing_task" >> $GITHUB_OUTPUT
             exit 0
           else
@@ -136,6 +144,28 @@ jobs:
             echo "status=no_status_field" >> $GITHUB_OUTPUT
           fi
 
+      # ---------------------------------------------------------------
+      # DOMAIN-AWARE E2E RESOLUTION
+      # ---------------------------------------------------------------
+      - name: Resolve Affected E2E Tests
+        id: resolve_e2e
+        run: |
+          ALL_CHANGED="${{ steps.changed_files.outputs.all_files }}"
+          echo "$ALL_CHANGED" > /tmp/changed-files.txt
+
+          RESULT=$(bash scripts/ci/resolve-affected-tests.sh /tmp/changed-files.txt)
+          echo "e2e_decision=$RESULT" >> $GITHUB_OUTPUT
+
+          if [ "$RESULT" = "SKIP" ]; then
+            echo "🟢 No E2E tests needed for this PR (docs/config/test-only changes)"
+          elif [ "$RESULT" = "SMOKE" ]; then
+            echo "🟡 Shared infrastructure changed — smoke E2E subset will run"
+          else
+            SPEC_COUNT=$(echo "$RESULT" | tr ' ' '\n' | wc -l)
+            echo "🔵 $SPEC_COUNT targeted E2E spec(s) will run:"
+            echo "$RESULT" | tr ' ' '\n'
+          fi
+
       - name: Post Status Comment
         uses: actions/github-script@v7
         with:
@@ -145,6 +175,7 @@ jobs:
             const taskId = '${{ steps.extract_task.outputs.task_id }}';
             const hasViolations = '${{ steps.security_check.outputs.has_violations }}' === 'true';
             const violations = decodeURIComponent('${{ steps.security_check.outputs.violations }}' || '');
+            const e2eDecision = '${{ steps.resolve_e2e.outputs.e2e_decision }}';
 
             let sections = [];
 
@@ -154,6 +185,18 @@ jobs:
             } else {
               sections.push(`## ✅ Security Patterns\n\nNo forbidden security patterns detected.`);
             }
+
+            // E2E section
+            let e2eSummary = '';
+            if (e2eDecision === 'SKIP') {
+              e2eSummary = '⏭️ **E2E Tests:** Skipped (no application code changes detected)';
+            } else if (e2eDecision === 'SMOKE') {
+              e2eSummary = '🔶 **E2E Tests:** Smoke subset (shared infrastructure changes detected)';
+            } else {
+              const specs = e2eDecision.split(' ').map(s => `\`${s.split('/').pop()}\``).join(', ');
+              e2eSummary = `🎯 **E2E Tests:** Targeted — ${specs}`;
+            }
+            sections.push(`## E2E Test Strategy\n\n${e2eSummary}`);
 
             // Roadmap section (advisory)
             let roadmapSummary = "";
@@ -209,31 +252,18 @@ jobs:
           echo "Fix the patterns listed in the PR comment before merging."
           exit 1
 
-  critical-interactions:
+    outputs:
+      e2e_decision: ${{ steps.resolve_e2e.outputs.e2e_decision }}
+
+  # ================================================================
+  # JOB 2: Static analysis — TypeScript + lint (~3 min)
+  # ================================================================
+  static-analysis:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root_password
-          MYSQL_DATABASE: terp_test
-          MYSQL_USER: terp_test
-          MYSQL_PASSWORD: terp_test_password
-        ports:
-          - 3307:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
-    env:
-      DATABASE_URL: mysql://terp_test:terp_test_password@localhost:3307/terp_test
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -257,6 +287,77 @@ jobs:
             echo "$CHANGED" | xargs pnpm eslint --max-warnings=0 || true
           fi
 
+  # ================================================================
+  # JOB 3: Unit tests — vitest, no DB needed (~2 min)
+  # ================================================================
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm test --run
+
+  # ================================================================
+  # JOB 4: Targeted E2E — only runs specs affected by this PR
+  # Skips entirely for docs-only, config-only, or test-only changes
+  # ================================================================
+  targeted-e2e:
+    runs-on: ubuntu-latest
+    needs: [quality-gate]
+    # Only run if the quality gate determined E2E tests are needed
+    if: |
+      needs.quality-gate.outputs.e2e_decision != 'SKIP'
+    timeout-minutes: 20
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root_password
+          MYSQL_DATABASE: terp_test
+          MYSQL_USER: terp_test
+          MYSQL_PASSWORD: terp_test_password
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      DATABASE_URL: mysql://terp_test:terp_test_password@localhost:3307/terp_test
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Wait for MySQL
         run: |
           MAX_ATTEMPTS=30
@@ -273,14 +374,35 @@ jobs:
       - name: Push schema and seed
         run: pnpm drizzle-kit push --force && pnpm seed:light
 
-      - name: Unit tests
-        run: pnpm test --run
-
       - name: Install Playwright
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run critical-path E2E tests
-        run: pnpm exec playwright test tests-e2e/critical-paths/ --reporter=list
+      - name: Resolve affected E2E specs
+        id: resolve
+        run: |
+          ALL_CHANGED=$(git diff --name-only origin/main...HEAD 2>/dev/null || true)
+          echo "$ALL_CHANGED" > /tmp/changed-files.txt
+          RESULT=$(bash scripts/ci/resolve-affected-tests.sh /tmp/changed-files.txt)
+          echo "specs=$RESULT" >> $GITHUB_OUTPUT
+
+      - name: Run targeted E2E tests
+        id: e2e
+        run: |
+          SPECS="${{ steps.resolve.outputs.specs }}"
+
+          if [ "$SPECS" = "SMOKE" ]; then
+            echo "Running smoke E2E subset (shared infrastructure changed)..."
+            pnpm exec playwright test \
+              tests-e2e/critical-paths/order-fulfillment-workflow.spec.ts \
+              tests-e2e/critical-paths/inventory-intake.spec.ts \
+              tests-e2e/critical-paths/accounting-quick-payment.spec.ts \
+              tests-e2e/critical-paths/client-credit-workflow.spec.ts \
+              --reporter=list
+          else
+            echo "Running targeted E2E specs: $SPECS"
+            # shellcheck disable=SC2086
+            pnpm exec playwright test $SPECS --reporter=list
+          fi
         env:
           CI: true
           E2E_USE_LIVE_DB: '1'
@@ -289,6 +411,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: critical-paths-report
+          name: targeted-e2e-report
           path: playwright-report/
           retention-days: 7

--- a/scripts/ci/domain-test-map.json
+++ b/scripts/ci/domain-test-map.json
@@ -1,0 +1,267 @@
+{
+  "_comment": "Maps source code paths (glob patterns) to the E2E test specs that validate them. Used by the CI pipeline to run only the E2E tests affected by a PR's changes. Patterns are matched against the list of changed files in a PR.",
+
+  "domains": {
+    "accounting": {
+      "source_patterns": [
+        "server/routers/accounting*",
+        "server/routers/cashAudit*",
+        "server/routers/invoices*",
+        "server/routers/payments*",
+        "server/routers/badDebt*",
+        "server/routers/cogs*",
+        "server/routers/vendorPayables*",
+        "server/routers/transactionFees*",
+        "server/routers/installmentPayments*",
+        "server/routers/cryptoPayments*",
+        "server/routers/serviceBilling*",
+        "client/src/pages/Account*",
+        "client/src/pages/CogsSettings*",
+        "client/src/components/**/accounting/**"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/accounting-quick-payment.spec.ts"
+      ]
+    },
+
+    "calendar": {
+      "source_patterns": [
+        "server/routers/calendar*",
+        "server/routers/scheduling*",
+        "server/routers/appointmentRequests*",
+        "server/routers/timeOffRequests*",
+        "client/src/pages/Calendar*",
+        "client/src/pages/Scheduling*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/calendar-events.spec.ts"
+      ]
+    },
+
+    "clients": {
+      "source_patterns": [
+        "server/routers/clients*",
+        "server/routers/clientLedger*",
+        "server/routers/client360*",
+        "server/routers/clientNeeds*",
+        "server/routers/clientWants*",
+        "server/routers/credit*",
+        "server/routers/credits*",
+        "client/src/pages/Client*",
+        "client/src/pages/Credit*",
+        "client/src/hooks/useClientsData*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/client-credit-workflow.spec.ts",
+        "tests-e2e/critical-paths/sales-client-management.spec.ts"
+      ]
+    },
+
+    "orders": {
+      "source_patterns": [
+        "server/routers/orders*",
+        "server/routers/orderEnhancements*",
+        "server/routers/quotes*",
+        "client/src/pages/Orders*",
+        "client/src/pages/Quotes*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/order-fulfillment-workflow.spec.ts",
+        "tests-e2e/critical-paths/control-action-contracts.spec.ts",
+        "tests-e2e/critical-paths/returns-workflow.spec.ts"
+      ]
+    },
+
+    "inventory": {
+      "source_patterns": [
+        "server/routers/inventory*",
+        "server/routers/productIntake*",
+        "server/routers/intakeReceipts*",
+        "server/routers/warehouseTransfers*",
+        "server/routers/photography*",
+        "server/routers/productCategories*",
+        "server/routers/productGrades*",
+        "server/routers/productCatalogue*",
+        "server/routers/strains*",
+        "client/src/pages/Inventory*",
+        "client/src/pages/IntakeReceipts*",
+        "client/src/hooks/useInventory*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/inventory-intake.spec.ts",
+        "tests-e2e/critical-paths/control-action-contracts.spec.ts"
+      ]
+    },
+
+    "pick-pack": {
+      "source_patterns": [
+        "server/routers/pickPack*",
+        "client/src/pages/PickPack*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/pick-pack.spec.ts"
+      ]
+    },
+
+    "sales-sheets": {
+      "source_patterns": [
+        "server/routers/salesSheet*",
+        "server/routers/catalog*",
+        "server/routers/unifiedSalesPortal*",
+        "client/src/pages/SalesSheet*",
+        "client/src/pages/SalesPortal*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/sales-sheet-workflow.spec.ts",
+        "tests-e2e/critical-paths/sales-sheets-workflow.spec.ts"
+      ]
+    },
+
+    "locations": {
+      "source_patterns": [
+        "server/routers/locations*",
+        "server/routers/storage*",
+        "client/src/pages/Locations*",
+        "client/src/pages/CashLocations*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/locations-management.spec.ts"
+      ]
+    },
+
+    "returns": {
+      "source_patterns": [
+        "server/routers/returns*",
+        "server/routers/refunds*",
+        "client/src/pages/Returns*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/returns-workflow.spec.ts"
+      ]
+    },
+
+    "settings-admin": {
+      "source_patterns": [
+        "server/routers/featureFlags*",
+        "server/routers/settings*",
+        "server/routers/configuration*",
+        "server/routers/organizationSettings*",
+        "server/routers/admin*",
+        "client/src/pages/Settings*",
+        "client/src/pages/AdminSetup*",
+        "client/src/pages/FeatureFlags*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/feature-flags-workflow.spec.ts",
+        "tests-e2e/critical-paths/vip-admin-impersonation.spec.ts"
+      ]
+    },
+
+    "vip-portal": {
+      "source_patterns": [
+        "server/routers/vipPortal*",
+        "server/routers/vipTiers*",
+        "server/routers/liveShopping*",
+        "client/src/pages/VIP*",
+        "client/src/pages/LiveShopping*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/vip-admin-impersonation.spec.ts"
+      ]
+    },
+
+    "dashboard-analytics": {
+      "source_patterns": [
+        "server/routers/dashboard*",
+        "server/routers/analytics*",
+        "server/routers/leaderboard*",
+        "server/routers/dataCardMetrics*",
+        "server/routers/gamification*",
+        "client/src/pages/Dashboard*",
+        "client/src/pages/Analytics*",
+        "client/src/pages/Leaderboard*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/kpi-actionability.spec.ts",
+        "tests-e2e/critical-paths/leaderboard.spec.ts"
+      ]
+    },
+
+    "auth-rbac": {
+      "source_patterns": [
+        "server/routers/auth*",
+        "server/routers/rbac*",
+        "server/routers/userManagement*",
+        "server/routers/users*",
+        "server/_core/trpc*",
+        "server/_core/auth*",
+        "client/src/pages/Login*",
+        "client/src/pages/Users*",
+        "client/src/hooks/useAuth*",
+        "tests-e2e/fixtures/auth*"
+      ],
+      "e2e_specs": [
+        "tests-e2e/critical-paths/vip-admin-impersonation.spec.ts"
+      ]
+    },
+
+    "vendors-purchasing": {
+      "source_patterns": [
+        "server/routers/vendors*",
+        "server/routers/vendorSupply*",
+        "server/routers/vendorPayables*",
+        "server/routers/vendorReminders*",
+        "server/routers/purchaseOrders*",
+        "server/routers/poReceiving*",
+        "client/src/pages/Vendors*",
+        "client/src/pages/PurchaseOrders*"
+      ],
+      "e2e_specs": []
+    }
+  },
+
+  "shared_infrastructure": {
+    "_comment": "Changes to these paths affect the whole system — run a broader smoke set",
+    "patterns": [
+      "drizzle/schema.ts",
+      "server/_core/**",
+      "server/routers.ts",
+      "shared/**",
+      "client/src/lib/trpc.ts",
+      "client/src/lib/api-utils.ts",
+      "client/src/App.tsx",
+      "client/src/main.tsx",
+      "package.json",
+      "pnpm-lock.yaml",
+      "vite.config.ts",
+      "tsconfig.json"
+    ],
+    "e2e_specs": [
+      "tests-e2e/critical-paths/order-fulfillment-workflow.spec.ts",
+      "tests-e2e/critical-paths/inventory-intake.spec.ts",
+      "tests-e2e/critical-paths/accounting-quick-payment.spec.ts",
+      "tests-e2e/critical-paths/client-credit-workflow.spec.ts"
+    ]
+  },
+
+  "skip_e2e_patterns": {
+    "_comment": "Changes ONLY to these paths skip E2E tests entirely",
+    "patterns": [
+      "docs/**",
+      "*.md",
+      ".github/**",
+      ".manus/**",
+      "scripts/linear_helpers*",
+      "scripts/legacy/**",
+      "testing/**",
+      "tests/**",
+      "tests-e2e/**",
+      "*.yml",
+      "*.yaml",
+      ".eslintrc*",
+      ".prettierrc*",
+      "CHANGELOG*",
+      "LICENSE*"
+    ]
+  }
+}

--- a/scripts/ci/resolve-affected-tests.sh
+++ b/scripts/ci/resolve-affected-tests.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ============================================================================
+# resolve-affected-tests.sh
+#
+# Determines which E2E test specs to run based on the files changed in a PR.
+# Uses the domain-test-map.json configuration to map source paths to tests.
+#
+# Usage:
+#   ./scripts/ci/resolve-affected-tests.sh <changed-files-list>
+#
+# Output (to stdout):
+#   - "SKIP"              → No E2E tests needed (docs/config-only changes)
+#   - "SMOKE"             → Shared infrastructure changed, run smoke subset
+#   - Space-separated list of spec file paths to run
+#
+# Exit codes:
+#   0 = success
+#   1 = error (missing input, bad config)
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP_FILE="${SCRIPT_DIR}/domain-test-map.json"
+CHANGED_FILES_INPUT="${1:-}"
+
+if [ -z "$CHANGED_FILES_INPUT" ]; then
+  echo "Usage: $0 <file-with-changed-paths | - for stdin>" >&2
+  exit 1
+fi
+
+if [ ! -f "$MAP_FILE" ]; then
+  echo "ERROR: domain-test-map.json not found at $MAP_FILE" >&2
+  exit 1
+fi
+
+# Read changed files (from file or stdin)
+if [ "$CHANGED_FILES_INPUT" = "-" ]; then
+  CHANGED_FILES=$(cat)
+else
+  CHANGED_FILES=$(cat "$CHANGED_FILES_INPUT")
+fi
+
+# If no files changed, skip
+if [ -z "$CHANGED_FILES" ]; then
+  echo "SKIP"
+  exit 0
+fi
+
+# ---- Step 1: Check if ALL changes are skip-eligible ----
+# Uses node for reliable JSON parsing and glob matching
+RESULT=$(node -e "
+const fs = require('fs');
+const path = require('path');
+
+const map = JSON.parse(fs.readFileSync('$MAP_FILE', 'utf8'));
+const changedFiles = \`$CHANGED_FILES\`.trim().split('\n').filter(Boolean);
+
+// Simple glob matcher (supports *, **, and ?)
+function globMatch(pattern, filepath) {
+  // Convert glob to regex
+  let regex = pattern
+    .replace(/\./g, '\\\\.')
+    .replace(/\*\*/g, '__DOUBLESTAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLESTAR__/g, '.*')
+    .replace(/\?/g, '[^/]');
+  return new RegExp('^' + regex + '\$').test(filepath);
+}
+
+function matchesAnyPattern(file, patterns) {
+  return patterns.some(p => globMatch(p, file));
+}
+
+// Step 1: Check if ALL files match skip patterns
+const skipPatterns = map.skip_e2e_patterns.patterns;
+const allSkippable = changedFiles.every(f => matchesAnyPattern(f, skipPatterns));
+if (allSkippable) {
+  console.log('SKIP');
+  process.exit(0);
+}
+
+// Step 2: Check if any file matches shared infrastructure
+const sharedPatterns = map.shared_infrastructure.patterns;
+const touchesShared = changedFiles.some(f => matchesAnyPattern(f, sharedPatterns));
+
+// Step 3: Collect domain-specific tests
+const affectedSpecs = new Set();
+
+// If shared infra is touched, add the smoke subset
+if (touchesShared) {
+  for (const spec of map.shared_infrastructure.e2e_specs) {
+    affectedSpecs.add(spec);
+  }
+}
+
+// Match each changed file against domain patterns
+for (const file of changedFiles) {
+  for (const [domainName, domain] of Object.entries(map.domains)) {
+    if (matchesAnyPattern(file, domain.source_patterns)) {
+      for (const spec of domain.e2e_specs) {
+        affectedSpecs.add(spec);
+      }
+    }
+  }
+}
+
+// If we found specific specs, output them
+if (affectedSpecs.size > 0) {
+  console.log([...affectedSpecs].join(' '));
+} else if (touchesShared) {
+  // Shared infra touched but no specific specs mapped — run smoke
+  console.log('SMOKE');
+} else {
+  // Changed files don't match any domain — skip E2E
+  // (e.g., a new router with no E2E coverage yet)
+  console.log('SKIP');
+}
+")
+
+echo "$RESULT"


### PR DESCRIPTION
## Problem

Every PR ran all 16 critical-path E2E specs regardless of what changed, and every merge to main ran the ENTIRE 68-spec E2E suite. This was slow, expensive, and tested things unrelated to the actual changes.

## Solution

Introduce a **domain-aware test resolution system** that maps source code paths to the specific E2E tests that validate them.

### Pre-merge (PR gate) — now 4 parallel jobs:

| Job | What it does | Duration |
|-----|-------------|----------|
| **quality-gate** | Security patterns + domain-aware E2E resolution | ~1 min |
| **static-analysis** | TypeScript check + lint on changed files | ~2 min |
| **unit-tests** | Vitest unit tests | ~2 min |
| **targeted-e2e** | Only E2E specs affected by changed files | 0-10 min |

**E2E behavior by change type:**
- Docs/config/test-only changes → **SKIP** E2E entirely
- Domain-specific changes (e.g. orders router) → run **only** order-related specs
- Shared infrastructure (schema, trpc core) → run **smoke subset** (4 core specs)

### Post-merge:
- Integration tests + schema push + deployment verification (kept)
- Full E2E suite **removed** — moved to nightly

### New: Nightly Full E2E (`nightly-e2e.yml`):
- Runs complete E2E suite at 3 AM UTC daily
- Auto-creates GitHub issues on failure
- Can be triggered manually with suite selection (full/critical-paths/golden-flows)

## Files Changed

| File | Purpose |
|------|--------|
| `scripts/ci/domain-test-map.json` | Maps 13 source domains to their E2E specs |
| `scripts/ci/resolve-affected-tests.sh` | Resolves which specs to run for a given changeset |
| `.github/workflows/pre-merge.yml` | Redesigned with 4 parallel jobs + targeted E2E |
| `.github/workflows/merge.yml` | Streamlined — no E2E, keeps integration + deploy |
| `.github/workflows/nightly-e2e.yml` | New nightly full E2E suite |

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| PR feedback time | ~15-25 min | ~3 min (typical) |
| Post-merge time | ~15-25 min | ~5 min |
| Full E2E coverage | Every merge | Nightly (+ targeted per PR) |
| CI minutes/month | High | ~70% reduction |

## Test Results

The domain resolver was tested with 10 scenarios:
- ✅ Docs-only → SKIP
- ✅ Orders router → 3 targeted specs
- ✅ Schema change → 4 smoke specs
- ✅ Inventory + calendar → 3 targeted specs
- ✅ Test-only changes → SKIP
- ✅ Shared infra + domain → union of smoke + domain specs
- ✅ Pick-pack only → 1 targeted spec
- ✅ Unknown router → SKIP (no mapping yet)
- ✅ Mixed docs + code → targets code domain only
- ✅ package.json → smoke subset