### PR TITLE
test: harden oracle contracts and refresh frontend action checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "qa:test:clients": "ORACLE_RUN_MODE=domain ORACLE_DOMAIN=clients playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle",
     "qa:test:inventory": "ORACLE_RUN_MODE=domain ORACLE_DOMAIN=inventory playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle",
     "qa:test:accounting": "ORACLE_RUN_MODE=domain ORACLE_DOMAIN=accounting playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle",
+    "qa:test:control-actions": "playwright test tests-e2e/critical-paths/control-action-contracts.spec.ts --project=prod-smoke",
     "qa:test:flow": "playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle",
     "qa:test:headed": "ORACLE_RUN_MODE=tier1 playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle --headed",
     "qa:coverage": "tsx scripts/qa/oracle-coverage-report.ts",

--- a/tests-e2e/oracles/orders/create-draft-enhanced.oracle.yaml
+++ b/tests-e2e/oracles/orders/create-draft-enhanced.oracle.yaml
@@ -68,7 +68,7 @@ steps:
     name: "draft_order_created"
 
 expected_ui:
-  url_contains: "/orders/create"
+  url_equals: "/sales?tab=create-order"
   visible:
     - "text=Create Sales Order"
   text_present:

--- a/tests-e2e/oracles/orders/create-order.oracle.yaml
+++ b/tests-e2e/oracles/orders/create-order.oracle.yaml
@@ -70,7 +70,7 @@ steps:
     name: "order_created"
 
 expected_ui:
-  url_contains: "/orders/create"
+  url_equals: "/sales?tab=create-order"
   visible:
     - "text=Create Sales Order"
 

--- a/tests-e2e/oracles/orders/navigate-create-order.oracle.yaml
+++ b/tests-e2e/oracles/orders/navigate-create-order.oracle.yaml
@@ -31,6 +31,6 @@ steps:
     name: "order_form"
 
 expected_ui:
-  url_contains: "/orders"
+  url_equals: "/sales?tab=create-order"
   visible:
     - "form, [data-testid='order-form'], [data-testid='order-creator'], main"

--- a/tests-e2e/oracles/orders/update-draft-enhanced.oracle.yaml
+++ b/tests-e2e/oracles/orders/update-draft-enhanced.oracle.yaml
@@ -102,7 +102,7 @@ steps:
     name: "draft_order_updated"
 
 expected_ui:
-  url_contains: "/orders/create"
+  url_equals: "/sales?tab=create-order"
   visible:
     - "text=Create Sales Order"
   text_present:


### PR DESCRIPTION
## Summary
- harden oracle loading/selection to fail fast instead of silently passing (malformed file and empty-selection false-green protection)
- implement missing oracle DSL coverage in executor (`url_equals`, `table`, and `select.type_to_search`)
- refresh order-create oracles for consolidated frontend canonical URL (`/sales?tab=create-order`)
- replace legacy control-action spec with a staging-backed consolidated frontend contract matrix
- add `qa:test:control-actions` script for repeatable live frontend contract checks

## Live Verification
- `pnpm check`
- `pnpm lint`
- `PLAYWRIGHT_BASE_URL=https://terp-staging-yicld.ondigitalocean.app pnpm run qa:test:control-actions` (5 passed)
- `PLAYWRIGHT_BASE_URL=https://terp-staging-yicld.ondigitalocean.app ORACLE_RUN_MODE=single ORACLE_FLOW_ID=Orders.Orders.NavigateCreateOrder pnpm exec playwright test tests-e2e/oracles/oracle-runner.spec.ts --project=runtime-oracle` (2 passed)
- negative proof: `ORACLE_FLOW_ID=Orders.Orders.DoesNotExist` now fails fast with explicit error

## Artifacts
- route screenshots: `test-results/control-action-contracts/route-*.png`
- oracle summary: `test-results/oracle-results.json`
