### PR TITLE
Simplify workspaces and harden order flows

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -85,6 +85,7 @@ import {
 } from "wouter";
 import { VersionChecker } from "@/components/VersionChecker";
 import { PageErrorBoundary } from "@/components/common/PageErrorBoundary";
+import { PageLoading } from "@/components/ui/loading-state";
 
 type AnyRouteParams = Record<string, string | undefined>;
 type AnyRouteProps = WouterRouteComponentProps<AnyRouteParams>;
@@ -211,13 +212,7 @@ const withLazyErrorBoundary = (
 ): FC<AnyRouteProps> => {
   const WrappedLazyRoute: FC<AnyRouteProps> = props => (
     <PageErrorBoundary>
-      <Suspense
-        fallback={
-          <div className="flex items-center justify-center h-full p-8">
-            Loading...
-          </div>
-        }
-      >
+      <Suspense fallback={<PageLoading message="Loading page..." />}>
         <Component {...props} />
       </Suspense>
     </PageErrorBoundary>

--- a/client/src/components/CommandPalette.tsx
+++ b/client/src/components/CommandPalette.tsx
@@ -12,6 +12,10 @@ import {
 import { HelpCircle, LayoutDashboard, Plus, ReceiptText } from "lucide-react";
 import { buildNavigationAccessModel } from "@/config/navigation";
 import { useFeatureFlags } from "@/hooks/useFeatureFlag";
+import {
+  buildProcurementWorkspacePath,
+  buildSalesWorkspacePath,
+} from "@/lib/workspaceRoutes";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -73,7 +77,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       icon: Plus,
       shortcut: "N",
       action: () => {
-        setLocation("/sales?tab=create-order");
+        setLocation(buildSalesWorkspacePath("create-order"));
         onOpenChange(false);
       },
     },
@@ -83,7 +87,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
       icon: ReceiptText,
       shortcut: "R",
       action: () => {
-        setLocation("/receiving");
+        setLocation(buildProcurementWorkspacePath("receiving"));
         onOpenChange(false);
       },
     },

--- a/client/src/components/layout/AppHeader.test.tsx
+++ b/client/src/components/layout/AppHeader.test.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 const mockSetLocation = vi.fn();
 vi.mock("wouter", () => ({
   useLocation: () => ["/", mockSetLocation],
+  useSearch: () => "",
 }));
 
 // Mock version.json
@@ -114,7 +115,7 @@ describe("AppHeader - Notification Bell", () => {
     expect(densityToggle).toBeInTheDocument();
   });
 
-  it("routes notification preferences through account", () => {
+  it("routes notifications to the notifications hub", () => {
     render(
       <ThemeProvider>
         <AppHeader />
@@ -124,6 +125,6 @@ describe("AppHeader - Notification Bell", () => {
     openAccountMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: /notifications/i }));
 
-    expect(mockSetLocation).toHaveBeenCalledWith("/account");
+    expect(mockSetLocation).toHaveBeenCalledWith("/notifications");
   });
 });

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -34,10 +34,11 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ onMenuClick }: AppHeaderProps) {
-  const [, setLocation] = useLocation();
+  const [location, setLocation] = useLocation();
   const [searchQuery, setSearchQuery] = useState("");
   const { theme, toggleTheme, switchable } = useTheme();
   const { isCompact, toggleDensity } = useUiDensity();
+  const showBreadcrumbRow = location !== "/";
 
   // Get current user
   const { data: user } = trpc.auth.me.useQuery();
@@ -180,7 +181,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
                 <User className="h-4 w-4 mr-2" />
                 My Account
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setLocation("/account")}>
+              <DropdownMenuItem onClick={() => setLocation("/notifications")}>
                 <Bell className="h-4 w-4 mr-2" />
                 Notifications
               </DropdownMenuItem>
@@ -209,16 +210,17 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
         </div>
       </div>
 
-      {/* Breadcrumb row with version - CHAOS-027 */}
-      <div className="flex items-center justify-between px-3 md:px-4 py-1.5 border-t border-border/40">
-        <AppBreadcrumb />
-        <span
-          className="text-[11px] text-muted-foreground hidden sm:inline-block"
-          title={`Build: ${versionInfo.commit} (${versionInfo.date})`}
-        >
-          v{versionInfo.version}
-        </span>
-      </div>
+      {showBreadcrumbRow ? (
+        <div className="flex items-center justify-between px-3 md:px-4 py-1.5 border-t border-border/40">
+          <AppBreadcrumb />
+          <span
+            className="text-[11px] text-muted-foreground hidden sm:inline-block"
+            title={`Build: ${versionInfo.commit} (${versionInfo.date})`}
+          >
+            v{versionInfo.version}
+          </span>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/client/src/components/layout/AppSidebar.test.tsx
+++ b/client/src/components/layout/AppSidebar.test.tsx
@@ -16,7 +16,11 @@ const mockTogglePin = vi.fn();
 let mockSpreadsheetEnabled = true;
 
 vi.mock("wouter", () => ({
-  useLocation: () => [mockLocation, mockSetLocation],
+  useLocation: () => [mockLocation.split("?")[0], mockSetLocation],
+  useSearch: () => {
+    const [, search = ""] = mockLocation.split("?");
+    return search ? `?${search}` : "";
+  },
   Link: ({
     href,
     children,

--- a/client/src/components/layout/LinearWorkspaceShell.tsx
+++ b/client/src/components/layout/LinearWorkspaceShell.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode } from "react";
-import { Command, Search } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
-import { useUiDensity } from "@/hooks/useUiDensity";
 import { cn } from "@/lib/utils";
 
 export interface LinearWorkspaceTab<T extends string = string> {
@@ -36,47 +33,44 @@ export function LinearWorkspaceShell<T extends string>({
   className,
   section,
 }: LinearWorkspaceShellProps<T>) {
-  const { isCompact, toggleDensity } = useUiDensity();
+  const showHeader = Boolean(title || description || section);
+  const showMeta = meta.length > 0;
+  const showTabs = tabs.length > 1;
+  const showTabRow = showTabs || Boolean(commandStrip);
 
   return (
-    <section className={cn("linear-workspace-shell", className)}>
-      <header className="linear-workspace-header">
-        <div className="linear-workspace-title-wrap">
-          <p className="linear-workspace-eyebrow">
-            {section ? (
-              <>
-                <span className="linear-workspace-eyebrow-section">
-                  {section}
-                </span>
-                <span className="linear-workspace-eyebrow-sep" aria-hidden>
-                  {" "}
-                  /{" "}
-                </span>
-              </>
-            ) : null}
-            Operations Workspace
-          </p>
-          <div>
-            <h1 className="linear-workspace-title">{title}</h1>
-            <p className="linear-workspace-description">{description}</p>
+    <section
+      className={cn("linear-workspace-shell", className)}
+      data-single-tab={!showTabs}
+    >
+      {showHeader && (
+        <header className="linear-workspace-header">
+          <div className="linear-workspace-title-wrap">
+            <p className="linear-workspace-eyebrow">
+              {section ? (
+                <>
+                  <span className="linear-workspace-eyebrow-section">
+                    {section}
+                  </span>
+                  <span className="linear-workspace-eyebrow-sep" aria-hidden>
+                    {" "}
+                    /{" "}
+                  </span>
+                </>
+              ) : null}
+              Operations Workspace
+            </p>
+            <div>
+              <h1 className="linear-workspace-title">{title}</h1>
+              {description ? (
+                <p className="linear-workspace-description">{description}</p>
+              ) : null}
+            </div>
           </div>
-        </div>
+        </header>
+      )}
 
-        <div
-          className="linear-workspace-shortcuts"
-          aria-label="Workspace shortcuts"
-        >
-          <span className="linear-workspace-shortcut-chip">
-            <Search className="h-3.5 w-3.5" />
-            Search
-          </span>
-          <span className="linear-workspace-shortcut-chip">
-            <Command className="h-3.5 w-3.5" />K
-          </span>
-        </div>
-      </header>
-
-      {meta.length > 0 && (
+      {showMeta && (
         <div className="linear-workspace-meta" aria-label="Workspace metadata">
           {meta.map(item => (
             <div key={item.label} className="linear-workspace-meta-item">
@@ -92,35 +86,28 @@ export function LinearWorkspaceShell<T extends string>({
         onValueChange={value => onTabChange(value as T)}
         className="linear-workspace-tabs"
       >
-        <div className="linear-workspace-tab-row">
-          <TabsList
-            className={cn(
-              "linear-workspace-tabs-list",
-              `linear-workspace-tabs-count-${tabs.length}`
+        {showTabRow ? (
+          <div className="linear-workspace-tab-row">
+            {showTabs ? (
+              <div className="linear-workspace-tabs-scroller scrollbar-hide">
+                <TabsList className="linear-workspace-tabs-list">
+                  {tabs.map(tab => (
+                    <TabsTrigger
+                      key={tab.value}
+                      value={tab.value}
+                      className="linear-workspace-tabs-trigger"
+                    >
+                      {tab.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </div>
+            ) : (
+              <div className="linear-workspace-tabs-spacer" aria-hidden />
             )}
-          >
-            {tabs.map(tab => (
-              <TabsTrigger
-                key={tab.value}
-                value={tab.value}
-                className="linear-workspace-tabs-trigger"
-              >
-                {tab.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          <div className="linear-workspace-command-strip">
-            {commandStrip}
-            <Button
-              size="sm"
-              variant={isCompact ? "secondary" : "outline"}
-              onClick={toggleDensity}
-              data-testid="workspace-density-toggle"
-            >
-              {isCompact ? "Comfortable" : "Compact"}
-            </Button>
+            <div className="linear-workspace-command-strip">{commandStrip}</div>
           </div>
-        </div>
+        ) : null}
         {children}
       </Tabs>
     </section>

--- a/client/src/components/layout/MobileNav.tsx
+++ b/client/src/components/layout/MobileNav.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Menu, Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { APP_TITLE } from "@/const";
+import { useLocation } from "wouter";
 
 export interface MobileNavProps {
   onMenuClick?: () => void;
@@ -11,6 +12,8 @@ export interface MobileNavProps {
 export const MobileNav = React.memo(function MobileNav({
   onMenuClick,
 }: MobileNavProps) {
+  const [, setLocation] = useLocation();
+
   return (
     <div className="flex items-center justify-between h-14 px-4 border-b border-border md:hidden bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       <Button
@@ -29,11 +32,15 @@ export const MobileNav = React.memo(function MobileNav({
         <span className="text-sm font-semibold text-foreground">Menu</span>
       </div>
       <div className="flex items-center gap-2">
-        <Button variant="ghost" size="icon" aria-label="Notifications">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Notifications"
+          onClick={() => setLocation("/notifications")}
+        >
           <Bell className="h-5 w-5" />
         </Button>
         <Avatar className="h-8 w-8">
-          <AvatarImage src="/avatar.png" alt="User avatar" />
           <AvatarFallback>U</AvatarFallback>
         </Avatar>
       </div>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { flushSync } from "react-dom";
-import { Link, useLocation } from "wouter";
+import { Link, useLocation, useSearch } from "wouter";
 import {
   ChevronDown,
   ChevronRight,
@@ -24,13 +24,14 @@ import { APP_TITLE } from "@/const";
 import {
   buildNavigationAccessModel,
   defaultQuickLinkPaths,
+  navigationItems,
   type NavigationGroupKey,
 } from "@/config/navigation";
 import { useFeatureFlags } from "@/hooks/useFeatureFlag";
 import { useNavigationState } from "@/hooks/useNavigationState";
 import { trpc } from "@/lib/trpc";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 
 export interface SidebarProps {
@@ -40,23 +41,74 @@ export interface SidebarProps {
 
 const TERRACOTTA_ACTIVE = "border-l-[oklch(0.53_0.13_44)]";
 
+function normalizeNavRoute(path: string) {
+  const [rawPath, queryString = ""] = path.split("?");
+  const params = new URLSearchParams(queryString);
+
+  let pathname = rawPath;
+  if (pathname === "/orders") {
+    pathname = "/sales";
+  }
+  if (pathname === "/pick-pack") {
+    pathname = "/sales";
+    params.set("tab", "pick-pack");
+  }
+  if (pathname === "/direct-intake" || pathname === "/receiving") {
+    pathname = "/purchase-orders";
+    params.set("tab", "receiving");
+  }
+
+  return {
+    pathname,
+    tab: params.get("tab"),
+  };
+}
+
+function matchesNavRoute(currentPath: string, targetPath: string) {
+  const current = normalizeNavRoute(currentPath);
+  const target = normalizeNavRoute(targetPath);
+  const samePath =
+    current.pathname === target.pathname ||
+    (target.pathname !== "/" &&
+      current.pathname.startsWith(`${target.pathname}/`));
+
+  if (!samePath) {
+    return false;
+  }
+
+  if (target.tab) {
+    return current.tab === target.tab;
+  }
+
+  return true;
+}
+
+function getDefaultOpenGroups(currentPath: string) {
+  const activeGroup =
+    navigationItems.find(item => matchesNavRoute(currentPath, item.path))
+      ?.group ?? "sales";
+
+  return {
+    sales: activeGroup === "sales",
+    inventory: activeGroup === "inventory",
+    finance: activeGroup === "finance",
+    admin: activeGroup === "admin",
+  } satisfies Record<NavigationGroupKey, boolean>;
+}
+
 export const Sidebar = React.memo(function Sidebar({
   open = false,
   onClose,
 }: SidebarProps) {
   const [location, setLocation] = useLocation();
+  const search = useSearch();
   const { flags, isLoading: featureFlagsLoading } = useFeatureFlags();
   const { data: currentUser } = trpc.auth.me.useQuery(undefined, {
     staleTime: 60_000,
   });
   const [openGroups, setOpenGroups] = useState<
     Record<NavigationGroupKey, boolean>
-  >({
-    sales: true,
-    inventory: true,
-    finance: true,
-    admin: true,
-  });
+  >(() => getDefaultOpenGroups(`${location}${search || ""}`));
   const [collapsed, setCollapsed] = useState(false);
   const [showQuickLinkEditor, setShowQuickLinkEditor] = useState(false);
 
@@ -89,13 +141,6 @@ export const Sidebar = React.memo(function Sidebar({
   const groupedNavigation = navigationAccessModel.groups;
   const quickLinks = navigationAccessModel.quickLinks;
 
-  const normalizePath = useCallback((path: string) => {
-    if (path === "/direct-intake") {
-      return "/receiving";
-    }
-    return path;
-  }, []);
-
   const toggleGroup = useCallback((key: NavigationGroupKey) => {
     flushSync(() => {
       setOpenGroups(prev => ({ ...prev, [key]: !prev[key] }));
@@ -104,15 +149,9 @@ export const Sidebar = React.memo(function Sidebar({
 
   const isActivePath = useCallback(
     (path: string) => {
-      const normalizedCurrent = normalizePath(location);
-      const normalizedTarget = normalizePath(path);
-      return (
-        normalizedCurrent === normalizedTarget ||
-        (normalizedTarget !== "/" &&
-          normalizedCurrent.startsWith(`${normalizedTarget}/`))
-      );
+      return matchesNavRoute(`${location}${search || ""}`, path);
     },
-    [location, normalizePath]
+    [location, search]
   );
 
   const handleLogout = useCallback(() => {
@@ -121,6 +160,13 @@ export const Sidebar = React.memo(function Sidebar({
   }, [onClose, setLocation]);
 
   const navRef = useRef<HTMLElement>(null);
+  const activeGroupKey = useMemo(
+    () =>
+      groupedNavigation.find(group =>
+        group.items.some(item => isActivePath(item.path))
+      )?.key ?? "sales",
+    [groupedNavigation, isActivePath]
+  );
 
   // Scroll the active nav item into view whenever the location changes
   useEffect(() => {
@@ -130,7 +176,13 @@ export const Sidebar = React.memo(function Sidebar({
     if (activeLink) {
       activeLink.scrollIntoView({ block: "nearest", behavior: "smooth" });
     }
-  }, [location]);
+  }, [location, search]);
+
+  useEffect(() => {
+    setOpenGroups(prev =>
+      prev[activeGroupKey] ? prev : { ...prev, [activeGroupKey]: true }
+    );
+  }, [activeGroupKey]);
 
   return (
     <>
@@ -380,7 +432,6 @@ export const Sidebar = React.memo(function Sidebar({
           {!collapsed && (
             <div className="flex items-center gap-3">
               <Avatar>
-                <AvatarImage src="/avatar.png" alt="User avatar" />
                 <AvatarFallback>
                   <UserCircle2 className="h-5 w-5" />
                 </AvatarFallback>

--- a/client/src/components/orders/OrderStatusTimeline.tsx
+++ b/client/src/components/orders/OrderStatusTimeline.tsx
@@ -6,10 +6,10 @@ interface OrderStatusTimelineProps {
   orderId: number;
 }
 
-const formatFulfillmentStatus = (status: string) =>
+const formatFulfillmentStatus = (status: string | null | undefined) =>
   status === "READY_FOR_PACKING" || status === "PENDING"
     ? "Ready for Packing"
-    : status;
+    : status || "Unknown";
 
 export function OrderStatusTimeline({ orderId }: OrderStatusTimelineProps) {
   const { data: history, isLoading } =

--- a/client/src/components/work-surface/DirectIntakeWorkSurface.tsx
+++ b/client/src/components/work-surface/DirectIntakeWorkSurface.tsx
@@ -1837,23 +1837,25 @@ export function DirectIntakeWorkSurface() {
   return (
     <section
       {...keyboardProps}
-      className="linear-workspace-shell h-full min-h-[calc(100vh-8rem)] flex flex-col overflow-hidden"
+      className="h-full min-h-[calc(100vh-8rem)] flex flex-col overflow-hidden bg-background"
     >
-      <header className="linear-workspace-header">
-        <div className="linear-workspace-title-wrap">
-          <p className="linear-workspace-eyebrow">Inventory Intake</p>
-          <div>
-            <h2 className="linear-workspace-title flex items-center gap-2">
-              <Package className="h-5 w-5" />
-              Intake
-            </h2>
-            <p className="linear-workspace-description">
-              Keep key fields front and center, then use row details for
-              everything else.
-            </p>
-          </div>
+      <div className="flex flex-col gap-3 border-b border-border/70 bg-background px-3 py-3 md:flex-row md:items-center md:justify-between md:px-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary" className="px-2.5 py-1">
+            Receiving
+          </Badge>
+          <Badge variant="outline">Pending {pendingCount}</Badge>
+          <Badge variant="outline">Submitted {submittedCount}</Badge>
+          <Badge
+            variant="outline"
+            className={cn(errorCount > 0 && "border-red-200 text-red-600")}
+          >
+            Errors {errorCount}
+          </Badge>
+          <Badge variant="outline">Qty {summary.totalQty}</Badge>
+          <Badge variant="outline">${summary.totalValue.toFixed(2)}</Badge>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           {SaveStateIndicator}
           <Button
             variant="outline"
@@ -1863,40 +1865,6 @@ export function DirectIntakeWorkSurface() {
           >
             Edit Selected Details
           </Button>
-        </div>
-      </header>
-
-      <div className="linear-workspace-meta">
-        <div className="linear-workspace-meta-item">
-          <span className="linear-workspace-meta-label">Pending</span>
-          <span className="linear-workspace-meta-value">{pendingCount}</span>
-        </div>
-        <div className="linear-workspace-meta-item">
-          <span className="linear-workspace-meta-label">Submitted</span>
-          <span className="linear-workspace-meta-value">{submittedCount}</span>
-        </div>
-        <div className="linear-workspace-meta-item">
-          <span className="linear-workspace-meta-label">Errors</span>
-          <span
-            className={cn(
-              "linear-workspace-meta-value",
-              errorCount > 0 && "text-red-600"
-            )}
-          >
-            {errorCount}
-          </span>
-        </div>
-        <div className="linear-workspace-meta-item">
-          <span className="linear-workspace-meta-label">Qty</span>
-          <span className="linear-workspace-meta-value">
-            {summary.totalQty}
-          </span>
-        </div>
-        <div className="linear-workspace-meta-item">
-          <span className="linear-workspace-meta-label">Value</span>
-          <span className="linear-workspace-meta-value">
-            ${summary.totalValue.toFixed(2)}
-          </span>
         </div>
       </div>
 

--- a/client/src/components/work-surface/InventoryWorkSurface.tsx
+++ b/client/src/components/work-surface/InventoryWorkSurface.tsx
@@ -26,6 +26,14 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import {
+  DatabaseErrorState,
+  EmptyState,
+  ErrorState,
+  NoSearchResults,
+  isDatabaseError,
+} from "@/components/ui/empty-state";
+import { LoadingState } from "@/components/ui/loading-state";
+import {
   Table,
   TableBody,
   TableCell,
@@ -643,6 +651,7 @@ export function InventoryWorkSurface() {
   const {
     data: enhancedData,
     isLoading: isEnhancedLoading,
+    error: enhancedError,
     refetch: refetchEnhanced,
   } = trpc.inventory.getEnhanced.useQuery(
     {
@@ -677,6 +686,7 @@ export function InventoryWorkSurface() {
   const {
     data: legacyData,
     isLoading: isLegacyLoading,
+    error: legacyError,
     refetch: refetchLegacy,
   } = trpc.inventory.list.useQuery(
     {
@@ -694,8 +704,11 @@ export function InventoryWorkSurface() {
     }
   );
 
-  const { data: dashboardStats, refetch: refetchDashboardStats } =
-    trpc.inventory.dashboardStats.useQuery();
+  const {
+    data: dashboardStats,
+    error: dashboardStatsError,
+    refetch: refetchDashboardStats,
+  } = trpc.inventory.dashboardStats.useQuery();
 
   const refreshInventory = useCallback(async () => {
     await Promise.all([
@@ -751,6 +764,9 @@ export function InventoryWorkSurface() {
   }, [useEnhancedApi, enhancedData?.items, legacyData?.items]);
 
   const items = normalizedItems;
+  const inventoryLoadError = useEnhancedApi
+    ? enhancedError ?? dashboardStatsError
+    : legacyError ?? dashboardStatsError;
   const clientSideFilterActive =
     !useEnhancedApi &&
     (filters.stockLevel !== "all" ||
@@ -2061,16 +2077,49 @@ export function InventoryWorkSurface() {
           )}
         >
           {isLoading ? (
-            <div className="flex items-center justify-center h-64">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            </div>
+            <LoadingState
+              className="h-64"
+              message="Loading inventory workspace..."
+            />
+          ) : inventoryLoadError ? (
+            isDatabaseError(inventoryLoadError) ? (
+              <DatabaseErrorState
+                entity="inventory"
+                errorMessage={inventoryLoadError.message}
+                onRetry={() => {
+                  void refreshInventory();
+                }}
+              />
+            ) : (
+              <ErrorState
+                title="Unable to load inventory"
+                description={inventoryLoadError.message}
+                onRetry={() => {
+                  void refreshInventory();
+                }}
+              />
+            )
           ) : displayItems.length === 0 ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="text-center">
-                <Package className="h-12 w-12 text-muted-foreground mx-auto mb-4 opacity-50" />
-                <p className="font-medium">No inventory found</p>
-              </div>
-            </div>
+            hasActiveFilters || search ? (
+              <NoSearchResults
+                searchTerm={search || undefined}
+                onClear={() => {
+                  clearAllFilters();
+                  setSearch("");
+                  setPage(0);
+                }}
+              />
+            ) : (
+              <EmptyState
+                variant="inventory"
+                title="No inventory found"
+                description="Intake products to start managing stock, locations, and availability."
+                action={{
+                  label: "Open Intake",
+                  onClick: () => setShowPurchaseModal(true),
+                }}
+              />
+            )
           ) : (
             <>
               {inventoryViewMode === "table" ? (

--- a/client/src/components/work-surface/OrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/OrdersWorkSurface.tsx
@@ -22,6 +22,7 @@ import {
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { toast } from "sonner";
 import { format } from "date-fns";
 import { usePermissions } from "@/hooks/usePermissions";
@@ -1110,11 +1111,11 @@ export function OrdersWorkSurface() {
       },
       "cmd+n": e => {
         e.preventDefault();
-        setLocation("/orders/create");
+        setLocation(buildSalesWorkspacePath("create-order"));
       },
       "ctrl+n": e => {
         e.preventDefault();
-        setLocation("/orders/create");
+        setLocation(buildSalesWorkspacePath("create-order"));
       },
       arrowdown: e => {
         e.preventDefault();
@@ -1162,7 +1163,7 @@ export function OrdersWorkSurface() {
 
   // Handlers
   const handleEdit = (orderId: number) =>
-    setLocation(`/orders/create?draftId=${orderId}`);
+    setLocation(buildSalesWorkspacePath("create-order", { draftId: orderId }));
   const handleConfirm = (orderId: number) => {
     setSelectedOrderId(orderId);
     setShowConfirmDialog(true);
@@ -1307,7 +1308,7 @@ export function OrdersWorkSurface() {
                 Refresh
               </Button>
               <Button
-                onClick={() => setLocation("/orders/create")}
+                onClick={() => setLocation(buildSalesWorkspacePath("create-order"))}
                 data-testid="new-order-button"
               >
                 <Plus className="h-4 w-4 mr-2" />

--- a/client/src/components/work-surface/QuotesWorkSurface.tsx
+++ b/client/src/components/work-surface/QuotesWorkSurface.tsx
@@ -17,6 +17,7 @@ import { useState, useMemo, useCallback, useRef } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { toast } from "sonner";
 import { format } from "date-fns";
 
@@ -538,7 +539,7 @@ export function QuotesWorkSurface() {
       },
       "cmd+n": e => {
         e.preventDefault();
-        setLocation("/orders/create");
+        setLocation(buildSalesWorkspacePath("create-order"));
       },
       arrowdown: e => {
         e.preventDefault();
@@ -571,7 +572,7 @@ export function QuotesWorkSurface() {
 
   // Handlers
   const handleEdit = (quoteId: number) =>
-    setLocation(`/orders/create?quoteId=${quoteId}`);
+    setLocation(buildSalesWorkspacePath("create-order", { quoteId }));
   // API-016: Open send dialog
   const handleSend = (quoteId: number) => {
     setSelectedQuoteId(quoteId);
@@ -583,7 +584,12 @@ export function QuotesWorkSurface() {
     setShowConvertDialog(true);
   };
   const handleDuplicate = (quoteId: number) =>
-    setLocation(`/orders/create?quoteId=${quoteId}&mode=duplicate`);
+    setLocation(
+      buildSalesWorkspacePath("create-order", {
+        quoteId,
+        mode: "duplicate",
+      })
+    );
   const handleDelete = (quoteId: number) => {
     setSelectedQuoteId(quoteId);
     setShowDeleteDialog(true);
@@ -654,7 +660,7 @@ export function QuotesWorkSurface() {
               </SelectContent>
             </Select>
           </div>
-          <Button onClick={() => setLocation("/orders/create")}>
+          <Button onClick={() => setLocation(buildSalesWorkspacePath("create-order"))}>
             <Plus className="h-4 w-4 mr-2" />
             New Quote
           </Button>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -222,10 +222,9 @@
     min-width: 0;
     gap: 0;
     border: 1px solid color-mix(in oklab, var(--border) 90%, transparent);
-    /* Accent left border that echoes the sidebar active-item indicator color */
-    border-left: 3px solid oklch(0.53 0.13 44 / 0.45);
-    border-radius: 12px;
-    background: color-mix(in oklab, var(--card) 96%, transparent);
+    border-left: 2px solid oklch(0.53 0.13 44 / 0.22);
+    border-radius: 10px;
+    background: color-mix(in oklab, var(--card) 98%, transparent);
     overflow: hidden;
   }
 
@@ -235,8 +234,8 @@
     align-items: flex-start;
     gap: 0.75rem;
     border-bottom: 1px solid color-mix(in oklab, var(--border) 85%, transparent);
-    padding: 0.85rem 1rem;
-    background: color-mix(in oklab, var(--background) 85%, var(--card));
+    padding: 0.8rem 1rem 0.75rem;
+    background: color-mix(in oklab, var(--background) 90%, var(--card));
   }
 
   .linear-workspace-title-wrap {
@@ -281,33 +280,14 @@
     color: var(--muted-foreground);
   }
 
-  .linear-workspace-shortcuts {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--muted-foreground);
-  }
-
-  .linear-workspace-shortcut-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.32rem;
-    border: 1px solid color-mix(in oklab, var(--border) 90%, transparent);
-    border-radius: 999px;
-    padding: 0.15rem 0.5rem;
-    font-size: 0.71rem;
-    font-weight: 500;
-    background: color-mix(in oklab, var(--background) 86%, var(--card));
-  }
-
   .linear-workspace-meta {
     display: flex;
     align-items: center;
     gap: 0.65rem 1.25rem;
     flex-wrap: wrap;
-    padding: 0.55rem 1rem;
+    padding: 0.5rem 1rem;
     border-bottom: 1px solid color-mix(in oklab, var(--border) 85%, transparent);
-    background: color-mix(in oklab, var(--muted) 65%, transparent);
+    background: color-mix(in oklab, var(--muted) 52%, transparent);
   }
 
   .linear-workspace-meta-item {
@@ -342,39 +322,40 @@
     display: flex;
     align-items: center;
     gap: 0.6rem;
-    padding: 0.55rem 1rem;
+    padding: 0.5rem 1rem;
     border-bottom: 1px solid color-mix(in oklab, var(--border) 85%, transparent);
     background: color-mix(in oklab, var(--background) 92%, transparent);
-    min-height: 50px;
+    min-height: 46px;
     position: sticky;
     top: 0;
     z-index: 25;
     backdrop-filter: blur(10px);
   }
 
+  .linear-workspace-tabs-scroller {
+    min-width: 0;
+    flex: 1;
+    overflow-x: auto;
+  }
+
+  .linear-workspace-tabs-spacer {
+    flex: 1;
+    min-width: 0;
+  }
+
   .linear-workspace-tabs-list {
-    display: grid;
+    display: inline-flex;
     height: 34px;
+    min-width: max-content;
     border-radius: 9px;
     padding: 2px;
     border: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
     background: color-mix(in oklab, var(--muted) 62%, transparent);
   }
 
-  .linear-workspace-tabs-count-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .linear-workspace-tabs-count-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .linear-workspace-tabs-count-4 {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
   .linear-workspace-tabs-trigger {
     min-width: 88px;
+    white-space: nowrap;
     font-size: 0.78rem;
     font-weight: 600;
     letter-spacing: 0.005em;
@@ -399,7 +380,11 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    padding: 0.55rem;
+    padding: 0.4rem;
+  }
+
+  .linear-workspace-shell[data-single-tab="true"] .linear-workspace-content {
+    padding: 0;
   }
 
   /**
@@ -572,10 +557,6 @@
       padding: 0.75rem;
     }
 
-    .linear-workspace-shortcuts {
-      justify-content: flex-start;
-    }
-
     .linear-workspace-meta,
     .linear-workspace-tab-row {
       padding-left: 0.75rem;
@@ -591,7 +572,7 @@
     }
 
     .linear-workspace-tabs-list {
-      width: 100%;
+      min-width: 100%;
     }
 
     .linear-workspace-command-strip {

--- a/client/src/lib/workspaceRoutes.ts
+++ b/client/src/lib/workspaceRoutes.ts
@@ -1,0 +1,37 @@
+type WorkspaceParamValue = string | number | boolean | null | undefined;
+
+function buildWorkspacePath(
+  basePath: string,
+  tab?: string,
+  params?: Record<string, WorkspaceParamValue>
+) {
+  const search = new URLSearchParams();
+
+  if (tab) {
+    search.set("tab", tab);
+  }
+
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === null || value === undefined || value === "") {
+      continue;
+    }
+    search.set(key, String(value));
+  }
+
+  const query = search.toString();
+  return `${basePath}${query ? `?${query}` : ""}`;
+}
+
+export function buildSalesWorkspacePath(
+  tab?: string,
+  params?: Record<string, WorkspaceParamValue>
+) {
+  return buildWorkspacePath("/sales", tab, params);
+}
+
+export function buildProcurementWorkspacePath(
+  tab?: string,
+  params?: Record<string, WorkspaceParamValue>
+) {
+  return buildWorkspacePath("/purchase-orders", tab, params);
+}

--- a/client/src/pages/AccountingWorkspacePage.tsx
+++ b/client/src/pages/AccountingWorkspacePage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import {
   LinearWorkspacePanel,
   LinearWorkspaceShell,
@@ -43,38 +42,7 @@ export default function AccountingWorkspacePage() {
           label: "Core flow",
           value: "Invoice / Bill -> Payment -> Ledger",
         },
-        {
-          label: "Current view",
-          value:
-            ACCOUNTING_WORKSPACE.tabs.find(tab => tab.value === activeTab)
-              ?.label ?? activeTab,
-        },
       ]}
-      commandStrip={
-        <>
-          <Button
-            size="sm"
-            variant={activeTab === "invoices" ? "default" : "outline"}
-            onClick={() => setActiveTab("invoices")}
-          >
-            Invoices
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "bills" ? "default" : "outline"}
-            onClick={() => setActiveTab("bills")}
-          >
-            Bills
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "payments" ? "default" : "outline"}
-            onClick={() => setActiveTab("payments")}
-          >
-            Payments
-          </Button>
-        </>
-      }
     >
       <LinearWorkspacePanel value="dashboard">
         <AccountingDashboard embedded />

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 import { BackButton } from "@/components/common/BackButton";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 // Alert components available from @/components/ui/alert when needed
 import { formatCurrency } from "@/lib/utils";
 import {
@@ -276,7 +277,8 @@ export default function AnalyticsPage() {
                   size="sm"
                   action={{
                     label: "Create your first order",
-                    onClick: () => setLocation("/orders/create"),
+                    onClick: () =>
+                      setLocation(buildSalesWorkspacePath("create-order")),
                   }}
                 />
               )}

--- a/client/src/pages/ConsolidatedWorkspaces.test.tsx
+++ b/client/src/pages/ConsolidatedWorkspaces.test.tsx
@@ -125,7 +125,7 @@ describe("Consolidated workspace pages", () => {
     expect(screen.getByRole("heading", { name: "Sales" })).toBeInTheDocument();
     expect(screen.getByText("Quotes Surface")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "New Sales Order" })
+      screen.getByRole("tab", { name: "New Sales Order" })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "New Order" })

--- a/client/src/pages/InterestListPage.tsx
+++ b/client/src/pages/InterestListPage.tsx
@@ -6,6 +6,7 @@
 import { useState, useMemo } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -221,7 +222,12 @@ export default function InterestListPage() {
   const totalMatches = items.reduce((sum, i) => sum + i.matchCount, 0);
 
   const handleConvertToOrder = (item: InterestItem) => {
-    setLocation(`/orders/create?clientId=${item.clientId}&needId=${item.id}`);
+    setLocation(
+      buildSalesWorkspacePath("create-order", {
+        clientId: item.clientId,
+        needId: item.id,
+      })
+    );
   };
 
   // CHAOS-016: Show confirm dialog instead of window.confirm

--- a/client/src/pages/InventoryWorkspacePage.tsx
+++ b/client/src/pages/InventoryWorkspacePage.tsx
@@ -1,13 +1,7 @@
-import { useLocation } from "wouter";
-import { Button } from "@/components/ui/button";
 import InventoryWorkSurface from "@/components/work-surface/InventoryWorkSurface";
 import { useQueryTabState } from "@/hooks/useQueryTabState";
 import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
 import { INVENTORY_WORKSPACE } from "@/config/workspaces";
-import {
-  LinearWorkspacePanel,
-  LinearWorkspaceShell,
-} from "@/components/layout/LinearWorkspaceShell";
 
 type InventoryTab = (typeof INVENTORY_WORKSPACE.tabs)[number]["value"];
 const INVENTORY_TABS = INVENTORY_WORKSPACE.tabs.map(
@@ -15,41 +9,19 @@ const INVENTORY_TABS = INVENTORY_WORKSPACE.tabs.map(
 ) as readonly InventoryTab[];
 
 export default function InventoryWorkspacePage() {
-  const [, setLocation] = useLocation();
-  const { activeTab, setActiveTab } = useQueryTabState<InventoryTab>({
+  const { activeTab } = useQueryTabState<InventoryTab>({
     defaultTab: "inventory",
     validTabs: INVENTORY_TABS,
   });
   useWorkspaceHomeTelemetry("inventory", activeTab);
 
   return (
-    <LinearWorkspaceShell
-      title={INVENTORY_WORKSPACE.title}
-      description={INVENTORY_WORKSPACE.description}
-      section="Buy"
-      activeTab={activeTab}
-      tabs={INVENTORY_WORKSPACE.tabs}
-      onTabChange={tab => setActiveTab(tab)}
-      meta={[
-        { label: "Views", value: "Table + Gallery" },
-        { label: "Focus", value: "Batch operations" },
-      ]}
-      commandStrip={
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => setLocation("/direct-intake")}
-        >
-          New Intake
-        </Button>
-      }
-      className="min-h-[calc(100vh-8.5rem)]"
+    <div
+      data-testid="inventory-header"
+      className="linear-workspace-shell min-h-[calc(100vh-8.5rem)]"
     >
-      <LinearWorkspacePanel value="inventory">
-        <div data-testid="inventory-header" className="contents">
-          <InventoryWorkSurface />
-        </div>
-      </LinearWorkspacePanel>
-    </LinearWorkspaceShell>
+      <h1 className="sr-only">{INVENTORY_WORKSPACE.title}</h1>
+      <InventoryWorkSurface />
+    </div>
   );
 }

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -5,7 +5,7 @@
  * v2.0 Sales Order Enhancements
  */
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useLocation, useSearch } from "wouter";
 import { z } from "zod";
 import { trpc } from "@/lib/trpc";
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { ClientCombobox } from "@/components/ui/client-combobox";
 import { cn } from "@/lib/utils";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { normalizePositiveIntegerWithin } from "@/lib/quantity";
 import { usePermissions } from "@/hooks/usePermissions";
 import {
@@ -47,7 +48,6 @@ import {
   FileText,
   Send,
 } from "lucide-react";
-import { BackButton } from "@/components/common/BackButton";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -118,13 +118,150 @@ const orderValidationSchema = z.object({
   orderType: z.enum(["SALE", "QUOTE"]),
 });
 
+interface DraftLineItemPayload {
+  id?: number;
+  batchId: number;
+  productId?: number | null;
+  batchSku?: string | null;
+  productDisplayName?: string | null;
+  quantity: number | string;
+  cogsPerUnit: number | string;
+  originalCogsPerUnit: number | string;
+  isCogsOverridden: boolean;
+  cogsOverrideReason?: string | null;
+  marginPercent: number | string;
+  marginDollar: number | string;
+  isMarginOverridden: boolean;
+  marginSource: "CUSTOMER_PROFILE" | "DEFAULT" | "MANUAL";
+  unitPrice: number | string;
+  lineTotal: number | string;
+  isSample: boolean;
+}
+
+interface OrderDraftSnapshot {
+  clientId: number | null;
+  linkedNeedId: number | null;
+  orderType: "QUOTE" | "SALE";
+  referredByClientId: number | null;
+  adjustment: OrderAdjustment | null;
+  showAdjustmentOnDocument: boolean;
+  items: LineItem[];
+}
+
+const normalizeFingerprintNumber = (
+  value: number | null | undefined,
+  precision = 4
+): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return Number(value.toFixed(precision));
+};
+
+const buildOrderFingerprint = (snapshot: OrderDraftSnapshot): string =>
+  JSON.stringify({
+    clientId: snapshot.clientId,
+    linkedNeedId: snapshot.linkedNeedId,
+    orderType: snapshot.orderType,
+    referredByClientId: snapshot.referredByClientId,
+    adjustment: snapshot.adjustment
+      ? {
+          amount: normalizeFingerprintNumber(snapshot.adjustment.amount, 2),
+          mode: snapshot.adjustment.mode,
+          type: snapshot.adjustment.type,
+        }
+      : null,
+    showAdjustmentOnDocument: snapshot.showAdjustmentOnDocument,
+    items: snapshot.items.map(item => ({
+      batchId: item.batchId,
+      productId: item.productId ?? null,
+      productDisplayName: item.productDisplayName ?? null,
+      quantity: normalizeFingerprintNumber(item.quantity, 4),
+      cogsPerUnit: normalizeFingerprintNumber(item.cogsPerUnit, 4),
+      originalCogsPerUnit: normalizeFingerprintNumber(
+        item.originalCogsPerUnit,
+        4
+      ),
+      isCogsOverridden: item.isCogsOverridden,
+      cogsOverrideReason: item.cogsOverrideReason ?? null,
+      marginPercent: normalizeFingerprintNumber(item.marginPercent, 4),
+      marginDollar: normalizeFingerprintNumber(item.marginDollar, 4),
+      isMarginOverridden: item.isMarginOverridden,
+      marginSource: item.marginSource,
+      unitPrice: normalizeFingerprintNumber(item.unitPrice, 4),
+      lineTotal: normalizeFingerprintNumber(item.lineTotal, 4),
+      isSample: item.isSample,
+    })),
+  });
+
+const EMPTY_ORDER_FINGERPRINT = buildOrderFingerprint({
+  clientId: null,
+  linkedNeedId: null,
+  orderType: "SALE",
+  referredByClientId: null,
+  adjustment: null,
+  showAdjustmentOnDocument: true,
+  items: [],
+});
+
+const parseRouteEntityId = (value: string | null): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const mapDraftLineItemsToEditorState = (
+  lineItems: DraftLineItemPayload[]
+): LineItem[] =>
+  lineItems.map(item => ({
+    id: item.id,
+    batchId: item.batchId,
+    batchSku: item.batchSku ?? undefined,
+    productId: item.productId ?? undefined,
+    productDisplayName: item.productDisplayName ?? "Unknown Product",
+    quantity: Number(item.quantity),
+    cogsPerUnit: Number(item.cogsPerUnit),
+    originalCogsPerUnit: Number(item.originalCogsPerUnit),
+    isCogsOverridden: item.isCogsOverridden,
+    cogsOverrideReason: item.cogsOverrideReason ?? undefined,
+    marginPercent: Number(item.marginPercent),
+    marginDollar: Number(item.marginDollar),
+    isMarginOverridden: item.isMarginOverridden,
+    marginSource: item.marginSource,
+    unitPrice: Number(item.unitPrice),
+    lineTotal: Number(item.lineTotal),
+    isSample: item.isSample,
+  }));
+
 export default function OrderCreatorPageV2() {
   // TER-216: Navigation after save/finalize
   const [, setLocation] = useLocation();
   const searchString = useSearch();
+  const searchParams = useMemo(
+    () => new URLSearchParams(searchString),
+    [searchString]
+  );
+  const draftIdFromRoute = parseRouteEntityId(searchParams.get("draftId"));
+  const quoteIdFromRoute = parseRouteEntityId(searchParams.get("quoteId"));
+  const clientIdFromRoute = parseRouteEntityId(searchParams.get("clientId"));
+  const needIdFromRoute = parseRouteEntityId(searchParams.get("needId"));
+  const routeMode = searchParams.get("mode");
+  const isDuplicateRoute = routeMode === "duplicate" && quoteIdFromRoute !== null;
+  const routeOrderId = draftIdFromRoute ?? quoteIdFromRoute;
+  const isSalesSheetImport = searchParams.get("fromSalesSheet") === "true";
+  const hasRouteSeedContext =
+    routeOrderId !== null ||
+    clientIdFromRoute !== null ||
+    needIdFromRoute !== null ||
+    isSalesSheetImport;
 
   // State
   const [clientId, setClientId] = useState<number | null>(null);
+  const [linkedNeedId, setLinkedNeedId] = useState<number | null>(null);
   const [items, setItems] = useState<LineItem[]>([]);
   const [adjustment, setAdjustment] = useState<OrderAdjustment | null>(null);
   const [showAdjustmentOnDocument, setShowAdjustmentOnDocument] =
@@ -153,6 +290,10 @@ export default function OrderCreatorPageV2() {
 
   // Referral tracking state (WS-004)
   const [referredByClientId, setReferredByClientId] = useState<number | null>(
+    null
+  );
+  const [activeDraftId, setActiveDraftId] = useState<number | null>(null);
+  const [activeDraftVersion, setActiveDraftVersion] = useState<number | null>(
     null
   );
   const { hasAnyPermission } = usePermissions();
@@ -184,58 +325,100 @@ export default function OrderCreatorPageV2() {
   // before finalization completes
   const isFinalizingRef = useRef(false);
   const itemsRef = useRef<LineItem[]>([]);
+  const hydratedRouteKeyRef = useRef<string | null>(null);
+  const seededRouteKeyRef = useRef<string | null>(null);
+  const previousSearchRef = useRef(searchString);
+  const pendingPersistFingerprintRef = useRef<string | null>(null);
+  const persistedFingerprintRef = useRef(EMPTY_ORDER_FINGERPRINT);
 
-  // TER-215: Import items from Sales Sheet when navigating with ?fromSalesSheet=true
+  const currentOrderSnapshot = useMemo<OrderDraftSnapshot>(
+    () => ({
+      clientId,
+      linkedNeedId,
+      orderType,
+      referredByClientId,
+      adjustment,
+      showAdjustmentOnDocument,
+      items,
+    }),
+    [
+      adjustment,
+      clientId,
+      items,
+      linkedNeedId,
+      orderType,
+      referredByClientId,
+      showAdjustmentOnDocument,
+    ]
+  );
+  const currentOrderFingerprint = useMemo(
+    () => buildOrderFingerprint(currentOrderSnapshot),
+    [currentOrderSnapshot]
+  );
+  const currentOrderFingerprintRef = useRef(currentOrderFingerprint);
   useEffect(() => {
-    const params = new URLSearchParams(searchString);
-    if (params.get("fromSalesSheet") === "true") {
-      try {
-        const raw = sessionStorage.getItem("salesSheetToQuote");
-        if (raw) {
-          const data = JSON.parse(raw) as {
-            clientId: number;
-            items: InventoryItemForOrder[];
-          };
-          setClientId(data.clientId);
-          setOrderType("QUOTE");
-          // Convert will happen after inventory loads, but pre-set client
-          // Items will be added via convertInventoryToLineItems once available
-          const lineItems = convertInventoryToLineItems(data.items);
-          if (lineItems.length > 0) {
-            setItems(lineItems);
-          }
-          sessionStorage.removeItem("salesSheetToQuote");
-        }
-      } catch {
-        toast.error("Failed to import items from sales sheet");
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    currentOrderFingerprintRef.current = currentOrderFingerprint;
+  }, [currentOrderFingerprint]);
+
+  const applyPersistedFingerprint = useCallback(
+    (fingerprint?: string) => {
+      persistedFingerprintRef.current =
+        fingerprint ??
+        pendingPersistFingerprintRef.current ??
+        currentOrderFingerprintRef.current;
+      pendingPersistFingerprintRef.current = null;
+      setSaved();
+    },
+    [setSaved]
+  );
+
+  const resetComposerState = useCallback(() => {
+    setClientId(null);
+    setLinkedNeedId(null);
+    setItems([]);
+    setAdjustment(null);
+    setShowAdjustmentOnDocument(true);
+    setOrderType("SALE");
+    setReferredByClientId(null);
+    setActiveDraftId(null);
+    setActiveDraftVersion(null);
+    hydratedRouteKeyRef.current = null;
+    seededRouteKeyRef.current = null;
+    pendingPersistFingerprintRef.current = null;
+    persistedFingerprintRef.current = EMPTY_ORDER_FINGERPRINT;
+    setSaved();
+  }, [setSaved]);
 
   useEffect(() => {
     if (!clientId) {
       return;
     }
 
-    const params = new URLSearchParams(searchString);
-    const drawerSection = params.get("customerDrawer");
+    const drawerSection = searchParams.get("customerDrawer");
     if (drawerSection === "credit" || drawerSection === "pricing") {
       setCustomerDrawerSection(drawerSection);
       setCustomerDrawerOpen(true);
     }
-  }, [clientId, searchString]);
+  }, [clientId, searchParams]);
 
-  // QA-W2-005: Track unsaved changes - consider both items and auto-save status
-  // Warning should show when there are items OR when auto-save is pending/failed
+  // QA-W2-005: Track unsaved changes using persisted draft state plus active save status.
   useEffect(() => {
-    const hasItems = items.length > 0;
     const autoSavePending =
       saveState.status === "saving" ||
       saveState.status === "error" ||
       saveState.status === "queued";
-    setHasUnsavedChanges(hasItems || autoSavePending);
-  }, [items.length, saveState.status, setHasUnsavedChanges]);
+    const hasSnapshotChanges =
+      currentOrderFingerprint !== persistedFingerprintRef.current;
+    const hasOrderContent =
+      currentOrderFingerprint !== EMPTY_ORDER_FINGERPRINT || activeDraftId !== null;
+
+    setHasUnsavedChanges((hasOrderContent && hasSnapshotChanges) || autoSavePending);
+  }, [
+    activeDraftId,
+    currentOrderFingerprint,
+    saveState.status,
+    setHasUnsavedChanges,
+  ]);
 
   useEffect(() => {
     itemsRef.current = items;
@@ -254,11 +437,171 @@ export default function OrderCreatorPageV2() {
   const clients = Array.isArray(clientsData)
     ? clientsData
     : (clientsData?.items ?? []);
+  const {
+    data: routeOrderData,
+    error: routeOrderError,
+    isLoading: routeOrderLoading,
+  } = trpc.orders.getOrderWithLineItems.useQuery(
+    { orderId: routeOrderId ?? 0 },
+    {
+      enabled: routeOrderId !== null,
+      retry: false,
+      refetchOnWindowFocus: false,
+    }
+  );
   const { data: clientDetails, refetch: refetchClientDetails } =
     trpc.clients.getById.useQuery(
       { clientId: clientId || 0 },
       { enabled: !!clientId }
     );
+
+  useEffect(() => {
+    if (!routeOrderError || routeOrderId === null) {
+      return;
+    }
+
+    const entityLabel = draftIdFromRoute ? "draft" : "quote";
+    toast.error(`Failed to load ${entityLabel}: ${routeOrderError.message}`);
+  }, [draftIdFromRoute, routeOrderError, routeOrderId]);
+
+  useEffect(() => {
+    if (!routeOrderData || routeOrderId === null) {
+      return;
+    }
+
+    const hydrationKey = `${routeOrderId}:${isDuplicateRoute ? "duplicate" : "edit"}`;
+    if (hydratedRouteKeyRef.current === hydrationKey) {
+      return;
+    }
+
+    const draftItems = mapDraftLineItemsToEditorState(
+      routeOrderData.lineItems as DraftLineItemPayload[]
+    );
+    const snapshot: OrderDraftSnapshot = {
+      clientId: routeOrderData.order.clientId,
+      linkedNeedId: routeOrderData.order.clientNeedId ?? null,
+      orderType: routeOrderData.order.orderType,
+      referredByClientId: routeOrderData.order.referredByClientId ?? null,
+      adjustment: null,
+      showAdjustmentOnDocument: true,
+      items: draftItems,
+    };
+
+    setClientId(snapshot.clientId);
+    setLinkedNeedId(snapshot.linkedNeedId);
+    setOrderType(snapshot.orderType);
+    setItems(snapshot.items);
+    setAdjustment(snapshot.adjustment);
+    setShowAdjustmentOnDocument(snapshot.showAdjustmentOnDocument);
+    setReferredByClientId(snapshot.referredByClientId);
+    setActiveDraftId(isDuplicateRoute ? null : routeOrderData.order.id);
+    setActiveDraftVersion(
+      isDuplicateRoute ? null : routeOrderData.order.version ?? 1
+    );
+    hydratedRouteKeyRef.current = hydrationKey;
+    seededRouteKeyRef.current = null;
+    pendingPersistFingerprintRef.current = null;
+    applyPersistedFingerprint(buildOrderFingerprint(snapshot));
+
+    if (isDuplicateRoute) {
+      toast.success(`Quote #${routeOrderData.order.orderNumber} loaded for duplication`);
+    }
+  }, [applyPersistedFingerprint, isDuplicateRoute, routeOrderData, routeOrderId]);
+
+  useEffect(() => {
+    if (
+      routeOrderId !== null ||
+      routeOrderLoading ||
+      isSalesSheetImport ||
+      clientIdFromRoute === null
+    ) {
+      return;
+    }
+
+    const seedKey = `${clientIdFromRoute}:${needIdFromRoute ?? "none"}`;
+    if (seededRouteKeyRef.current === seedKey) {
+      return;
+    }
+
+    setClientId(clientIdFromRoute);
+    setLinkedNeedId(needIdFromRoute);
+    setItems([]);
+    setAdjustment(null);
+    setShowAdjustmentOnDocument(true);
+    setReferredByClientId(null);
+    setActiveDraftId(null);
+    setActiveDraftVersion(null);
+    hydratedRouteKeyRef.current = null;
+    pendingPersistFingerprintRef.current = null;
+    persistedFingerprintRef.current = EMPTY_ORDER_FINGERPRINT;
+    setSaved();
+    setOrderType("SALE");
+    seededRouteKeyRef.current = seedKey;
+  }, [
+    clientIdFromRoute,
+    isSalesSheetImport,
+    needIdFromRoute,
+    routeOrderId,
+    routeOrderLoading,
+    setSaved,
+  ]);
+
+  // TER-215: Import items from Sales Sheet when navigating with ?fromSalesSheet=true
+  useEffect(() => {
+    if (!isSalesSheetImport || routeOrderId !== null) {
+      return;
+    }
+
+    try {
+      const raw = sessionStorage.getItem("salesSheetToQuote");
+      if (!raw) {
+        return;
+      }
+
+      const data = JSON.parse(raw) as {
+        clientId: number;
+        items: InventoryItemForOrder[];
+      };
+      const lineItems = convertInventoryToLineItems(data.items);
+
+      setClientId(data.clientId);
+      setLinkedNeedId(null);
+      setOrderType("QUOTE");
+      setItems(lineItems);
+      setAdjustment(null);
+      setShowAdjustmentOnDocument(true);
+      setReferredByClientId(null);
+      setActiveDraftId(null);
+      setActiveDraftVersion(null);
+      hydratedRouteKeyRef.current = null;
+      pendingPersistFingerprintRef.current = null;
+      persistedFingerprintRef.current = EMPTY_ORDER_FINGERPRINT;
+      setSaved();
+      sessionStorage.removeItem("salesSheetToQuote");
+    } catch {
+      toast.error("Failed to import items from sales sheet");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSalesSheetImport, routeOrderId]);
+
+  useEffect(() => {
+    if (
+      hasRouteSeedContext ||
+      previousSearchRef.current === searchString ||
+      currentOrderFingerprint === EMPTY_ORDER_FINGERPRINT
+    ) {
+      previousSearchRef.current = searchString;
+      return;
+    }
+
+    resetComposerState();
+    previousSearchRef.current = searchString;
+  }, [
+    currentOrderFingerprint,
+    hasRouteSeedContext,
+    resetComposerState,
+    searchString,
+  ]);
 
   // Fetch inventory with pricing when client is selected
   // BUG-045: Use useRetryableQuery to preserve form state on retry
@@ -294,6 +637,39 @@ export default function OrderCreatorPageV2() {
       );
     }
   }, [inventoryError]);
+
+  useEffect(() => {
+    if (!inventory || items.length === 0) {
+      return;
+    }
+
+    const inventoryByBatchId = new Map(
+      inventory.map(item => [item.id, item.productId ?? null])
+    );
+
+    setItems(currentItems => {
+      let changed = false;
+
+      const nextItems = currentItems.map(item => {
+        if (item.productId) {
+          return item;
+        }
+
+        const productId = inventoryByBatchId.get(item.batchId);
+        if (!productId) {
+          return item;
+        }
+
+        changed = true;
+        return {
+          ...item,
+          productId,
+        };
+      });
+
+      return changed ? nextItems : currentItems;
+    });
+  }, [inventory, items.length]);
 
   const openCustomerDrawer = useCallback(
     (
@@ -390,25 +766,84 @@ export default function OrderCreatorPageV2() {
   // Calculations
   const { totals, warnings, isValid } = useOrderCalculations(items, adjustment);
 
+  const buildDraftMutationPayload = useCallback(
+    (effectiveOrderType: "QUOTE" | "SALE" = orderType) => ({
+      orderType: effectiveOrderType,
+      clientId: clientId as number,
+      clientNeedId: linkedNeedId ?? undefined,
+      referredByClientId: referredByClientId ?? undefined,
+      lineItems: items.map(item => ({
+        batchId: item.batchId,
+        productDisplayName: item.productDisplayName,
+        quantity: item.quantity,
+        cogsPerUnit: item.cogsPerUnit,
+        isCogsOverridden: item.isCogsOverridden,
+        cogsOverrideReason: item.cogsOverrideReason,
+        marginPercent: item.marginPercent,
+        isMarginOverridden: item.isMarginOverridden,
+        marginSource: item.marginSource,
+        isSample: item.isSample,
+      })),
+      orderLevelAdjustment: adjustment || undefined,
+      showAdjustmentOnDocument,
+    }),
+    [
+      adjustment,
+      clientId,
+      items,
+      linkedNeedId,
+      orderType,
+      referredByClientId,
+      showAdjustmentOnDocument,
+    ]
+  );
+
   // Mutations
   // BUG-093 FIX: Modified to support two-step finalization
   const createDraftMutation = trpc.orders.createDraftEnhanced.useMutation({
     onSuccess: data => {
+      const nextVersion = data.version ?? 1;
+
+      setActiveDraftId(data.orderId);
+      setActiveDraftVersion(nextVersion);
+      applyPersistedFingerprint();
+
       if (isFinalizingRef.current) {
-        // We're in finalization mode - proceed to finalize the draft
-        // Don't reset form yet - wait for finalization to complete
         toast.info(`Draft #${data.orderId} created, finalizing...`);
-        // BUG-045 FIX: Pass version 1 for newly created drafts (optimistic locking)
-        finalizeMutation.mutate({ orderId: data.orderId, version: 1 });
-      } else {
-        // Keep the user in the create workspace after draft save for low-friction edits.
-        toast.success(`Draft order #${data.orderId} saved successfully`);
-        setHasUnsavedChanges(false);
-        setLocation(`/orders/create?draftId=${data.orderId}`);
+        finalizeMutation.mutate({ orderId: data.orderId, version: nextVersion });
+        return;
       }
+
+      toast.success(`Draft order #${data.orderId} saved successfully`);
+      setLocation(
+        buildSalesWorkspacePath("create-order", { draftId: data.orderId })
+      );
     },
     onError: error => {
-      // Reset finalization flag on error
+      pendingPersistFingerprintRef.current = null;
+      isFinalizingRef.current = false;
+      toast.error(`Failed to save draft: ${error.message}`);
+    },
+  });
+
+  const updateDraftMutation = trpc.orders.updateDraftEnhanced.useMutation({
+    onSuccess: data => {
+      setActiveDraftId(data.orderId);
+      setActiveDraftVersion(data.version);
+      applyPersistedFingerprint();
+
+      if (isFinalizingRef.current) {
+        finalizeMutation.mutate({
+          orderId: data.orderId,
+          version: data.version,
+        });
+        return;
+      }
+
+      toast.success(`Draft order #${data.orderId} saved successfully`);
+    },
+    onError: error => {
+      pendingPersistFingerprintRef.current = null;
       isFinalizingRef.current = false;
       toast.error(`Failed to save draft: ${error.message}`);
     },
@@ -420,11 +855,12 @@ export default function OrderCreatorPageV2() {
       isFinalizingRef.current = false;
       toast.success(`Order #${data.orderNumber} finalized successfully!`);
       // Keep creators in-place after finalize for quick follow-up edits/orders.
-      setHasUnsavedChanges(false);
-      setLocation("/orders/create");
+      resetComposerState();
+      setLocation(buildSalesWorkspacePath("create-order"));
     },
     onError: error => {
       // BUG-093 FIX: Reset flag on error, but preserve form data so user can retry
+      pendingPersistFingerprintRef.current = null;
       isFinalizingRef.current = false;
       toast.error(`Failed to finalize order: ${error.message}`);
     },
@@ -434,45 +870,42 @@ export default function OrderCreatorPageV2() {
   const creditCheckMutation = trpc.credit.checkOrderCredit.useMutation();
 
   // Auto-save mutation (silent, no toast notifications)
-  const autoSaveMutation = trpc.orders.createDraftEnhanced.useMutation({
-    onSuccess: () => {
-      setSaved();
+  const autoSaveMutation = trpc.orders.updateDraftEnhanced.useMutation({
+    onSuccess: data => {
+      setActiveDraftVersion(data.version);
+      applyPersistedFingerprint();
     },
     onError: error => {
+      pendingPersistFingerprintRef.current = null;
       setError("Auto-save failed", error);
     },
   });
 
   // CHAOS-025: Debounced auto-save callback (2 second delay)
   const performAutoSave = useCallback(() => {
-    if (!clientId || items.length === 0) {
+    if (
+      !clientId ||
+      items.length === 0 ||
+      activeDraftId === null ||
+      activeDraftVersion === null
+    ) {
       return;
     }
 
+    pendingPersistFingerprintRef.current = currentOrderFingerprintRef.current;
     setSaving();
     autoSaveMutation.mutate({
-      orderType,
-      clientId,
-      lineItems: items.map(item => ({
-        batchId: item.batchId,
-        quantity: item.quantity,
-        cogsPerUnit: item.cogsPerUnit,
-        isCogsOverridden: item.isCogsOverridden,
-        cogsOverrideReason: item.cogsOverrideReason,
-        marginPercent: item.marginPercent,
-        isMarginOverridden: item.isMarginOverridden,
-        marginSource: item.marginSource,
-      })),
-      orderLevelAdjustment: adjustment || undefined,
-      showAdjustmentOnDocument,
+      orderId: activeDraftId,
+      version: activeDraftVersion,
+      ...buildDraftMutationPayload(),
     });
   }, [
-    clientId,
-    items,
-    orderType,
-    adjustment,
-    showAdjustmentOnDocument,
+    activeDraftId,
+    activeDraftVersion,
     autoSaveMutation,
+    buildDraftMutationPayload,
+    clientId,
+    items.length,
     setSaving,
   ]);
 
@@ -480,15 +913,21 @@ export default function OrderCreatorPageV2() {
 
   // CHAOS-025: Trigger auto-save when order state changes
   useEffect(() => {
-    if (clientId && items.length > 0) {
+    if (
+      clientId &&
+      items.length > 0 &&
+      activeDraftId !== null &&
+      activeDraftVersion !== null &&
+      currentOrderFingerprint !== persistedFingerprintRef.current
+    ) {
       debouncedAutoSave();
     }
   }, [
+    activeDraftId,
+    activeDraftVersion,
     clientId,
-    items,
-    orderType,
-    adjustment,
-    showAdjustmentOnDocument,
+    currentOrderFingerprint,
+    items.length,
     debouncedAutoSave,
   ]);
 
@@ -526,22 +965,19 @@ export default function OrderCreatorPageV2() {
       return;
     }
 
-    createDraftMutation.mutate({
-      orderType: effectiveOrderType,
-      clientId: clientId as number,
-      lineItems: items.map(item => ({
-        batchId: item.batchId,
-        quantity: item.quantity,
-        cogsPerUnit: item.cogsPerUnit,
-        isCogsOverridden: item.isCogsOverridden,
-        cogsOverrideReason: item.cogsOverrideReason,
-        marginPercent: item.marginPercent,
-        isMarginOverridden: item.isMarginOverridden,
-        marginSource: item.marginSource,
-      })),
-      orderLevelAdjustment: adjustment || undefined,
-      showAdjustmentOnDocument,
-    });
+    pendingPersistFingerprintRef.current = currentOrderFingerprintRef.current;
+    setSaving();
+
+    if (activeDraftId !== null && activeDraftVersion !== null) {
+      updateDraftMutation.mutate({
+        orderId: activeDraftId,
+        version: activeDraftVersion,
+        ...buildDraftMutationPayload(effectiveOrderType),
+      });
+      return;
+    }
+
+    createDraftMutation.mutate(buildDraftMutationPayload(effectiveOrderType));
   };
 
   const handlePreviewAndFinalize = async () => {
@@ -602,24 +1038,19 @@ export default function OrderCreatorPageV2() {
     // BUG-093 FIX: Set finalization mode BEFORE calling createDraftMutation
     // This ensures the onSuccess handler knows to call finalizeMutation
     isFinalizingRef.current = true;
+    pendingPersistFingerprintRef.current = currentOrderFingerprintRef.current;
+    setSaving();
 
-    // First create the draft - finalization will happen in onSuccess callback
-    createDraftMutation.mutate({
-      orderType,
-      clientId,
-      lineItems: items.map(item => ({
-        batchId: item.batchId,
-        quantity: item.quantity,
-        cogsPerUnit: item.cogsPerUnit,
-        isCogsOverridden: item.isCogsOverridden,
-        cogsOverrideReason: item.cogsOverrideReason,
-        marginPercent: item.marginPercent,
-        isMarginOverridden: item.isMarginOverridden,
-        marginSource: item.marginSource,
-      })),
-      orderLevelAdjustment: adjustment || undefined,
-      showAdjustmentOnDocument,
-    });
+    if (activeDraftId !== null && activeDraftVersion !== null) {
+      updateDraftMutation.mutate({
+        orderId: activeDraftId,
+        version: activeDraftVersion,
+        ...buildDraftMutationPayload(),
+      });
+      return;
+    }
+
+    createDraftMutation.mutate(buildDraftMutationPayload());
   };
 
   // Convert inventory items to LineItem format
@@ -827,36 +1258,30 @@ export default function OrderCreatorPageV2() {
         {...keyboard.keyboardProps}
         className="container mx-auto p-3 md:p-4 space-y-4"
       >
-        <BackButton label="Back to Orders" to="/orders" className="mb-4" />
-        <section className="linear-workspace-shell">
-          <header className="linear-workspace-header">
-            <div className="linear-workspace-title-wrap">
-              <p className="linear-workspace-eyebrow">
-                <span className="linear-workspace-eyebrow-section">Sell</span>
-                <span className="linear-workspace-eyebrow-sep" aria-hidden>
-                  {" "}
-                  /{" "}
-                </span>
-                Order Workspace
+        <section className="rounded-xl border border-border/70 bg-card shadow-sm">
+          <div className="flex flex-col gap-4 border-b border-border/70 px-4 py-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h2 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
+                <ShoppingCart className="h-5 w-5" />
+                Create Sales Order
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Build the order, review margin, then save or finalize without
+                leaving the sales workspace.
               </p>
-              <div>
-                <h2 className="linear-workspace-title flex items-center gap-2">
-                  <ShoppingCart className="h-5 w-5" />
-                  Create Sales Order
-                </h2>
-                <p className="linear-workspace-description">
-                  Build sales order with COGS visibility and margin management
-                </p>
-              </div>
             </div>
             <div className="flex items-center gap-2">
-              {clientId && items.length > 0 ? SaveStateIndicator : null}
+              {clientId &&
+              items.length > 0 &&
+              (activeDraftId !== null || saveState.status !== "saved")
+                ? SaveStateIndicator
+                : null}
             </div>
-          </header>
+          </div>
 
-          <div className="linear-workspace-meta">
+          <div className="grid gap-4 border-b border-border/70 bg-muted/20 px-4 py-4 md:grid-cols-2">
             <div className="flex min-w-[260px] flex-1 flex-col gap-1">
-              <span className="linear-workspace-meta-label flex items-center gap-1">
+              <span className="flex items-center gap-1 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
                 Customer
                 {clientFieldState.showSuccess ? (
                   <CheckCircle className="h-3.5 w-3.5 text-emerald-600" />
@@ -900,7 +1325,9 @@ export default function OrderCreatorPageV2() {
             </div>
 
             <div className="flex min-w-[260px] flex-1 flex-col gap-1">
-              <span className="linear-workspace-meta-label">Referred By</span>
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                Referred By
+              </span>
               {clientId ? (
                 <ReferredBySelector
                   excludeClientId={clientId}
@@ -915,7 +1342,7 @@ export default function OrderCreatorPageV2() {
             </div>
           </div>
 
-          <div className="linear-workspace-content">
+          <div className="p-4">
             {clientId ? (
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                 {/* Left Column: Inventory Browser & Line Items & Adjustment (2/3) */}

--- a/client/src/pages/PricingRulesPage.tsx
+++ b/client/src/pages/PricingRulesPage.tsx
@@ -47,6 +47,12 @@ import {
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
+  EmptyState,
+  ErrorState,
+  NoSearchResults,
+} from "@/components/ui/empty-state";
+import { PageLoading } from "@/components/ui/loading-state";
+import {
   Plus,
   Edit,
   Trash,
@@ -101,7 +107,12 @@ export default function PricingRulesPage() {
   >(null);
 
   // Fetch pricing rules
-  const { data: rules, isLoading } = trpc.pricing.listRules.useQuery();
+  const {
+    data: rules,
+    isLoading,
+    error: rulesError,
+    refetch: refetchRules,
+  } = trpc.pricing.listRules.useQuery();
 
   // BUG-097 FIX: Use standardized error handling
   // Create mutation
@@ -394,9 +405,20 @@ export default function PricingRulesPage() {
   );
 
   if (isLoading) {
+    return <PageLoading message="Loading pricing rules..." />;
+  }
+
+  if (rulesError) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <p className="text-muted-foreground">Loading pricing rules...</p>
+      <div className="container mx-auto p-4 md:p-6 space-y-6">
+        <BackButton label="Back to Dashboard" to="/" className="mb-4" />
+        <ErrorState
+          title="Unable to load pricing rules"
+          description={rulesError.message}
+          onRetry={() => {
+            void refetchRules();
+          }}
+        />
       </div>
     );
   }
@@ -448,11 +470,24 @@ export default function PricingRulesPage() {
               <TableBody>
                 {filteredRules.length === 0 ? (
                   <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      className="text-center text-muted-foreground"
-                    >
-                      No pricing rules found. Create one to get started.
+                    <TableCell colSpan={7} className="p-0">
+                      {search ? (
+                        <NoSearchResults
+                          searchTerm={search}
+                          onClear={() => setSearch("")}
+                        />
+                      ) : (
+                        <EmptyState
+                          variant="reports"
+                          size="sm"
+                          title="No pricing rules yet"
+                          description="Create a rule to standardize markups, markdowns, and conditional pricing."
+                          action={{
+                            label: "Create Rule",
+                            onClick: () => setCreateDialogOpen(true),
+                          }}
+                        />
+                      )}
                     </TableCell>
                   </TableRow>
                 ) : (

--- a/client/src/pages/ProcurementWorkspacePage.tsx
+++ b/client/src/pages/ProcurementWorkspacePage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import {
   LinearWorkspacePanel,
   LinearWorkspaceShell,
@@ -20,7 +19,7 @@ type ProcurementTab =
 const PROCUREMENT_TABS = [
   { value: "purchase-orders", label: "Purchase Orders" },
   { value: "product-intake", label: "Product Intake" },
-  { value: "receiving", label: "PO Intake" },
+  { value: "receiving", label: "Receiving" },
   { value: "inventory-browse", label: "Inventory Browse" },
 ] as const satisfies readonly LinearWorkspaceTab<ProcurementTab>[];
 
@@ -52,38 +51,6 @@ export default function ProcurementWorkspacePage() {
             activeTab,
         },
       ]}
-      commandStrip={
-        <>
-          <Button
-            size="sm"
-            variant={activeTab === "purchase-orders" ? "default" : "outline"}
-            onClick={() => setActiveTab("purchase-orders")}
-          >
-            Purchase Orders
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "product-intake" ? "default" : "outline"}
-            onClick={() => setActiveTab("product-intake")}
-          >
-            Product Intake
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "inventory-browse" ? "default" : "outline"}
-            onClick={() => setActiveTab("inventory-browse")}
-          >
-            Inventory Browse
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "receiving" ? "default" : "outline"}
-            onClick={() => setActiveTab("receiving")}
-          >
-            PO Intake
-          </Button>
-        </>
-      }
     >
       <LinearWorkspacePanel value="purchase-orders">
         <PurchaseOrdersWorkSurface />

--- a/client/src/pages/SalesSheetCreatorPage.tsx
+++ b/client/src/pages/SalesSheetCreatorPage.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import {
   Card,
   CardContent,
@@ -502,7 +503,11 @@ export default function SalesSheetCreatorPage() {
                           })),
                         })
                       );
-                      setLocation("/orders/create?fromSalesSheet=true");
+                      setLocation(
+                        buildSalesWorkspacePath("create-order", {
+                          fromSalesSheet: true,
+                        })
+                      );
                     }}
                   >
                     <ArrowRight className="h-4 w-4 mr-2" />

--- a/client/src/pages/SalesWorkspacePage.tsx
+++ b/client/src/pages/SalesWorkspacePage.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import OrdersWorkSurface from "@/components/work-surface/OrdersWorkSurface";
 import QuotesWorkSurface from "@/components/work-surface/QuotesWorkSurface";
 import PickPackWorkSurface from "@/components/work-surface/PickPackWorkSurface";
@@ -43,38 +42,7 @@ export default function SalesWorkspacePage() {
       onTabChange={tab => setActiveTab(tab)}
       meta={[
         { label: "Primary flow", value: "Quote -> Order -> Fulfillment" },
-        {
-          label: "Current view",
-          value:
-            SALES_TABS_CONFIG.find(tab => tab.value === activeTab)?.label ??
-            activeTab,
-        },
       ]}
-      commandStrip={
-        <>
-          <Button
-            size="sm"
-            variant={activeTab === "create-order" ? "default" : "outline"}
-            onClick={() => setActiveTab("create-order")}
-          >
-            New Sales Order
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "quotes" ? "default" : "outline"}
-            onClick={() => setActiveTab("quotes")}
-          >
-            Jump to Quotes
-          </Button>
-          <Button
-            size="sm"
-            variant={activeTab === "pick-pack" ? "default" : "ghost"}
-            onClick={() => setActiveTab("pick-pack")}
-          >
-            Pick & Pack
-          </Button>
-        </>
-      }
     >
       <LinearWorkspacePanel value="orders">
         <OrdersWorkSurface />

--- a/client/src/pages/WorkflowQueuePage.tsx
+++ b/client/src/pages/WorkflowQueuePage.tsx
@@ -7,7 +7,7 @@
  * Initiative: 1.3 Workflow Queue Management
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Settings, History, BarChart3, Plus } from "lucide-react";
@@ -26,6 +26,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { EmptyState, ErrorState } from "@/components/ui/empty-state";
+import { LoadingState, PageLoading } from "@/components/ui/loading-state";
 import {
   Select,
   SelectContent,
@@ -35,30 +37,61 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
+import { useSearch } from "wouter";
 
 type ViewMode = "board" | "settings" | "history" | "analytics";
 
 export default function WorkflowQueuePage() {
+  const search = useSearch();
   const [viewMode, setViewMode] = useState<ViewMode>("board");
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [batchSearch, setBatchSearch] = useState("");
-  const [selectedBatchIds, setSelectedBatchIds] = useState<Set<number>>(new Set());
+  const [selectedBatchIds, setSelectedBatchIds] = useState<Set<number>>(
+    new Set()
+  );
   const [selectedStatusId, setSelectedStatusId] = useState<number | null>(null);
 
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const requestedView = params.get("view");
+
+    if (
+      requestedView === "board" ||
+      requestedView === "settings" ||
+      requestedView === "history" ||
+      requestedView === "analytics"
+    ) {
+      setViewMode(requestedView);
+    }
+  }, [search]);
+
   // Fetch workflow statuses
-  const { data: statuses, isLoading: statusesLoading } =
+  const {
+    data: statuses,
+    isLoading: statusesLoading,
+    error: statusesError,
+    refetch: refetchStatuses,
+  } =
     trpc.workflowQueue.listStatuses.useQuery();
 
   // Fetch batches grouped by status
-  const { data: queues, isLoading: queuesLoading, refetch: refetchQueues } =
-    trpc.workflowQueue.getQueues.useQuery();
+  const {
+    data: queues,
+    isLoading: queuesLoading,
+    error: queuesError,
+    refetch: refetchQueues,
+  } = trpc.workflowQueue.getQueues.useQuery();
 
   // Fetch batches not in queue
-  const { data: batchesNotInQueue, isLoading: batchesLoading } =
-    trpc.workflowQueue.getBatchesNotInQueue.useQuery(
-      { limit: 50, query: batchSearch || undefined },
-      { enabled: isAddDialogOpen }
-    );
+  const {
+    data: batchesNotInQueue,
+    isLoading: batchesLoading,
+    error: batchesError,
+    refetch: refetchAvailableBatches,
+  } = trpc.workflowQueue.getBatchesNotInQueue.useQuery(
+    { limit: 50, query: batchSearch || undefined },
+    { enabled: isAddDialogOpen }
+  );
 
   // Add batches to queue mutation
   const addBatchesMutation = trpc.workflowQueue.addBatchesToQueue.useMutation({
@@ -76,6 +109,7 @@ export default function WorkflowQueuePage() {
   });
 
   const isLoading = statusesLoading || queuesLoading;
+  const pageError = statusesError ?? queuesError;
 
   const handleToggleBatch = (batchId: number) => {
     const newSelected = new Set(selectedBatchIds);
@@ -104,12 +138,20 @@ export default function WorkflowQueuePage() {
   };
 
   if (isLoading) {
+    return <PageLoading message="Loading workflow queue..." />;
+  }
+
+  if (pageError) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading workflow queue...</p>
-        </div>
+      <div className="container mx-auto p-4 md:p-6 space-y-6">
+        <BackButton label="Back to Dashboard" to="/" />
+        <ErrorState
+          title="Unable to load workflow queue"
+          description={pageError.message}
+          onRetry={() => {
+            void Promise.all([refetchStatuses(), refetchQueues()]);
+          }}
+        />
       </div>
     );
   }
@@ -235,9 +277,19 @@ export default function WorkflowQueuePage() {
               <Label>Select Batches ({selectedBatchIds.size} selected)</Label>
               <div className="mt-2 border rounded-lg max-h-96 overflow-y-auto">
                 {batchesLoading ? (
-                  <div className="p-4 text-center text-muted-foreground">
-                    Loading batches...
-                  </div>
+                  <LoadingState
+                    size="sm"
+                    className="py-8"
+                    message="Loading available batches..."
+                  />
+                ) : batchesError ? (
+                  <ErrorState
+                    title="Unable to load available batches"
+                    description={batchesError.message}
+                    onRetry={() => {
+                      void refetchAvailableBatches();
+                    }}
+                  />
                 ) : batchesNotInQueue && batchesNotInQueue.length > 0 ? (
                   <div className="divide-y">
                     {batchesNotInQueue.map((batch) => (
@@ -262,9 +314,25 @@ export default function WorkflowQueuePage() {
                     ))}
                   </div>
                 ) : (
-                  <div className="p-4 text-center text-muted-foreground">
-                    {batchSearch ? "No batches found matching search" : "All batches are already in the workflow queue"}
-                  </div>
+                  <EmptyState
+                    size="sm"
+                    variant="inventory"
+                    title="No batches available to add"
+                    description={
+                      batchSearch
+                        ? "Try a broader search or clear the search field."
+                        : "All eligible batches are already in the workflow queue."
+                    }
+                    action={
+                      batchSearch
+                        ? {
+                            label: "Clear Search",
+                            onClick: () => setBatchSearch(""),
+                            variant: "outline",
+                          }
+                        : undefined
+                    }
+                  />
                 )}
               </div>
             </div>

--- a/server/db/queries/workflow-queue.ts
+++ b/server/db/queries/workflow-queue.ts
@@ -13,11 +13,39 @@ import {
   workflowStatuses, 
   batchStatusHistory, 
   batches,
+  products,
   type WorkflowStatus,
   type InsertWorkflowStatus,
   type BatchStatusHistory,
 } from "../../../drizzle/schema";
 import { eq, desc, asc, sql } from "drizzle-orm";
+
+export interface WorkflowQueueBatch {
+  [key: string]: string | number | Date | null;
+  id: number;
+  code: string;
+  sku: string;
+  statusId: number | null;
+  batchStatus: string;
+  status: string;
+  strain: string | null;
+  onHandQty: string;
+  quantity: string;
+  updatedAt: Date;
+}
+
+const workflowQueueBatchSelection = {
+  id: batches.id,
+  code: batches.code,
+  sku: batches.sku,
+  statusId: batches.statusId,
+  batchStatus: batches.batchStatus,
+  status: batches.batchStatus,
+  strain: products.nameCanonical,
+  onHandQty: batches.onHandQty,
+  quantity: batches.onHandQty,
+  updatedAt: batches.updatedAt,
+};
 
 // ============================================================================
 // WORKFLOW STATUS QUERIES
@@ -149,19 +177,20 @@ export async function reorderStatuses(statusIds: number[]): Promise<void> {
  * Get all batches grouped by workflow status
  */
 export async function getBatchesByStatus(): Promise<
-  Record<number, Array<typeof batches.$inferSelect>>
+  Record<number, WorkflowQueueBatch[]>
 > {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
   
   const allBatches = await db
-    .select()
+    .select(workflowQueueBatchSelection)
     .from(batches)
+    .leftJoin(products, eq(batches.productId, products.id))
     .where(sql`${batches.statusId} IS NOT NULL`)
     .orderBy(desc(batches.updatedAt));
   
   // Group by statusId
-  const grouped: Record<number, Array<typeof batches.$inferSelect>> = {};
+  const grouped: Record<number, WorkflowQueueBatch[]> = {};
   
   for (const batch of allBatches) {
     if (batch.statusId) {
@@ -180,13 +209,14 @@ export async function getBatchesByStatus(): Promise<
  */
 export async function getBatchesByStatusId(
   statusId: number
-): Promise<Array<typeof batches.$inferSelect>> {
+): Promise<WorkflowQueueBatch[]> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
   
   return db
-    .select()
+    .select(workflowQueueBatchSelection)
     .from(batches)
+    .leftJoin(products, eq(batches.productId, products.id))
     .where(eq(batches.statusId, statusId))
     .orderBy(desc(batches.updatedAt));
 }
@@ -205,7 +235,7 @@ export async function updateBatchStatus(
   
   // Get current status
   const batch = await db
-    .select()
+    .select({ statusId: batches.statusId })
     .from(batches)
     .where(eq(batches.id, batchId))
     .limit(1);
@@ -292,13 +322,14 @@ export async function getStatusChangesByUser(
 export async function getBatchesNotInQueue(
   limit: number = 50,
   query?: string
-): Promise<Array<typeof batches.$inferSelect>> {
+): Promise<WorkflowQueueBatch[]> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
   
   let batchQuery = db
-    .select()
+    .select(workflowQueueBatchSelection)
     .from(batches)
+    .leftJoin(products, eq(batches.productId, products.id))
     .where(sql`${batches.statusId} IS NULL`)
     .orderBy(desc(batches.createdAt))
     .limit(limit);
@@ -307,10 +338,11 @@ export async function getBatchesNotInQueue(
   if (query) {
     const searchTerm = `%${query}%`;
     batchQuery = db
-      .select()
+      .select(workflowQueueBatchSelection)
       .from(batches)
+      .leftJoin(products, eq(batches.productId, products.id))
       .where(
-        sql`${batches.statusId} IS NULL AND (${batches.sku} LIKE ${searchTerm} OR ${batches.code} LIKE ${searchTerm})`
+        sql`${batches.statusId} IS NULL AND (${batches.sku} LIKE ${searchTerm} OR ${batches.code} LIKE ${searchTerm} OR ${products.nameCanonical} LIKE ${searchTerm})`
       )
       .orderBy(desc(batches.createdAt))
       .limit(limit) as typeof batchQuery;

--- a/server/inventoryDb.ts
+++ b/server/inventoryDb.ts
@@ -5,6 +5,7 @@
 
 import { eq, and, or, like, desc, asc, sql, isNull } from "drizzle-orm";
 import { safeInArray } from "./lib/sqlSafety";
+import { hasPhotographyCompleteFlagColumn } from "./lib/photographyCompleteCompatibility";
 import { getDb } from "./db";
 import { AppError } from "./_core/errors";
 import cache, { CacheKeys, CacheTTL } from "./_core/cache";
@@ -48,6 +49,52 @@ const safeProductSelect = {
   createdAt: products.createdAt,
   updatedAt: products.updatedAt,
 };
+
+async function getCompatibleBatchSelect() {
+  const hasPhotographyFlag = await hasPhotographyCompleteFlagColumn();
+  const isPhotographyCompleteSelect = hasPhotographyFlag
+    ? batches.isPhotographyComplete
+    : sql<boolean>`CASE
+        WHEN ${batches.batchStatus} = 'PHOTOGRAPHY_COMPLETE' THEN true
+        ELSE false
+      END`.as("isPhotographyComplete");
+
+  return {
+    id: batches.id,
+    code: batches.code,
+    deletedAt: batches.deletedAt,
+    version: batches.version,
+    sku: batches.sku,
+    productId: batches.productId,
+    lotId: batches.lotId,
+    batchStatus: batches.batchStatus,
+    isPhotographyComplete: isPhotographyCompleteSelect,
+    statusId: batches.statusId,
+    grade: batches.grade,
+    isSample: batches.isSample,
+    sampleOnly: batches.sampleOnly,
+    sampleAvailable: batches.sampleAvailable,
+    cogsMode: batches.cogsMode,
+    unitCogs: batches.unitCogs,
+    unitCogsMin: batches.unitCogsMin,
+    unitCogsMax: batches.unitCogsMax,
+    paymentTerms: batches.paymentTerms,
+    ownershipType: batches.ownershipType,
+    amountPaid: batches.amountPaid,
+    metadata: batches.metadata,
+    photoSessionEventId: batches.photoSessionEventId,
+    onHandQty: batches.onHandQty,
+    sampleQty: batches.sampleQty,
+    reservedQty: batches.reservedQty,
+    quarantineQty: batches.quarantineQty,
+    holdQty: batches.holdQty,
+    defectiveQty: batches.defectiveQty,
+    publishEcom: batches.publishEcom,
+    publishB2b: batches.publishB2b,
+    createdAt: batches.createdAt,
+    updatedAt: batches.updatedAt,
+  };
+}
 
 // ============================================================================
 // VENDOR QUERIES (DEPRECATED - Use Supplier functions below)
@@ -918,6 +965,7 @@ export async function getBatchesWithDetails(
   if (!db) return { items: [], nextCursor: null, hasMore: false };
 
   const applyPagination = options?.applyPagination !== false;
+  const batchSelect = await getCompatibleBatchSelect();
 
   // Build where conditions
   const conditions = [];
@@ -1038,7 +1086,7 @@ export async function getBatchesWithDetails(
   // Join batches with products, brands, lots, and canonical supplier client
   const baseQuery = db
     .select({
-      batch: batches,
+      batch: batchSelect,
       product: safeProductSelect,
       brand: brands,
       lot: lots,
@@ -1078,6 +1126,7 @@ export async function searchBatches(
 ) {
   const db = await getDb();
   if (!db) return { items: [], nextCursor: null, hasMore: false };
+  const batchSelect = await getCompatibleBatchSelect();
 
   // Build where conditions
   // BUG-098 FIX: Also search in clients.name for canonical supplier data
@@ -1101,7 +1150,7 @@ export async function searchBatches(
   // BUG-122: Removed deprecated vendor field - use supplierClient instead
   const result = await db
     .select({
-      batch: batches,
+      batch: batchSelect,
       product: safeProductSelect,
       brand: brands,
       lot: lots,
@@ -2114,7 +2163,11 @@ export async function calculateBatchProfitability(batchId: number) {
 
   // Get batch details
   const [batch] = await db
-    .select()
+    .select({
+      id: batches.id,
+      unitCogs: batches.unitCogs,
+      onHandQty: batches.onHandQty,
+    })
     .from(batches)
     .where(eq(batches.id, batchId));
   if (!batch) throw new Error("Batch not found");
@@ -2193,7 +2246,13 @@ export async function getTopProfitableBatches(limit: number = 10) {
   if (!db) throw new Error("Database not available");
 
   // Get all batches
-  const allBatches = await db.select().from(batches);
+  const allBatches = await db
+    .select({
+      id: batches.id,
+      sku: batches.sku,
+      batchStatus: batches.batchStatus,
+    })
+    .from(batches);
 
   // Calculate profitability for each and collect results
   const results = [];
@@ -2312,11 +2371,12 @@ export async function getProfitabilitySummary() {
 export async function getBatchesBySupplier(supplierClientId: number) {
   const db = await getDb();
   if (!db) return [];
+  const batchSelect = await getCompatibleBatchSelect();
 
   // INV-PARTY-001: Join batches → lots → filter by supplierClientId (party model)
   const result = await db
     .select({
-      batch: batches,
+      batch: batchSelect,
       lot: lots,
       product: safeProductSelect,
       brand: brands,

--- a/server/lib/fulfillmentStatusCompatibility.ts
+++ b/server/lib/fulfillmentStatusCompatibility.ts
@@ -1,0 +1,130 @@
+import { logger } from "../_core/logger";
+import { getDb } from "../db";
+import { orderStatusHistory, orders } from "../../drizzle/schema";
+
+type FulfillmentStatusStorageTable = "orders" | "order_status_history";
+type ReadyForPackingStorageStatus = "READY_FOR_PACKING" | "PENDING";
+type OrderFulfillmentStatusValue = typeof orders.$inferInsert.fulfillmentStatus;
+type OrderStatusHistoryFulfillmentStatusValue =
+  typeof orderStatusHistory.$inferInsert.fulfillmentStatus;
+
+const readyStatusCache = new Map<
+  FulfillmentStatusStorageTable,
+  ReadyForPackingStorageStatus
+>();
+const readyStatusPromiseCache = new Map<
+  FulfillmentStatusStorageTable,
+  Promise<ReadyForPackingStorageStatus>
+>();
+
+async function detectReadyForPackingStorageStatus(
+  tableName: FulfillmentStatusStorageTable
+): Promise<ReadyForPackingStorageStatus> {
+  const db = await getDb();
+  if (!db) {
+    return "READY_FOR_PACKING";
+  }
+
+  try {
+    const [rows] = await db.execute(
+      `SELECT COLUMN_TYPE
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = '${tableName}'
+         AND COLUMN_NAME = 'fulfillmentStatus'
+       LIMIT 1`
+    );
+
+    const columnType =
+      ((Array.isArray(rows) ? rows[0] : undefined) as
+        | { COLUMN_TYPE?: string }
+        | undefined)
+        ?.COLUMN_TYPE ?? "";
+
+    if (columnType.includes("'READY_FOR_PACKING'")) {
+      return "READY_FOR_PACKING";
+    }
+
+    if (columnType.includes("'PENDING'")) {
+      logger.info(
+        { tableName, columnType },
+        "Legacy fulfillment status enum detected; mapping READY_FOR_PACKING to PENDING"
+      );
+      return "PENDING";
+    }
+  } catch (error) {
+    logger.warn(
+      { error, tableName },
+      "Failed to inspect fulfillment status enum; defaulting to READY_FOR_PACKING"
+    );
+  }
+
+  return "READY_FOR_PACKING";
+}
+
+async function getReadyForPackingStorageStatus(
+  tableName: FulfillmentStatusStorageTable
+): Promise<ReadyForPackingStorageStatus> {
+  const cached = readyStatusCache.get(tableName);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = readyStatusPromiseCache.get(tableName);
+  if (pending) {
+    return pending;
+  }
+
+  const detectionPromise = detectReadyForPackingStorageStatus(tableName)
+    .then(status => {
+      readyStatusCache.set(tableName, status);
+      readyStatusPromiseCache.delete(tableName);
+      return status;
+    })
+    .catch(error => {
+      readyStatusPromiseCache.delete(tableName);
+      throw error;
+    });
+
+  readyStatusPromiseCache.set(tableName, detectionPromise);
+  return detectionPromise;
+}
+
+export async function getStoredFulfillmentStatus(
+  status: string,
+  tableName: FulfillmentStatusStorageTable = "orders"
+): Promise<string> {
+  if (status !== "READY_FOR_PACKING") {
+    return status;
+  }
+
+  return await getReadyForPackingStorageStatus(tableName);
+}
+
+export function normalizeFulfillmentStatus(
+  status: string | null | undefined
+): string | null | undefined {
+  if (status === "PENDING") {
+    return "READY_FOR_PACKING";
+  }
+
+  return status;
+}
+
+export function isReadyForPackingLikeStatus(
+  status: string | null | undefined
+): boolean {
+  return normalizeFulfillmentStatus(status) === "READY_FOR_PACKING";
+}
+
+export function coerceOrderFulfillmentStatus(
+  status: string
+): OrderFulfillmentStatusValue {
+  return status as unknown as OrderFulfillmentStatusValue;
+}
+
+export function coerceOrderStatusHistoryFulfillmentStatus(
+  status: string
+): OrderStatusHistoryFulfillmentStatusValue {
+  return status as unknown as OrderStatusHistoryFulfillmentStatusValue;
+}

--- a/server/lib/photographyCompleteCompatibility.test.ts
+++ b/server/lib/photographyCompleteCompatibility.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../db", () => ({
+  getDb: mocks.mockGetDb,
+}));
+
+vi.mock("../_core/logger", () => ({
+  logger: mocks.logger,
+}));
+
+describe("hasPhotographyCompleteFlagColumn", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.mockGetDb.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.logger.warn.mockReset();
+  });
+
+  it("returns true when the photography flag column exists", async () => {
+    mocks.mockGetDb.mockResolvedValue({
+      execute: vi.fn().mockResolvedValue([[{ present: 1 }]]),
+    });
+
+    const { hasPhotographyCompleteFlagColumn } = await import(
+      "./photographyCompleteCompatibility"
+    );
+
+    await expect(hasPhotographyCompleteFlagColumn()).resolves.toBe(true);
+    expect(mocks.logger.info).not.toHaveBeenCalled();
+  });
+
+  it("returns false when running against a legacy batches schema", async () => {
+    mocks.mockGetDb.mockResolvedValue({
+      execute: vi.fn().mockResolvedValue([[]]),
+    });
+
+    const { hasPhotographyCompleteFlagColumn } = await import(
+      "./photographyCompleteCompatibility"
+    );
+
+    await expect(hasPhotographyCompleteFlagColumn()).resolves.toBe(false);
+    expect(mocks.logger.info).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/lib/photographyCompleteCompatibility.ts
+++ b/server/lib/photographyCompleteCompatibility.ts
@@ -1,0 +1,61 @@
+import { logger } from "../_core/logger";
+import { getDb } from "../db";
+
+let photographyFlagColumnExists: boolean | undefined;
+let photographyFlagColumnPromise: Promise<boolean> | undefined;
+
+async function detectPhotographyFlagColumn(): Promise<boolean> {
+  const db = await getDb();
+  if (!db) {
+    return true;
+  }
+
+  try {
+    const [rows] = await db.execute(
+      `SELECT 1 AS present
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = 'batches'
+         AND COLUMN_NAME = 'isPhotographyComplete'
+       LIMIT 1`
+    );
+
+    const hasColumn = Array.isArray(rows) && rows.length > 0;
+    if (!hasColumn) {
+      logger.info(
+        "Legacy batch schema detected; synthesizing isPhotographyComplete from batchStatus"
+      );
+    }
+
+    return hasColumn;
+  } catch (error) {
+    logger.warn(
+      { error },
+      "Failed to inspect batch photography flag column; assuming modern schema"
+    );
+    return true;
+  }
+}
+
+export async function hasPhotographyCompleteFlagColumn(): Promise<boolean> {
+  if (photographyFlagColumnExists !== undefined) {
+    return photographyFlagColumnExists;
+  }
+
+  if (photographyFlagColumnPromise) {
+    return photographyFlagColumnPromise;
+  }
+
+  photographyFlagColumnPromise = detectPhotographyFlagColumn()
+    .then(hasColumn => {
+      photographyFlagColumnExists = hasColumn;
+      photographyFlagColumnPromise = undefined;
+      return hasColumn;
+    })
+    .catch(error => {
+      photographyFlagColumnPromise = undefined;
+      throw error;
+    });
+
+  return photographyFlagColumnPromise;
+}

--- a/server/matchingEngineEnhanced.ts
+++ b/server/matchingEngineEnhanced.ts
@@ -89,6 +89,26 @@ export interface MatchResult {
   matches: Match[];
 }
 
+const matchingBatchSelection = {
+  id: batches.id,
+  code: batches.code,
+  sku: batches.sku,
+  grade: batches.grade,
+  cogsMode: batches.cogsMode,
+  unitCogs: batches.unitCogs,
+  unitCogsMin: batches.unitCogsMin,
+  unitCogsMax: batches.unitCogsMax,
+  onHandQty: batches.onHandQty,
+};
+
+const matchingProductSelection = {
+  id: products.id,
+  nameCanonical: products.nameCanonical,
+  category: products.category,
+  subcategory: products.subcategory,
+  strainId: products.strainId,
+};
+
 /**
  * Calculate match confidence based on field matches
  * Enhanced version with quantity and price validation
@@ -353,8 +373,8 @@ async function calculateMatchConfidence(
 async function getBatchWithProduct(db: any, batchId: number) {
   const [batch] = await db
     .select({
-      batch: batches,
-      product: products,
+      batch: matchingBatchSelection,
+      product: matchingProductSelection,
     })
     .from(batches)
     .leftJoin(products, eq(batches.productId, products.id))
@@ -437,8 +457,8 @@ export async function findMatchesForNeed(needId: number): Promise<MatchResult> {
     // 1. Check inventory (batches with available quantity) - ENHANCED
     const inventoryResults = await db
       .select({
-        batch: batches,
-        product: products,
+        batch: matchingBatchSelection,
+        product: matchingProductSelection,
       })
       .from(batches)
       .leftJoin(products, eq(batches.productId, products.id))

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -24,6 +24,13 @@ import {
 } from "./services/orderAccountingService";
 import { syncClientBalance } from "./services/clientBalanceService";
 import { calculateAvailableQty } from "./inventoryUtils";
+import {
+  coerceOrderFulfillmentStatus,
+  coerceOrderStatusHistoryFulfillmentStatus,
+  getStoredFulfillmentStatus,
+  isReadyForPackingLikeStatus,
+  normalizeFulfillmentStatus,
+} from "./lib/fulfillmentStatusCompatibility";
 // MEET-005: Import payables service for tracking vendor payables when inventory is sold
 import * as payablesService from "./services/payablesService";
 // ST-053: Import DbTransaction type for proper typing
@@ -103,6 +110,15 @@ export interface ConvertQuoteToSaleInput {
     | "CONSIGNMENT";
   cashPayment?: number;
   notes?: string;
+}
+
+function normalizeOrderRecord<T extends { fulfillmentStatus?: string | null }>(
+  order: T
+): T {
+  return {
+    ...order,
+    fulfillmentStatus: normalizeFulfillmentStatus(order.fulfillmentStatus),
+  };
 }
 
 // ============================================================================
@@ -292,6 +308,10 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
       dueDate = calculateDueDate(input.paymentTerms);
     }
 
+    const readyForPackingStatus = !isDraft
+      ? await getStoredFulfillmentStatus("READY_FOR_PACKING")
+      : undefined;
+
     // 7. Create order record
     await tx.insert(orders).values({
       orderNumber,
@@ -313,7 +333,9 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
       dueDate: dueDate,
       saleStatus:
         !isDraft && input.orderType === "SALE" ? "PENDING" : undefined,
-      fulfillmentStatus: !isDraft ? "READY_FOR_PACKING" : undefined,
+      fulfillmentStatus: readyForPackingStatus
+        ? coerceOrderFulfillmentStatus(readyForPackingStatus)
+        : undefined,
       notes: input.notes,
       createdBy: actorId,
     });
@@ -403,7 +425,7 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
       throw new Error("Failed to create order");
     }
 
-    return order;
+    return normalizeOrderRecord(order) as Order;
   });
 }
 
@@ -445,7 +467,7 @@ export async function getOrderById(id: number): Promise<Order | null> {
   }
 
   return {
-    ...order,
+    ...normalizeOrderRecord(order),
     items: parsedItems,
   } as Order;
 }
@@ -499,7 +521,7 @@ export async function getOrdersByClient(
       }
     }
     return {
-      ...order,
+      ...normalizeOrderRecord(order),
       items: parsedItems,
     };
   }) as Order[];
@@ -546,7 +568,7 @@ export async function getAllOrders(filters?: {
   const normalizedFulfillmentStatus =
     normalizeOptionalStatus(fulfillmentStatus);
 
-  const conditions: ReturnType<typeof eq>[] = [];
+  const conditions: SQL<unknown>[] = [];
 
   if (orderType) {
     conditions.push(eq(orders.orderType, orderType));
@@ -627,12 +649,21 @@ export async function getAllOrders(filters?: {
         normalizedFulfillmentStatus as (typeof validFulfillmentStatuses)[number]
       )
     ) {
-      conditions.push(
-        eq(
-          orders.fulfillmentStatus,
-          normalizedFulfillmentStatus as (typeof validFulfillmentStatuses)[number]
-        )
-      );
+      if (normalizedFulfillmentStatus === "READY_FOR_PACKING") {
+        conditions.push(
+          safeInArray(orders.fulfillmentStatus, [
+            "READY_FOR_PACKING",
+            "PENDING",
+          ])
+        );
+      } else {
+        conditions.push(
+          eq(
+            orders.fulfillmentStatus,
+            normalizedFulfillmentStatus as (typeof validFulfillmentStatuses)[number]
+          )
+        );
+      }
     }
   }
 
@@ -692,7 +723,7 @@ export async function getAllOrders(filters?: {
     }
 
     return {
-      ...row.orders,
+      ...normalizeOrderRecord(row.orders),
       items: parsedItems,
       client: row.clients,
     } as Order;
@@ -1285,6 +1316,8 @@ export async function confirmDraftOrder(input: {
     const total = parseFloat(draft.total as string);
     const saleStatus =
       cashPayment >= total ? "PAID" : cashPayment > 0 ? "PARTIAL" : "PENDING";
+    const readyForPackingStatus =
+      await getStoredFulfillmentStatus("READY_FOR_PACKING");
 
     // 6. Update order to confirmed
     await tx
@@ -1296,7 +1329,9 @@ export async function confirmDraftOrder(input: {
         cashPayment: cashPayment.toString(),
         dueDate: dueDate,
         saleStatus: saleStatus,
-        fulfillmentStatus: "READY_FOR_PACKING",
+        fulfillmentStatus: coerceOrderFulfillmentStatus(
+          readyForPackingStatus
+        ),
         notes: input.notes || draft.notes,
         confirmedAt: new Date(),
       })
@@ -1764,7 +1799,9 @@ export async function updateOrderStatus(input: {
       );
     }
 
-    const oldStatus = order.fulfillmentStatus || "READY_FOR_PACKING";
+    const oldStatus =
+      normalizeFulfillmentStatus(order.fulfillmentStatus) ??
+      "READY_FOR_PACKING";
 
     // TERP-0016: Validate status transition using state machine
     if (!isValidStatusTransition("fulfillment", oldStatus, newStatus)) {
@@ -1772,8 +1809,9 @@ export async function updateOrderStatus(input: {
     }
 
     // Prepare update data
+    const storedNewStatus = await getStoredFulfillmentStatus(newStatus);
     const updateData: Record<string, unknown> = {
-      fulfillmentStatus: newStatus,
+      fulfillmentStatus: coerceOrderFulfillmentStatus(storedNewStatus),
     };
     if (newStatus === "PACKED") {
       updateData.packedAt = new Date();
@@ -1882,7 +1920,7 @@ export async function updateOrderStatus(input: {
 
     // TER-258: Handle CANCELLED — restore reserved inventory
     if (newStatus === "CANCELLED") {
-      if (oldStatus === "PACKED" || oldStatus === "READY_FOR_PACKING") {
+      if (oldStatus === "PACKED" || isReadyForPackingLikeStatus(oldStatus)) {
         // When cancelling a PACKED or READY_FOR_PACKING order, release the reserved quantities
         // for each item. TER-259 reserves inventory at creation/confirmation time,
         // so both READY_FOR_PACKING and PACKED orders may have active reservations.
@@ -1921,20 +1959,15 @@ export async function updateOrderStatus(input: {
 
     // Log status change in history
     const { orderStatusHistory } = await import("../drizzle/schema");
-    const validStatus:
-      | "READY_FOR_PACKING"
-      | "PACKED"
-      | "SHIPPED"
-      | "CANCELLED" =
-      newStatus === "READY_FOR_PACKING" ||
-      newStatus === "PACKED" ||
-      newStatus === "SHIPPED" ||
-      newStatus === "CANCELLED"
-        ? newStatus
-        : "READY_FOR_PACKING";
+    const storedHistoryStatus = await getStoredFulfillmentStatus(
+      newStatus,
+      "order_status_history"
+    );
     await tx.insert(orderStatusHistory).values({
       orderId,
-      fulfillmentStatus: validStatus,
+      fulfillmentStatus: coerceOrderStatusHistoryFulfillmentStatus(
+        storedHistoryStatus
+      ),
       changedBy: userId,
       notes: sanitizedNotes,
     });
@@ -1956,7 +1989,7 @@ export async function getOrderStatusHistory(orderId: number) {
   if (!db) throw new Error("Database not available");
   const { orderStatusHistory, users } = await import("../drizzle/schema");
 
-  return await db
+  const history = await db
     .select({
       id: orderStatusHistory.id,
       orderId: orderStatusHistory.orderId,
@@ -1970,6 +2003,11 @@ export async function getOrderStatusHistory(orderId: number) {
     .leftJoin(users, eq(orderStatusHistory.changedBy, users.id))
     .where(eq(orderStatusHistory.orderId, orderId))
     .orderBy(orderStatusHistory.changedAt);
+
+  return history.map(entry => ({
+    ...entry,
+    fulfillmentStatus: normalizeFulfillmentStatus(entry.fulfillmentStatus),
+  }));
 }
 
 // ============================================================================

--- a/server/routers/matchingEnhanced.ts
+++ b/server/routers/matchingEnhanced.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
+import { inArray } from "drizzle-orm";
 import { protectedProcedure, router } from "../_core/trpc";
 import { requirePermission } from "../_core/permissionMiddleware";
 import * as matchingEngine from "../matchingEngineEnhanced";
 import * as historicalAnalysis from "../historicalAnalysis";
+import { getDb } from "../db";
+import { clients } from "../../drizzle/schema";
 
 /**
  * Matching Router (Enhanced Version)
@@ -161,6 +164,28 @@ export const matchingEnhancedRouter = router({
     .query(async () => {
       try {
         const results = await matchingEngine.getAllActiveNeedsWithMatches();
+        const db = await getDb();
+        const clientNameMap = new Map<number, string>();
+
+        if (db) {
+          const clientIds = Array.from(
+            new Set(results.map(result => result.clientId))
+          );
+
+          if (clientIds.length > 0) {
+            const clientRows = await db
+              .select({
+                id: clients.id,
+                name: clients.name,
+              })
+              .from(clients)
+              .where(inArray(clients.id, clientIds));
+
+            for (const client of clientRows) {
+              clientNameMap.set(client.id, client.name);
+            }
+          }
+        }
 
         // Helper to safely extract client name from sourceData
         const getClientName = (
@@ -209,10 +234,9 @@ export const matchingEnhancedRouter = router({
           result.matches.map(match => ({
             clientNeedId: result.clientNeedId ?? 0,
             clientId: result.clientId,
-            clientName: getClientName(
-              match.sourceData,
-              `Client ${result.clientId}`
-            ),
+            clientName:
+              clientNameMap.get(result.clientId) ||
+              getClientName(match.sourceData, `Client ${result.clientId}`),
             strain: getStrain(match.sourceData),
             priority:
               match.type === "EXACT"

--- a/server/routers/orders.ts
+++ b/server/routers/orders.ts
@@ -45,6 +45,11 @@ import { cogsChangeIntegrationService } from "../services/cogsChangeIntegrationS
 import { createSafeUnifiedResponse } from "../_core/pagination";
 import { withTransaction, withRetryableTransaction } from "../dbTransaction";
 import { logger } from "../_core/logger";
+import {
+  coerceOrderFulfillmentStatus,
+  getStoredFulfillmentStatus,
+  normalizeFulfillmentStatus,
+} from "../lib/fulfillmentStatusCompatibility";
 
 // ============================================================================
 // BUG-502: In-memory rate limiting for confirm endpoint
@@ -114,6 +119,8 @@ const orderAdjustmentSchema = z.object({
 const createOrderInputSchema = z.object({
   orderType: z.enum(["QUOTE", "SALE"]),
   clientId: z.number(),
+  clientNeedId: z.number().optional(),
+  referredByClientId: z.number().optional(),
   lineItems: z
     .array(lineItemInputSchema)
     .min(1, "At least one line item is required"),
@@ -432,13 +439,16 @@ export const ordersRouter = router({
 
         // BUG-414: Check fulfillment status allows confirmation
         const nonConfirmableStatuses = ["SHIPPED", "DELIVERED", "RETURNED"];
+        const normalizedFulfillmentStatus = normalizeFulfillmentStatus(
+          order.fulfillmentStatus
+        );
         if (
-          order.fulfillmentStatus &&
-          nonConfirmableStatuses.includes(order.fulfillmentStatus)
+          normalizedFulfillmentStatus &&
+          nonConfirmableStatuses.includes(normalizedFulfillmentStatus)
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: `Cannot confirm order with fulfillment status: ${order.fulfillmentStatus}`,
+            message: `Cannot confirm order with fulfillment status: ${normalizedFulfillmentStatus}`,
           });
         }
 
@@ -767,6 +777,11 @@ export const ordersRouter = router({
           // Get batch info for COGS
           const batch = await db.query.batches.findFirst({
             where: eq(batches.id, item.batchId),
+            columns: {
+              id: true,
+              productId: true,
+              unitCogs: true,
+            },
           });
 
           if (!batch) {
@@ -871,7 +886,10 @@ export const ordersRouter = router({
         orderNumber,
         orderType: input.orderType,
         clientId: input.clientId,
+        clientNeedId: input.clientNeedId ?? null,
         isDraft: true,
+        referredByClientId: input.referredByClientId ?? null,
+        isReferralOrder: Boolean(input.referredByClientId),
         items: JSON.stringify(
           lineItemsWithPrices.map(item => ({
             batchId: item.batchId,
@@ -926,6 +944,7 @@ export const ordersRouter = router({
       return {
         orderId,
         orderNumber,
+        version: 1,
         totals,
         validation,
       };
@@ -937,15 +956,9 @@ export const ordersRouter = router({
   updateDraftEnhanced: protectedProcedure
     .use(requirePermission("orders:update"))
     .input(
-      z.object({
+      createOrderInputSchema.extend({
         orderId: z.number(),
         version: z.number(), // Optimistic locking
-        lineItems: z
-          .array(lineItemInputSchema)
-          .min(1, "At least one line item is required"),
-        orderLevelAdjustment: orderAdjustmentSchema.optional(),
-        showAdjustmentOnDocument: z.boolean().optional(),
-        notes: z.string().optional(),
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -967,11 +980,37 @@ export const ordersRouter = router({
         throw new Error("Order not found");
       }
 
+      const client = await db
+        .select({ id: clients.id, deletedAt: clients.deletedAt })
+        .from(clients)
+        .where(eq(clients.id, input.clientId))
+        .limit(1)
+        .then(rows => rows[0]);
+
+      if (!client) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Client ${input.clientId} not found`,
+        });
+      }
+
+      if (client.deletedAt !== null) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Cannot update order for archived client ${input.clientId}`,
+        });
+      }
+
       // Calculate line item prices (same logic as createDraftEnhanced)
       const lineItemsWithPrices = await Promise.all(
         input.lineItems.map(async item => {
           const batch = await db.query.batches.findFirst({
             where: eq(batches.id, item.batchId),
+            columns: {
+              id: true,
+              productId: true,
+              unitCogs: true,
+            },
           });
 
           if (!batch) {
@@ -1001,7 +1040,7 @@ export const ordersRouter = router({
             // BUG-086 FIX: Use actual product category, not hardcoded "OTHER"
             const productCategory = product?.category || "OTHER";
             const marginResult = await pricingService.getMarginWithFallback(
-              existingOrder.clientId,
+              input.clientId,
               productCategory
             );
 
@@ -1052,8 +1091,8 @@ export const ordersRouter = router({
 
       // Validate order
       const validation = orderValidationService.validateOrder({
-        orderType: existingOrder.orderType as "QUOTE" | "SALE",
-        clientId: existingOrder.clientId,
+        orderType: input.orderType,
+        clientId: input.clientId,
         lineItems: lineItemsWithPrices.map(item => ({
           batchId: item.batchId,
           quantity: item.quantity,
@@ -1068,15 +1107,34 @@ export const ordersRouter = router({
 
       // ST-026: Update order with line items in transaction to prevent orphaned records
       const { sql } = await import("drizzle-orm");
+      const resolvedPaymentTerms =
+        input.paymentTerms || existingOrder.paymentTerms || "NET_30";
+      const nextVersion = existingOrder.version + 1;
       await withTransaction(async tx => {
         // Update order with version increment
         await tx
           .update(orders)
           .set({
+            orderType: input.orderType,
+            clientId: input.clientId,
+            clientNeedId: input.clientNeedId ?? null,
+            referredByClientId: input.referredByClientId ?? null,
+            isReferralOrder: Boolean(input.referredByClientId),
+            items: JSON.stringify(
+              lineItemsWithPrices.map(item => ({
+                batchId: item.batchId,
+                quantity: item.quantity,
+                unitPrice: item.unitPrice,
+                isSample: item.isSample,
+              }))
+            ),
             total: totals.finalTotal.toString(),
             subtotal: totals.subtotal.toString(),
             avgMarginPercent: totals.avgMarginPercent.toString(),
             notes: input.notes,
+            validUntil: input.validUntil ? new Date(input.validUntil) : null,
+            paymentTerms: resolvedPaymentTerms,
+            cashPayment: input.cashPayment?.toString() || null,
             version: sql`version + 1`,
           })
           .where(eq(orders.id, input.orderId));
@@ -1118,6 +1176,7 @@ export const ordersRouter = router({
 
       return {
         orderId: input.orderId,
+        version: nextVersion,
         totals,
         validation,
       };
@@ -1188,7 +1247,15 @@ export const ordersRouter = router({
           // INV-003: Extract unique batch IDs and lock all batches
           const batchIds = [...new Set(lineItems.map(item => item.batchId))];
           const batchRecords = await tx
-            .select()
+            .select({
+              id: batches.id,
+              sku: batches.sku,
+              onHandQty: batches.onHandQty,
+              reservedQty: batches.reservedQty,
+              quarantineQty: batches.quarantineQty,
+              holdQty: batches.holdQty,
+              sampleQty: batches.sampleQty,
+            })
             .from(batches)
             .where(safeInArray(batches.id, batchIds))
             .for("update");
@@ -1270,13 +1337,18 @@ export const ordersRouter = router({
             }
           }
 
+          const readyForPackingStatus =
+            await getStoredFulfillmentStatus("READY_FOR_PACKING");
+
           // ST-026: Update order to finalized with version increment
           await tx
             .update(orders)
             .set({
               isDraft: false,
               confirmedAt: new Date(),
-              fulfillmentStatus: "READY_FOR_PACKING",
+              fulfillmentStatus: coerceOrderFulfillmentStatus(
+                readyForPackingStatus
+              ),
               version: sqlFn`version + 1`,
             })
             .where(eq(orders.id, input.orderId));
@@ -1321,13 +1393,44 @@ export const ordersRouter = router({
         throw new Error("Order not found");
       }
 
+      const normalizedOrder = {
+        ...order,
+        fulfillmentStatus: normalizeFulfillmentStatus(order.fulfillmentStatus),
+      };
+
       const lineItems = await db.query.orderLineItems.findMany({
         where: eq(orderLineItems.orderId, input.orderId),
       });
 
+      const batchIds = Array.from(new Set(lineItems.map(item => item.batchId)));
+      const batchMetadata =
+        batchIds.length > 0
+          ? await db
+              .select({
+                id: batches.id,
+                productId: batches.productId,
+                batchSku: batches.sku,
+              })
+              .from(batches)
+              .where(safeInArray(batches.id, batchIds))
+          : [];
+      const batchMetadataById = new Map(
+        batchMetadata.map(batch => [
+          batch.id,
+          {
+            productId: batch.productId,
+            batchSku: batch.batchSku,
+          },
+        ])
+      );
+
       return {
-        order,
-        lineItems,
+        order: normalizedOrder,
+        lineItems: lineItems.map(lineItem => ({
+          ...lineItem,
+          productId: batchMetadataById.get(lineItem.batchId)?.productId ?? null,
+          batchSku: batchMetadataById.get(lineItem.batchId)?.batchSku ?? null,
+        })),
       };
     }),
 
@@ -1689,11 +1792,12 @@ export const ordersRouter = router({
 
           if (
             order.saleStatus !== "PENDING" &&
-            order.fulfillmentStatus !== "READY_FOR_PACKING"
+            normalizeFulfillmentStatus(order.fulfillmentStatus) !==
+              "READY_FOR_PACKING"
           ) {
             throw new TRPCError({
               code: "BAD_REQUEST",
-              message: `Order cannot be confirmed. Current status: ${order.saleStatus || order.fulfillmentStatus}`,
+              message: `Order cannot be confirmed. Current status: ${order.saleStatus || normalizeFulfillmentStatus(order.fulfillmentStatus) || order.fulfillmentStatus}`,
             });
           }
 
@@ -1786,12 +1890,17 @@ export const ordersRouter = router({
             }
           }
 
+          const readyForPackingStatus =
+            await getStoredFulfillmentStatus("READY_FOR_PACKING");
+
           // Update order to confirmed
           await tx
             .update(orders)
             .set({
               confirmedAt: new Date(),
-              fulfillmentStatus: "READY_FOR_PACKING",
+              fulfillmentStatus: coerceOrderFulfillmentStatus(
+                readyForPackingStatus
+              ),
               notes: input.notes
                 ? `${order.notes || ""}\n[Confirmed]: ${input.notes}`.trim()
                 : order.notes,
@@ -1889,7 +1998,11 @@ export const ordersRouter = router({
         // ARCH-003: Use state machine for transition validation
         const { validateTransition } =
           await import("../services/orderStateMachine");
-        validateTransition(order.fulfillmentStatus, "SHIPPED", input.id);
+        validateTransition(
+          normalizeFulfillmentStatus(order.fulfillmentStatus) ?? null,
+          "SHIPPED",
+          input.id
+        );
 
         // INV-001: Get all line items for this order
         const lineItems = await tx
@@ -2071,7 +2184,11 @@ export const ordersRouter = router({
         // ARCH-003: Use state machine for transition validation
         const { validateTransition } =
           await import("../services/orderStateMachine");
-        validateTransition(order.fulfillmentStatus, "DELIVERED", input.id);
+        validateTransition(
+          normalizeFulfillmentStatus(order.fulfillmentStatus) ?? null,
+          "DELIVERED",
+          input.id
+        );
 
         // Build delivery notes
         let deliveryNotes = `Delivered: ${input.deliveredAt || new Date().toISOString()}\n`;
@@ -2139,7 +2256,7 @@ export const ordersRouter = router({
           await import("../services/orderStateMachine");
         try {
           validateTransition(
-            order.fulfillmentStatus,
+            normalizeFulfillmentStatus(order.fulfillmentStatus) ?? null,
             "RETURNED",
             input.orderId
           );
@@ -2261,9 +2378,12 @@ export const ordersRouter = router({
       }
 
       const batchIdList = Array.from(batchIds);
+      const normalizedOrderStatus = normalizeFulfillmentStatus(
+        order.fulfillmentStatus
+      );
       if (batchIdList.length === 0) {
         return {
-          orderStatus: order.fulfillmentStatus,
+          orderStatus: normalizedOrderStatus,
           items: [] as Array<{ id: number; label: string }>,
         };
       }
@@ -2276,7 +2396,7 @@ export const ordersRouter = router({
       const lotIds = Array.from(new Set(batchRows.map(batch => batch.lotId)));
       if (lotIds.length === 0) {
         return {
-          orderStatus: order.fulfillmentStatus,
+          orderStatus: normalizedOrderStatus,
           items: [] as Array<{ id: number; label: string }>,
         };
       }
@@ -2298,7 +2418,7 @@ export const ordersRouter = router({
       const vendorIdList = Array.from(vendorIds);
       if (vendorIdList.length === 0) {
         return {
-          orderStatus: order.fulfillmentStatus,
+          orderStatus: normalizedOrderStatus,
           items: [] as Array<{ id: number; label: string }>,
         };
       }
@@ -2309,7 +2429,7 @@ export const ordersRouter = router({
         .where(safeInArray(clients.id, vendorIdList));
 
       return {
-        orderStatus: order.fulfillmentStatus,
+        orderStatus: normalizedOrderStatus,
         items: vendorRows.map(vendor => ({
           id: vendor.id,
           label: vendor.name || `Vendor #${vendor.id}`,
@@ -2341,7 +2461,8 @@ export const ordersRouter = router({
       const { getNextStatuses, STATUS_LABELS } =
         await import("../services/orderStateMachine");
       const nextStatuses = getNextStatuses(
-        order.fulfillmentStatus || "READY_FOR_PACKING"
+        normalizeFulfillmentStatus(order.fulfillmentStatus) ??
+          "READY_FOR_PACKING"
       );
 
       return nextStatuses.map(status => ({
@@ -2398,10 +2519,13 @@ export const ordersRouter = router({
 
         // Only allow allocation for draft orders or orders awaiting fulfillment
         const editableStatuses = ["DRAFT", "READY_FOR_PACKING", "CONFIRMED"];
-        if (!editableStatuses.includes(order.fulfillmentStatus || "")) {
+        const normalizedFulfillmentStatus = normalizeFulfillmentStatus(
+          order.fulfillmentStatus
+        );
+        if (!editableStatuses.includes(normalizedFulfillmentStatus || "")) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: `Cannot allocate batches for order in ${order.fulfillmentStatus} status`,
+            message: `Cannot allocate batches for order in ${normalizedFulfillmentStatus || order.fulfillmentStatus} status`,
           });
         }
 

--- a/server/routers/referrals.ts
+++ b/server/routers/referrals.ts
@@ -10,6 +10,7 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
+import { logger } from "../_core/logger";
 import {
   clients,
   orders,
@@ -23,29 +24,41 @@ export const referralsRouter = router({
    * Get referral settings (global and per-tier)
    */
   getSettings: adminProcedure.query(async () => {
-    const settings = await db
-      .select()
-      .from(referralCreditSettings)
-      .where(eq(referralCreditSettings.isActive, true))
-      .orderBy(referralCreditSettings.clientTier);
+    try {
+      const settings = await db
+        .select()
+        .from(referralCreditSettings)
+        .where(eq(referralCreditSettings.isActive, true))
+        .orderBy(referralCreditSettings.clientTier);
 
-    const globalSetting = settings.find(s => s.clientTier === null);
-    const tierSettings = settings.filter(s => s.clientTier !== null);
+      const globalSetting = settings.find(s => s.clientTier === null);
+      const tierSettings = settings.filter(s => s.clientTier !== null);
 
-    return {
-      globalPercentage: globalSetting
-        ? parseFloat(globalSetting.creditPercentage)
-        : 10.0,
-      tierSettings: tierSettings.map(s => ({
-        tier: s.clientTier,
-        percentage: parseFloat(s.creditPercentage),
-        minOrderAmount: s.minOrderAmount ? parseFloat(s.minOrderAmount) : 0,
-        maxCreditAmount: s.maxCreditAmount
-          ? parseFloat(s.maxCreditAmount)
-          : null,
-        creditExpiryDays: s.creditExpiryDays,
-      })),
-    };
+      return {
+        globalPercentage: globalSetting
+          ? parseFloat(globalSetting.creditPercentage)
+          : 10.0,
+        tierSettings: tierSettings.map(s => ({
+          tier: s.clientTier,
+          percentage: parseFloat(s.creditPercentage),
+          minOrderAmount: s.minOrderAmount ? parseFloat(s.minOrderAmount) : 0,
+          maxCreditAmount: s.maxCreditAmount
+            ? parseFloat(s.maxCreditAmount)
+            : null,
+          creditExpiryDays: s.creditExpiryDays,
+        })),
+      };
+    } catch (error) {
+      logger.warn(
+        { error, context: "referrals.getSettings" },
+        "Referral settings unavailable, using default settings"
+      );
+
+      return {
+        globalPercentage: 10.0,
+        tierSettings: [],
+      };
+    }
   }),
 
   /**

--- a/server/salesSheetsDb.ts
+++ b/server/salesSheetsDb.ts
@@ -102,10 +102,18 @@ export async function getInventoryWithPricing(
     // SCHEMA-015: Removed strainId and vendors joins - columns don't exist in production
     // Use clients table for supplier data via supplierClientId
     let inventoryWithDetails: Array<{
-      batch: typeof batches.$inferSelect;
-      product: typeof products.$inferSelect | null;
-      lot: typeof lots.$inferSelect | null;
-      supplier: typeof clients.$inferSelect | null;
+      batchId: number;
+      batchSku: string;
+      batchProductId: number;
+      batchStatus: string;
+      batchGrade: string | null;
+      batchUnitCogs: string | null;
+      batchOnHandQty: string;
+      productId: number | null;
+      productName: string | null;
+      productCategory: string | null;
+      productSubcategory: string | null;
+      supplierName: string | null;
     }>;
 
     try {
@@ -113,10 +121,18 @@ export async function getInventoryWithPricing(
       // Status is included in the response for display and filtering on frontend
       inventoryWithDetails = await db
         .select({
-          batch: batches,
-          product: products,
-          lot: lots,
-          supplier: clients,
+          batchId: batches.id,
+          batchSku: batches.sku,
+          batchProductId: batches.productId,
+          batchStatus: batches.batchStatus,
+          batchGrade: batches.grade,
+          batchUnitCogs: batches.unitCogs,
+          batchOnHandQty: batches.onHandQty,
+          productId: products.id,
+          productName: products.nameCanonical,
+          productCategory: products.category,
+          productSubcategory: products.subcategory,
+          supplierName: clients.name,
         })
         .from(batches)
         .leftJoin(products, eq(batches.productId, products.id))
@@ -143,9 +159,17 @@ export async function getInventoryWithPricing(
       // Fallback query without joins in case of other schema issues
       const fallbackResults = await db
         .select({
-          batch: batches,
-          product: products,
-          lot: lots,
+          batchId: batches.id,
+          batchSku: batches.sku,
+          batchProductId: batches.productId,
+          batchStatus: batches.batchStatus,
+          batchGrade: batches.grade,
+          batchUnitCogs: batches.unitCogs,
+          batchOnHandQty: batches.onHandQty,
+          productId: products.id,
+          productName: products.nameCanonical,
+          productCategory: products.category,
+          productSubcategory: products.subcategory,
         })
         .from(batches)
         .leftJoin(products, eq(batches.productId, products.id))
@@ -162,7 +186,7 @@ export async function getInventoryWithPricing(
       // Map fallback results to expected format with null supplier
       inventoryWithDetails = fallbackResults.map(row => ({
         ...row,
-        supplier: null,
+        supplierName: null,
       }));
     }
 
@@ -203,18 +227,18 @@ export async function getInventoryWithPricing(
     // INV-CONSISTENCY-002: Include status for display/filtering
     // SCHEMA-015: Updated to use supplier instead of vendor, removed strain fields
     const inventoryItems = inventoryWithDetails
-      .filter(({ batch }) => batch !== null && batch !== undefined)
-      .map(({ batch, product, supplier }) => ({
-        id: batch.id,
-        productId: product?.id || undefined, // WSQA-002: Include productId for flexible lot selection
-        name: product?.nameCanonical || batch.sku || `Batch #${batch.id}`,
-        category: product?.category || undefined,
-        subcategory: product?.subcategory || undefined,
-        basePrice: parseNumber(batch.unitCogs, 0),
-        quantity: parseNumber(batch.onHandQty, 0),
-        grade: batch.grade || undefined,
-        vendor: supplier?.name || undefined, // Keep 'vendor' key name for backward compatibility
-        status: batch.batchStatus || undefined,
+      .filter(row => row.batchId !== null && row.batchId !== undefined)
+      .map(row => ({
+        id: row.batchId,
+        productId: row.productId || row.batchProductId || undefined, // WSQA-002: Include productId for flexible lot selection
+        name: row.productName || row.batchSku || `Batch #${row.batchId}`,
+        category: row.productCategory || undefined,
+        subcategory: row.productSubcategory || undefined,
+        basePrice: parseNumber(row.batchUnitCogs, 0),
+        quantity: parseNumber(row.batchOnHandQty, 0),
+        grade: row.batchGrade || undefined,
+        vendor: row.supplierName || undefined, // Keep 'vendor' key name for backward compatibility
+        status: row.batchStatus || undefined,
       }));
 
     // Calculate retail prices using pricing engine with error handling


### PR DESCRIPTION
## Summary
- simplify the primary workspace shells and reduce navigation noise across sales, procurement, inventory, and accounting
- harden sales create-order routing, draft hydration, save/finalize behavior, and linked create actions so simplified flows still preserve business logic
- add legacy-schema compatibility for fulfillment status and batch photography flags so live QA environments without the newest columns/enums still load correctly

## Validation
- pnpm check
- pnpm lint
- pnpm build
- pnpm test
- live QA on http://127.0.0.1:3015 covering sales, procurement, and inventory primary create flows plus draft finalize/hydration paths