### PR TITLE
fix(docs): correct k6 profile path in TESTING.md

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -154,8 +154,9 @@ pnpm qa:stress:soak          # Long-duration soak test
 pnpm qa:stress               # Full orchestrated run
 ```
 
-k6 profiles: `tests/stress/*.k6.js`
+k6 profile: `scripts/stress/staging-mixed-traffic.k6.js`
 Orchestrator: `scripts/stress/run-stress-testing.sh`
+Profiles config: `scripts/stress/profiles.json`
 
 **Stress contract (from CLAUDE.md):**
 


### PR DESCRIPTION
Fix stale reference in docs/TESTING.md — k6 files in tests/stress/ were removed in PR #466, update to canonical path at scripts/stress/staging-mixed-traffic.k6.js.

https://claude.ai/code/session_01HuVC7FXzKze4KoALx2pYN9