### PR TITLE
fix(procurement): recover po workflow and receiving range cogs

### DIFF
--- a/client/src/components/uiux-slice/ProductIntakeSlicePage.tsx
+++ b/client/src/components/uiux-slice/ProductIntakeSlicePage.tsx
@@ -1268,7 +1268,7 @@ export function ProductIntakeSlicePage() {
       <div className="px-6 py-4 border-b">
         <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
           <Package className="h-6 w-6" />
-          Product Intake
+          Receiving
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
           Review to Receive with inline QA gating and correction actions.
@@ -1281,7 +1281,7 @@ export function ProductIntakeSlicePage() {
           onValueChange={value => setSelectedDraftId(value)}
         >
           <SelectTrigger className="w-[300px]">
-            <SelectValue placeholder="Select Product Intake" />
+            <SelectValue placeholder="Select receiving draft" />
           </SelectTrigger>
           <SelectContent>
             {drafts.map(draft => (
@@ -1712,7 +1712,7 @@ export function ProductIntakeSlicePage() {
                   className="p-8 text-center text-muted-foreground"
                   colSpan={12}
                 >
-                  Select a Product Intake draft.
+                  Select a receiving draft.
                 </td>
               </tr>
             )}

--- a/client/src/components/uiux-slice/PurchaseOrdersSlicePage.tsx
+++ b/client/src/components/uiux-slice/PurchaseOrdersSlicePage.tsx
@@ -520,7 +520,7 @@ export function PurchaseOrdersSlicePage() {
       ? "/slice-v1-lab/product-intake"
       : route.startsWith("/slice-v1")
         ? "/slice-v1/product-intake"
-        : "/product-intake";
+        : "/operations?tab=receiving";
 
     upsertProductIntakeDraft(draft, preferenceUserId);
     setPickerOpen(false);
@@ -573,7 +573,7 @@ export function PurchaseOrdersSlicePage() {
 
   const contextLine = selectedPo
     ? `${selectedPo.poNumber} · ${getSupplierName(selectedPo)} · ${selectedPo.purchaseOrderStatus} · ${selectedPo.items?.length ?? 0} lines · $${Number(selectedPo.total ?? 0).toFixed(2)}`
-    : "Select a Purchase Order row to inspect detail context and create Product Intake.";
+    : "Select a purchase order row to inspect detail context and start receiving.";
 
   return (
     <div className="h-full flex flex-col">
@@ -582,7 +582,7 @@ export function PurchaseOrdersSlicePage() {
           Purchase Orders
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Purchase Order to Product Intake routing surface.
+          Purchase Order to Receiving routing surface.
         </p>
       </div>
 
@@ -668,7 +668,7 @@ export function PurchaseOrdersSlicePage() {
           disabled={!activePoForIntake}
         >
           <ClipboardPlus className="h-4 w-4 mr-1" />
-          Create Product Intake
+          Start Receiving
         </Button>
 
         <Button
@@ -810,11 +810,11 @@ export function PurchaseOrdersSlicePage() {
         <DrawerContent className="w-[760px] sm:max-w-none">
           <DrawerHeader>
             <DrawerTitle>
-              Create Product Intake
+              Start Receiving
               {activePoForIntake ? ` from ${activePoForIntake.poNumber}` : ""}
             </DrawerTitle>
             <DrawerDescription className="sr-only">
-              Select PO lines and quantities to start a Product Intake draft.
+              Select PO lines and quantities to start a receiving draft.
             </DrawerDescription>
           </DrawerHeader>
           <div className="px-4 pb-4 overflow-auto">

--- a/client/src/components/uiux-slice/SliceV1WorkbenchLayout.tsx
+++ b/client/src/components/uiux-slice/SliceV1WorkbenchLayout.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from "wouter";
 
 const tabs = [
   { href: "/slice-v1-lab/purchase-orders", label: "Purchase Orders" },
-  { href: "/slice-v1-lab/product-intake", label: "Product Intake" },
+  { href: "/slice-v1-lab/product-intake", label: "Receiving" },
   { href: "/slice-v1-lab/inventory", label: "Inventory Browse" },
 ];
 
@@ -13,7 +13,9 @@ export function SliceV1WorkbenchLayout({ children }: PropsWithChildren) {
   return (
     <div
       className="min-h-screen bg-[#f5f5f2] text-slate-900"
-      style={{ fontFamily: '"IBM Plex Sans","SF Pro Text","Segoe UI",sans-serif' }}
+      style={{
+        fontFamily: '"IBM Plex Sans","SF Pro Text","Segoe UI",sans-serif',
+      }}
     >
       <header className="border-b border-slate-300 bg-[#efefe9] px-6 py-3">
         <div className="flex flex-wrap items-center gap-3">
@@ -22,7 +24,7 @@ export function SliceV1WorkbenchLayout({ children }: PropsWithChildren) {
               Calm Power Slice Lab
             </p>
             <p className="text-base font-semibold tracking-tight">
-              Purchase Order → Product Intake → Received
+              Purchase Order → Receiving → Received
             </p>
           </div>
           <nav className="flex items-center gap-2">

--- a/client/src/components/work-surface/DirectIntakeWorkSurface.tsx
+++ b/client/src/components/work-surface/DirectIntakeWorkSurface.tsx
@@ -101,36 +101,79 @@ import {
 // TYPES & SCHEMAS
 // ============================================================================
 
-const intakeRowSchema = z.object({
-  vendorName: z.string().min(1, "Supplier is required"),
-  brandName: z.string().min(1, "Brand/Farmer is required"),
-  category: z.enum([
-    "Flower",
-    "Deps",
-    "Concentrate",
-    "Edible",
-    "PreRoll",
-    "Vape",
-    "Other",
-  ]),
-  item: z.string().min(1, "Product is required"),
-  // TER-223: Subcategory is first-class, category defaults to Flower
-  subcategory: z.string().optional(),
-  qty: z.number().min(0.01, "Quantity must be greater than 0"),
-  cogs: z.number().min(0.01, "COGS must be greater than 0"),
-  paymentTerms: z.enum([
-    "COD",
-    "NET_7",
-    "NET_15",
-    "NET_30",
-    "CONSIGNMENT",
-    "PARTIAL",
-  ]),
-  site: z.string().min(1, "Location is required"),
-  notes: z.string().optional(),
-});
+const intakeRowSchema = z
+  .object({
+    vendorName: z.string().min(1, "Supplier is required"),
+    brandName: z.string().min(1, "Brand/Farmer is required"),
+    category: z.enum([
+      "Flower",
+      "Deps",
+      "Concentrate",
+      "Edible",
+      "PreRoll",
+      "Vape",
+      "Other",
+    ]),
+    item: z.string().min(1, "Product is required"),
+    // TER-223: Subcategory is first-class, category defaults to Flower
+    subcategory: z.string().optional(),
+    qty: z.number().min(0.01, "Quantity must be greater than 0"),
+    cogsMode: z.enum(["FIXED", "RANGE"]),
+    cogs: z.number().min(0, "COGS must be 0 or greater"),
+    cogsMin: z.number().min(0, "Min COGS must be 0 or greater").optional(),
+    cogsMax: z.number().min(0, "Max COGS must be 0 or greater").optional(),
+    paymentTerms: z.enum([
+      "COD",
+      "NET_7",
+      "NET_15",
+      "NET_30",
+      "CONSIGNMENT",
+      "PARTIAL",
+    ]),
+    site: z.string().min(1, "Location is required"),
+    notes: z.string().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.cogsMode === "FIXED") {
+      if (!value.cogs || value.cogs <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cogs"],
+          message: "COGS must be greater than 0",
+        });
+      }
+      return;
+    }
+
+    if (!value.cogsMin || value.cogsMin <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["cogsMin"],
+        message: "Min COGS must be greater than 0",
+      });
+    }
+    if (!value.cogsMax || value.cogsMax <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["cogsMax"],
+        message: "Max COGS must be greater than 0",
+      });
+    }
+    if (
+      value.cogsMin !== undefined &&
+      value.cogsMax !== undefined &&
+      value.cogsMax < value.cogsMin
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["cogsMax"],
+        message: "Max COGS must be greater than or equal to min COGS",
+      });
+    }
+  });
 
 type IntakeRowData = z.infer<typeof intakeRowSchema>;
+type IntakeCogsMode = IntakeRowData["cogsMode"];
 
 interface IntakeGridRow extends IntakeRowData {
   id: string;
@@ -197,7 +240,10 @@ const FILL_DOWN_FIELD_OPTIONS = [
   { value: "category", label: "Category" },
   { value: "subcategory", label: "Subcategory" },
   { value: "qty", label: "Qty" },
+  { value: "cogsMode", label: "COGS Mode" },
   { value: "cogs", label: "COGS" },
+  { value: "cogsMin", label: "COGS Min" },
+  { value: "cogsMax", label: "COGS Max" },
   { value: "paymentTerms", label: "Payment Terms" },
   { value: "notes", label: "Notes" },
 ] as const;
@@ -224,7 +270,10 @@ const createEmptyRow = (defaults?: {
   productId: null,
   strainId: null,
   qty: 0,
+  cogsMode: "FIXED",
   cogs: 0,
+  cogsMin: 0,
+  cogsMax: 0,
   paymentTerms: INTAKE_DEFAULTS.paymentTerms,
   locationId: defaults?.locationId ?? null,
   locationName: defaults?.locationName ?? "",
@@ -233,19 +282,56 @@ const createEmptyRow = (defaults?: {
   status: "pending",
 });
 
+const getEffectiveCogs = (
+  row: Pick<IntakeGridRow, "cogsMode" | "cogs" | "cogsMin" | "cogsMax">
+) => {
+  if (row.cogsMode === "RANGE") {
+    const min = Number(row.cogsMin || 0);
+    const max = Number(row.cogsMax || 0);
+    return (min + max) / 2;
+  }
+  return Number(row.cogs || 0);
+};
+
+const normalizeIntakeCogs = (row: IntakeGridRow): IntakeGridRow => {
+  if (row.cogsMode !== "RANGE") {
+    return {
+      ...row,
+      cogsMin: 0,
+      cogsMax: 0,
+    };
+  }
+
+  return {
+    ...row,
+    cogs: getEffectiveCogs(row),
+  };
+};
+
+const formatCogsLabel = (
+  row: Pick<IntakeGridRow, "cogsMode" | "cogs" | "cogsMin" | "cogsMax">
+) => {
+  if (row.cogsMode === "RANGE") {
+    return `$${Number(row.cogsMin || 0).toFixed(2)}-$${Number(
+      row.cogsMax || 0
+    ).toFixed(2)}`;
+  }
+  return `$${Number(row.cogs || 0).toFixed(2)}`;
+};
+
 const normalizeRowForValidation = (row: IntakeGridRow): IntakeGridRow => {
   const vendorName = row.vendorName.trim();
   const brandName = row.brandName.trim() || vendorName;
   const item = row.item.trim();
   const site = row.site.trim();
 
-  return {
+  return normalizeIntakeCogs({
     ...row,
     vendorName,
     brandName,
     item,
     site,
-  };
+  });
 };
 
 // ============================================================================
@@ -550,6 +636,28 @@ function RowInspectorContent({
             )}
           </InspectorField>
 
+          <InspectorField label="COGS Mode" required>
+            <Select
+              value={row.cogsMode}
+              onValueChange={value => {
+                onUpdate({
+                  cogsMode: value as IntakeCogsMode,
+                });
+                validation.handleChange("cogsMode", value);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="FIXED">Fixed COGS</SelectItem>
+                <SelectItem value="RANGE">Range COGS</SelectItem>
+              </SelectContent>
+            </Select>
+          </InspectorField>
+        </div>
+
+        {row.cogsMode === "FIXED" ? (
           <InspectorField label="COGS ($)" required>
             <Input
               type="number"
@@ -572,7 +680,56 @@ function RowInspectorContent({
               </p>
             )}
           </InspectorField>
-        </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4">
+            <InspectorField label="Min COGS ($)" required>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={row.cogsMin || ""}
+                onChange={e => {
+                  const val = parseFloat(e.target.value) || 0;
+                  onUpdate({ cogsMin: val });
+                  validation.handleChange("cogsMin", val);
+                }}
+                onBlur={() => validation.handleBlur("cogsMin")}
+                className={cn(
+                  validation.getFieldState("cogsMin").showError &&
+                    "border-red-500"
+                )}
+              />
+              {validation.getFieldState("cogsMin").showError && (
+                <p className="text-xs text-red-500 mt-1">
+                  {validation.getFieldState("cogsMin").error}
+                </p>
+              )}
+            </InspectorField>
+            <InspectorField label="Max COGS ($)" required>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={row.cogsMax || ""}
+                onChange={e => {
+                  const val = parseFloat(e.target.value) || 0;
+                  onUpdate({ cogsMax: val });
+                  validation.handleChange("cogsMax", val);
+                }}
+                onBlur={() => validation.handleBlur("cogsMax")}
+                className={cn(
+                  validation.getFieldState("cogsMax").showError &&
+                    "border-red-500"
+                )}
+              />
+              {validation.getFieldState("cogsMax").showError && (
+                <p className="text-xs text-red-500 mt-1">
+                  {validation.getFieldState("cogsMax").error}
+                </p>
+              )}
+            </InspectorField>
+          </div>
+        )}
       </InspectorSection>
 
       <InspectorSection title="Transaction Details" defaultOpen>
@@ -718,9 +875,14 @@ function RowInspectorContent({
         <div className="flex justify-between items-center">
           <span className="text-sm text-muted-foreground">Line Total</span>
           <span className="font-semibold text-lg">
-            ${((row.qty || 0) * (row.cogs || 0)).toFixed(2)}
+            ${((row.qty || 0) * getEffectiveCogs(row)).toFixed(2)}
           </span>
         </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {row.cogsMode === "RANGE"
+            ? `Range midpoint used for line total: ${formatCogsLabel(row)}`
+            : `Fixed COGS: ${formatCogsLabel(row)}`}
+        </p>
       </div>
     </div>
   );
@@ -1020,11 +1182,56 @@ export function DirectIntakeWorkSurface() {
         },
       },
       {
+        headerName: "COGS Mode",
+        field: "cogsMode",
+        width: 120,
+        editable: params => params.data?.status === "pending",
+        cellEditor: "agSelectCellEditor",
+        cellEditorParams: { values: ["FIXED", "RANGE"] },
+      },
+      {
         headerName: "COGS",
         field: "cogs",
         width: 100,
-        editable: params => params.data?.status === "pending",
-        valueFormatter: params => `$${(params.value ?? 0).toFixed(2)}`,
+        editable: params =>
+          params.data?.status === "pending" &&
+          params.data?.cogsMode !== "RANGE",
+        valueFormatter: params =>
+          params.data
+            ? formatCogsLabel(params.data)
+            : `$${(params.value ?? 0).toFixed(2)}`,
+        valueParser: params => {
+          const val = Number(params.newValue);
+          return Number.isFinite(val) && val >= 0 ? val : params.oldValue;
+        },
+      },
+      {
+        headerName: "COGS Min",
+        field: "cogsMin",
+        width: 100,
+        editable: params =>
+          params.data?.status === "pending" &&
+          params.data?.cogsMode === "RANGE",
+        valueFormatter: params =>
+          params.data?.cogsMode === "RANGE"
+            ? `$${(params.value ?? 0).toFixed(2)}`
+            : "Fixed",
+        valueParser: params => {
+          const val = Number(params.newValue);
+          return Number.isFinite(val) && val >= 0 ? val : params.oldValue;
+        },
+      },
+      {
+        headerName: "COGS Max",
+        field: "cogsMax",
+        width: 100,
+        editable: params =>
+          params.data?.status === "pending" &&
+          params.data?.cogsMode === "RANGE",
+        valueFormatter: params =>
+          params.data?.cogsMode === "RANGE"
+            ? `$${(params.value ?? 0).toFixed(2)}`
+            : "Fixed",
         valueParser: params => {
           const val = Number(params.newValue);
           return Number.isFinite(val) && val >= 0 ? val : params.oldValue;
@@ -1170,6 +1377,15 @@ export function DirectIntakeWorkSurface() {
           nextRow.productId = null;
           nextRow.strainId = null;
         }
+      }
+
+      if (
+        event.colDef.field === "cogsMode" ||
+        event.colDef.field === "cogs" ||
+        event.colDef.field === "cogsMin" ||
+        event.colDef.field === "cogsMax"
+      ) {
+        Object.assign(nextRow, normalizeIntakeCogs(nextRow));
       }
 
       // Reset error status when editing after a validation failure
@@ -1428,8 +1644,19 @@ export function DirectIntakeWorkSurface() {
           subcategory: normalizedRow.subcategory || undefined,
           strainId: normalizedRow.strainId,
           quantity: normalizedRow.qty,
-          cogsMode: "FIXED" as const,
-          unitCogs: normalizedRow.cogs.toFixed(2),
+          cogsMode: normalizedRow.cogsMode,
+          unitCogs:
+            normalizedRow.cogsMode === "FIXED"
+              ? normalizedRow.cogs.toFixed(2)
+              : undefined,
+          unitCogsMin:
+            normalizedRow.cogsMode === "RANGE"
+              ? Number(normalizedRow.cogsMin || 0).toFixed(2)
+              : undefined,
+          unitCogsMax:
+            normalizedRow.cogsMode === "RANGE"
+              ? Number(normalizedRow.cogsMax || 0).toFixed(2)
+              : undefined,
           paymentTerms: normalizedRow.paymentTerms,
           location: { site: normalizedRow.site },
           metadata: normalizedRow.notes
@@ -1574,8 +1801,16 @@ export function DirectIntakeWorkSurface() {
           subcategory: row.subcategory || undefined,
           strainId: row.strainId,
           quantity: row.qty,
-          cogsMode: "FIXED" as const,
-          unitCogs: row.cogs.toFixed(2),
+          cogsMode: row.cogsMode,
+          unitCogs: row.cogsMode === "FIXED" ? row.cogs.toFixed(2) : undefined,
+          unitCogsMin:
+            row.cogsMode === "RANGE"
+              ? Number(row.cogsMin || 0).toFixed(2)
+              : undefined,
+          unitCogsMax:
+            row.cogsMode === "RANGE"
+              ? Number(row.cogsMax || 0).toFixed(2)
+              : undefined,
           paymentTerms: row.paymentTerms,
           location: { site: row.site },
           metadata: row.notes ? { notes: row.notes } : undefined,
@@ -1657,12 +1892,20 @@ export function DirectIntakeWorkSurface() {
           { key: "category", label: "Category" },
           { key: "subcategory", label: "Subcategory" },
           { key: "qty", label: "Qty" },
+          { key: "cogsMode", label: "COGS Mode" },
           { key: "cogs", label: "COGS" },
+          { key: "cogsMin", label: "COGS Min" },
+          { key: "cogsMax", label: "COGS Max" },
+          {
+            key: "effectiveCogs",
+            label: "Effective COGS",
+            formatter: (_value, row) => getEffectiveCogs(row).toFixed(2),
+          },
           {
             key: "lineTotal",
             label: "Line Total",
             formatter: (_value, row) =>
-              ((row.qty || 0) * (row.cogs || 0)).toFixed(2),
+              ((row.qty || 0) * getEffectiveCogs(row)).toFixed(2),
           },
           { key: "paymentTerms", label: "Payment Terms" },
           { key: "site", label: "Location" },
@@ -1687,6 +1930,10 @@ export function DirectIntakeWorkSurface() {
         prev.map(r =>
           r.id === selectedRowId
             ? (() => {
+                const nextRow = normalizeIntakeCogs({
+                  ...r,
+                  ...updates,
+                } as IntakeGridRow);
                 const nextVendorName =
                   typeof updates.vendorName === "string"
                     ? updates.vendorName.trim()
@@ -1697,8 +1944,7 @@ export function DirectIntakeWorkSurface() {
                   !r.brandName.trim();
 
                 return {
-                  ...r,
-                  ...updates,
+                  ...nextRow,
                   ...(typeof nextVendorName === "string"
                     ? { vendorName: nextVendorName }
                     : {}),
@@ -1735,7 +1981,10 @@ export function DirectIntakeWorkSurface() {
     return {
       totalItems: pendingRows.length,
       totalQty: pendingRows.reduce((sum, r) => sum + r.qty, 0),
-      totalValue: pendingRows.reduce((sum, r) => sum + r.qty * r.cogs, 0),
+      totalValue: pendingRows.reduce(
+        (sum, r) => sum + r.qty * getEffectiveCogs(r),
+        0
+      ),
     };
   }, [rows]);
 
@@ -1976,22 +2225,85 @@ export function DirectIntakeWorkSurface() {
             />
           </div>
           <div className="space-y-1 min-w-0">
-            <Label className="text-xs text-muted-foreground">COGS</Label>
-            <Input
-              type="number"
-              min="0"
-              step="0.01"
-              value={selectedRow?.cogs ?? ""}
-              onChange={e => {
-                const val = Number(e.target.value);
+            <Label className="text-xs text-muted-foreground">COGS Mode</Label>
+            <Select
+              value={selectedRow?.cogsMode ?? "FIXED"}
+              onValueChange={value =>
                 handleUpdateSelectedRow({
-                  cogs: Number.isFinite(val) ? val : 0,
-                });
-              }}
+                  cogsMode: value as IntakeCogsMode,
+                })
+              }
               disabled={!selectedRowEditable}
-              className="h-9"
-            />
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="FIXED">Fixed</SelectItem>
+                <SelectItem value="RANGE">Range</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
+          {selectedRow?.cogsMode === "RANGE" ? (
+            <>
+              <div className="space-y-1 min-w-0">
+                <Label className="text-xs text-muted-foreground">
+                  COGS Min
+                </Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={selectedRow?.cogsMin ?? ""}
+                  onChange={e => {
+                    const val = Number(e.target.value);
+                    handleUpdateSelectedRow({
+                      cogsMin: Number.isFinite(val) ? val : 0,
+                    });
+                  }}
+                  disabled={!selectedRowEditable}
+                  className="h-9"
+                />
+              </div>
+              <div className="space-y-1 min-w-0">
+                <Label className="text-xs text-muted-foreground">
+                  COGS Max
+                </Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={selectedRow?.cogsMax ?? ""}
+                  onChange={e => {
+                    const val = Number(e.target.value);
+                    handleUpdateSelectedRow({
+                      cogsMax: Number.isFinite(val) ? val : 0,
+                    });
+                  }}
+                  disabled={!selectedRowEditable}
+                  className="h-9"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="space-y-1 min-w-0">
+              <Label className="text-xs text-muted-foreground">COGS</Label>
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                value={selectedRow?.cogs ?? ""}
+                onChange={e => {
+                  const val = Number(e.target.value);
+                  handleUpdateSelectedRow({
+                    cogs: Number.isFinite(val) ? val : 0,
+                  });
+                }}
+                disabled={!selectedRowEditable}
+                className="h-9"
+              />
+            </div>
+          )}
           <div className="space-y-1 min-w-0">
             <Label className="text-xs text-muted-foreground">Location</Label>
             <Select

--- a/client/src/components/work-surface/PurchaseOrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/PurchaseOrdersWorkSurface.tsx
@@ -759,6 +759,14 @@ export function PurchaseOrdersWorkSurface() {
         enabled: Number(formData.supplierClientId || 0) > 0,
       }
     );
+  const supplierHistoryQuery = trpc.purchaseOrders.getBySupplier.useQuery(
+    {
+      supplierClientId: Number(formData.supplierClientId || 0),
+    },
+    {
+      enabled: Number(formData.supplierClientId || 0) > 0,
+    }
+  );
 
   const productNameLookup = useMemo(
     () =>
@@ -1421,20 +1429,6 @@ export function PurchaseOrdersWorkSurface() {
     selectedPoDraftRowSet,
   ]);
 
-  const handleItemChange = useCallback(
-    (index: number, field: keyof LineItem, value: string) => {
-      setFormData(prev => {
-        const nextItems = [...prev.items];
-        nextItems[index] = { ...nextItems[index], [field]: value };
-        return {
-          ...prev,
-          items: nextItems,
-        };
-      });
-    },
-    []
-  );
-
   const handleLineItemFieldChange = useCallback(
     (index: number, field: PoDraftField, value: string) => {
       const currentItem = formData.items[index];
@@ -1442,16 +1436,30 @@ export function PurchaseOrdersWorkSurface() {
         return;
       }
 
-      handleItemChange(index, field, value);
+      const nextItem =
+        field === "productName"
+          ? resolveTypedProduct({
+              ...currentItem,
+              productName: value,
+            })
+          : {
+              ...currentItem,
+              [field]: value,
+            };
+
+      setFormData(prev => {
+        const nextItems = [...prev.items];
+        nextItems[index] = nextItem;
+        return {
+          ...prev,
+          items: nextItems,
+        };
+      });
 
       if (field === "category" || field === "subcategory") {
         return;
       }
 
-      const nextItem = {
-        ...currentItem,
-        [field]: value,
-      };
       const values = buildPoLineValues(nextItem);
       const schemaField = poDraftFieldToSchemaField[field];
 
@@ -1463,8 +1471,8 @@ export function PurchaseOrdersWorkSurface() {
       buildPoLineValues,
       clearPoDraftFieldError,
       formData.items,
-      handleItemChange,
       handlePoLineValidationChange,
+      resolveTypedProduct,
       setPoLineValidationValues,
     ]
   );
@@ -1806,73 +1814,193 @@ export function PurchaseOrdersWorkSurface() {
             </div>
 
             {Number(formData.supplierClientId || 0) > 0 && (
-              <div className="rounded-lg border bg-muted/20 p-3">
-                <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="rounded-xl border bg-muted/20 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <p className="text-sm font-medium">
-                      Quick add from previous purchase orders
+                    <p className="text-sm font-semibold">
+                      Supplier history and quick add
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      Tap a prior supplier product to copy it into a fresh row.
+                      Start typing in the spreadsheet below. Existing products
+                      snap to the catalog automatically, and new names create a
+                      fresh product on submit.
                     </p>
                   </div>
-                  {recentSupplierProductsQuery.isLoading && (
+                  {(recentSupplierProductsQuery.isLoading ||
+                    supplierHistoryQuery.isLoading) && (
                     <span className="text-xs text-muted-foreground">
                       Loading supplier history...
                     </span>
                   )}
                 </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {(recentSupplierProductsQuery.data ?? []).map(item => (
-                    <Button
-                      key={`${item.productId}-${item.poNumber}`}
-                      type="button"
-                      variant="outline"
-                      className="h-auto items-start justify-start px-3 py-2 text-left"
-                      onClick={() =>
-                        appendQuickAddItem({
-                          productId: item.productId,
-                          productName: item.productName,
-                          category: item.category,
-                          subcategory: item.subcategory,
-                          cogsMode: item.cogsMode,
-                          unitCost: item.unitCost,
-                          unitCostMin: item.unitCostMin,
-                          unitCostMax: item.unitCostMax,
-                        })
-                      }
-                    >
-                      <div>
-                        <div className="font-medium text-foreground">
-                          {item.productName ?? `Product #${item.productId}`}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {formatItemCostLabel({
-                            cogsMode: item.cogsMode,
-                            unitCost: Number(item.unitCost ?? 0),
-                            unitCostMin:
-                              item.unitCostMin !== null &&
-                              item.unitCostMin !== undefined
-                                ? Number(item.unitCostMin)
-                                : undefined,
-                            unitCostMax:
-                              item.unitCostMax !== null &&
-                              item.unitCostMax !== undefined
-                                ? Number(item.unitCostMax)
-                                : undefined,
-                          })}{" "}
-                          • {item.poNumber}
-                        </div>
-                      </div>
-                    </Button>
-                  ))}
-                  {!recentSupplierProductsQuery.isLoading &&
-                    (recentSupplierProductsQuery.data ?? []).length === 0 && (
-                      <p className="text-sm text-muted-foreground">
-                        No prior supplier items yet. Type the first product
-                        below and it will show up here next time.
+                <div className="mt-4 grid gap-4 xl:grid-cols-[1.3fr_1fr]">
+                  <div className="rounded-lg border bg-background">
+                    <div className="border-b px-3 py-2">
+                      <p className="text-sm font-medium">
+                        Reorder products from prior POs
                       </p>
-                    )}
+                      <p className="text-xs text-muted-foreground">
+                        Each quick add creates a new draft row for a new batch
+                        and lot.
+                      </p>
+                    </div>
+                    <div className="max-h-64 overflow-auto">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Product</TableHead>
+                            <TableHead>Last Cost</TableHead>
+                            <TableHead>Source PO</TableHead>
+                            <TableHead className="w-[96px] text-right">
+                              Action
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {(recentSupplierProductsQuery.data ?? []).map(
+                            item => (
+                              <TableRow
+                                key={`${item.productId}-${item.poNumber}`}
+                                className="align-top"
+                              >
+                                <TableCell>
+                                  <div className="font-medium">
+                                    {item.productName ??
+                                      `Product #${item.productId}`}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {[item.category, item.subcategory]
+                                      .filter(Boolean)
+                                      .join(" / ") || "Uncategorized"}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-sm">
+                                  {formatItemCostLabel({
+                                    cogsMode: item.cogsMode,
+                                    unitCost: Number(item.unitCost ?? 0),
+                                    unitCostMin:
+                                      item.unitCostMin !== null &&
+                                      item.unitCostMin !== undefined
+                                        ? Number(item.unitCostMin)
+                                        : undefined,
+                                    unitCostMax:
+                                      item.unitCostMax !== null &&
+                                      item.unitCostMax !== undefined
+                                        ? Number(item.unitCostMax)
+                                        : undefined,
+                                  })}
+                                </TableCell>
+                                <TableCell className="text-sm">
+                                  <div>{item.poNumber}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {formatDate(item.orderDate)}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() =>
+                                      appendQuickAddItem({
+                                        productId: item.productId,
+                                        productName: item.productName,
+                                        category: item.category,
+                                        subcategory: item.subcategory,
+                                        cogsMode: item.cogsMode,
+                                        unitCost: item.unitCost,
+                                        unitCostMin: item.unitCostMin,
+                                        unitCostMax: item.unitCostMax,
+                                      })
+                                    }
+                                  >
+                                    Add row
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            )
+                          )}
+                          {!recentSupplierProductsQuery.isLoading &&
+                            (recentSupplierProductsQuery.data ?? []).length ===
+                              0 && (
+                              <TableRow>
+                                <TableCell
+                                  colSpan={4}
+                                  className="text-sm text-muted-foreground"
+                                >
+                                  No prior supplier items yet. Type the first
+                                  product below and it will show up here next
+                                  time.
+                                </TableCell>
+                              </TableRow>
+                            )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border bg-background">
+                    <div className="border-b px-3 py-2">
+                      <p className="text-sm font-medium">
+                        Previous purchase orders
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Use this to sanity-check cadence, terms, and prior PO
+                        totals while you build the new batch.
+                      </p>
+                    </div>
+                    <div className="max-h-64 overflow-auto">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>PO</TableHead>
+                            <TableHead>Date</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead className="text-right">Total</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {(supplierHistoryQuery.data ?? [])
+                            .slice(0, 8)
+                            .map(po => (
+                              <TableRow key={po.id}>
+                                <TableCell>
+                                  <div className="font-medium">
+                                    {po.poNumber}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {po.paymentTerms || "CONSIGNMENT"}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-sm">
+                                  {formatDate(po.orderDate)}
+                                </TableCell>
+                                <TableCell>
+                                  <StatusBadge
+                                    status={po.purchaseOrderStatus}
+                                  />
+                                </TableCell>
+                                <TableCell className="text-right text-sm font-medium">
+                                  {formatCurrency(po.total)}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          {!supplierHistoryQuery.isLoading &&
+                            (supplierHistoryQuery.data ?? []).length === 0 && (
+                              <TableRow>
+                                <TableCell
+                                  colSpan={4}
+                                  className="text-sm text-muted-foreground"
+                                >
+                                  This supplier does not have prior purchase
+                                  orders yet.
+                                </TableCell>
+                              </TableRow>
+                            )}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </div>
                 </div>
               </div>
             )}
@@ -1916,7 +2044,13 @@ export function PurchaseOrdersWorkSurface() {
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <Label>Line Items *</Label>
+                <div>
+                  <Label>Line Items *</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Spreadsheet drafting with typed product lookup, bulk fills,
+                    and fixed or range COGS.
+                  </p>
+                </div>
                 <Button
                   type="button"
                   variant="outline"
@@ -1984,246 +2118,95 @@ export function PurchaseOrdersWorkSurface() {
               )}
               <div
                 ref={poDraftRowsRef}
-                className="space-y-2 rounded-md border p-3"
+                className="overflow-x-auto rounded-lg border bg-background"
               >
                 <datalist id="po-product-suggestions">
                   {products.map(product => (
                     <option key={product.id} value={product.name} />
                   ))}
                 </datalist>
-                <div className="grid grid-cols-12 gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-                  <span className="col-span-1">
-                    <Checkbox
-                      aria-label="Select all draft rows"
-                      checked={
-                        allPoDraftRowsSelected
-                          ? true
-                          : poDraftSelection.selectedCount > 0
-                            ? "indeterminate"
-                            : false
-                      }
-                      onCheckedChange={() =>
-                        poDraftSelection.toggleAll(poDraftRowIds)
-                      }
-                    />
-                  </span>
-                  <span className="col-span-4">Product</span>
-                  <span className="col-span-2">Category</span>
-                  <span className="col-span-1 text-right">Qty</span>
-                  <span className="col-span-3">COGS</span>
-                  <span className="col-span-1 text-right">Total</span>
-                  <span className="col-span-1 text-right">Action</span>
-                </div>
-                {formData.items.map((item, index) => {
-                  const quantity = Number(item.quantityOrdered || 0);
-                  const unitCost = getDraftUnitCostValue(item);
-                  const rowTotal = quantity * unitCost;
-                  const matchedProduct = item.productId
-                    ? products.find(
-                        product => product.id === Number(item.productId)
-                      )
-                    : productNameLookup.get(
-                        item.productName.trim().toLowerCase()
-                      );
-
-                  return (
-                    <div
-                      key={item.tempId}
-                      className={cn(
-                        "grid grid-cols-12 gap-2 items-center rounded px-1 py-1",
-                        selectedPoDraftRowSet.has(item.tempId) && "bg-muted/50"
-                      )}
-                    >
-                      <div className="col-span-1">
+                <Table className="min-w-[1120px]">
+                  <TableHeader>
+                    <TableRow className="bg-muted/40">
+                      <TableHead className="w-[48px]">
                         <Checkbox
-                          aria-label={`Select draft row ${index + 1}`}
-                          checked={selectedPoDraftRowSet.has(item.tempId)}
-                          onCheckedChange={checked => {
-                            if (
-                              (checked === true) !==
-                              poDraftSelection.isSelected(item.tempId)
-                            ) {
-                              poDraftSelection.toggleRow(item.tempId);
-                            }
-                          }}
-                        />
-                      </div>
-                      <div className="col-span-4">
-                        <Input
-                          list="po-product-suggestions"
-                          placeholder="Type product name"
-                          value={item.productName}
-                          data-po-draft-row-id={item.tempId}
-                          data-po-draft-field="productName"
-                          onChange={e =>
-                            handleLineItemFieldChange(
-                              index,
-                              "productName",
-                              e.target.value
-                            )
+                          aria-label="Select all draft rows"
+                          checked={
+                            allPoDraftRowsSelected
+                              ? true
+                              : poDraftSelection.selectedCount > 0
+                                ? "indeterminate"
+                                : false
                           }
-                          onBlur={e =>
-                            handleLineItemFieldBlur(
-                              {
-                                ...item,
-                                productName: e.target.value,
-                              },
-                              "productName"
-                            )
-                          }
-                          onKeyDown={event =>
-                            handleDraftFieldKeyDown(event, index, "productName")
+                          onCheckedChange={() =>
+                            poDraftSelection.toggleAll(poDraftRowIds)
                           }
                         />
-                        <div className="mt-1 flex items-center gap-2 text-xs">
-                          {matchedProduct ? (
-                            <Badge variant="secondary">
-                              Matched existing product
-                            </Badge>
-                          ) : item.productName.trim() ? (
-                            <Badge variant="outline">
-                              New product will be created
-                            </Badge>
-                          ) : null}
-                          {productsLoading && (
-                            <span className="text-muted-foreground">
-                              Loading products...
-                            </span>
-                          )}
-                        </div>
-                        {poDraftFieldErrors[item.tempId]?.productName && (
-                          <p className="text-xs text-red-500 mt-1">
-                            {poDraftFieldErrors[item.tempId]?.productName}
-                          </p>
-                        )}
-                      </div>
-                      <div className="col-span-2 space-y-1">
-                        <Select
-                          value={item.category}
-                          onValueChange={value =>
-                            handleLineItemFieldChange(index, "category", value)
-                          }
-                        >
-                          <SelectTrigger className="h-9">
-                            <SelectValue placeholder="Category" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {CATEGORY_OPTIONS.map(option => (
-                              <SelectItem
-                                key={option.value}
-                                value={option.value}
-                              >
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <Input
-                          placeholder="Subcategory"
-                          value={item.subcategory}
-                          onChange={e =>
-                            handleLineItemFieldChange(
-                              index,
-                              "subcategory",
-                              e.target.value
-                            )
-                          }
-                        />
-                      </div>
-                      <div className="col-span-1">
-                        <Input
-                          type="number"
+                      </TableHead>
+                      <TableHead className="w-[56px]">Row</TableHead>
+                      <TableHead className="min-w-[320px]">Product</TableHead>
+                      <TableHead className="min-w-[220px]">Category</TableHead>
+                      <TableHead className="w-[96px] text-right">Qty</TableHead>
+                      <TableHead className="w-[160px]">COGS Mode</TableHead>
+                      <TableHead className="min-w-[220px]">Cost</TableHead>
+                      <TableHead className="w-[120px] text-right">
+                        Total
+                      </TableHead>
+                      <TableHead className="w-[72px] text-right">
+                        Action
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {formData.items.map((item, index) => {
+                      const quantity = Number(item.quantityOrdered || 0);
+                      const unitCost = getDraftUnitCostValue(item);
+                      const rowTotal = quantity * unitCost;
+                      const matchedProduct = item.productId
+                        ? products.find(
+                            product => product.id === Number(item.productId)
+                          )
+                        : productNameLookup.get(
+                            item.productName.trim().toLowerCase()
+                          );
+
+                      return (
+                        <TableRow
+                          key={item.tempId}
                           className={cn(
-                            "text-right",
-                            poDraftFieldErrors[item.tempId]?.quantityOrdered &&
-                              "border-red-500"
+                            "align-top",
+                            selectedPoDraftRowSet.has(item.tempId) &&
+                              "bg-muted/40"
                           )}
-                          placeholder="0"
-                          min="0.01"
-                          step="0.01"
-                          data-po-draft-row-id={item.tempId}
-                          data-po-draft-field="quantityOrdered"
-                          value={item.quantityOrdered}
-                          onChange={e =>
-                            handleLineItemFieldChange(
-                              index,
-                              "quantityOrdered",
-                              e.target.value
-                            )
-                          }
-                          onBlur={e =>
-                            handleLineItemFieldBlur(
-                              {
-                                ...item,
-                                quantityOrdered: e.target.value,
-                              },
-                              "quantityOrdered"
-                            )
-                          }
-                          onKeyDown={event =>
-                            handleDraftFieldKeyDown(
-                              event,
-                              index,
-                              "quantityOrdered"
-                            )
-                          }
-                        />
-                        {poDraftFieldErrors[item.tempId]?.quantityOrdered && (
-                          <p className="text-xs text-red-500 mt-1 text-right">
-                            {poDraftFieldErrors[item.tempId]?.quantityOrdered}
-                          </p>
-                        )}
-                      </div>
-                      <div className="col-span-3 space-y-2">
-                        <Select
-                          value={item.cogsMode}
-                          onValueChange={value => {
-                            const nextMode = value as PoCogsMode;
-                            setFormData(prev => ({
-                              ...prev,
-                              items: prev.items.map(existing =>
-                                existing.tempId === item.tempId
-                                  ? {
-                                      ...existing,
-                                      cogsMode: nextMode,
-                                      unitCost:
-                                        nextMode === "FIXED"
-                                          ? existing.unitCost ||
-                                            existing.unitCostMin
-                                          : existing.unitCost,
-                                    }
-                                  : existing
-                              ),
-                            }));
-                          }}
                         >
-                          <SelectTrigger className="h-9">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="FIXED">Fixed COGS</SelectItem>
-                            <SelectItem value="RANGE">Range COGS</SelectItem>
-                          </SelectContent>
-                        </Select>
-                        {item.cogsMode === "FIXED" ? (
-                          <>
+                          <TableCell className="align-top">
+                            <Checkbox
+                              aria-label={`Select draft row ${index + 1}`}
+                              checked={selectedPoDraftRowSet.has(item.tempId)}
+                              onCheckedChange={checked => {
+                                if (
+                                  (checked === true) !==
+                                  poDraftSelection.isSelected(item.tempId)
+                                ) {
+                                  poDraftSelection.toggleRow(item.tempId);
+                                }
+                              }}
+                            />
+                          </TableCell>
+                          <TableCell className="align-top text-sm text-muted-foreground">
+                            {index + 1}
+                          </TableCell>
+                          <TableCell className="space-y-2 align-top">
                             <Input
-                              type="number"
-                              className={cn(
-                                "text-right",
-                                poDraftFieldErrors[item.tempId]?.unitCost &&
-                                  "border-red-500"
-                              )}
-                              placeholder="0.00"
-                              min="0"
-                              step="0.01"
+                              list="po-product-suggestions"
+                              placeholder="Type product name"
+                              value={item.productName}
                               data-po-draft-row-id={item.tempId}
-                              data-po-draft-field="unitCost"
-                              value={item.unitCost}
+                              data-po-draft-field="productName"
                               onChange={e =>
                                 handleLineItemFieldChange(
                                   index,
-                                  "unitCost",
+                                  "productName",
                                   e.target.value
                                 )
                               }
@@ -2231,118 +2214,311 @@ export function PurchaseOrdersWorkSurface() {
                                 handleLineItemFieldBlur(
                                   {
                                     ...item,
-                                    unitCost: e.target.value,
+                                    productName: e.target.value,
                                   },
-                                  "unitCost"
+                                  "productName"
                                 )
                               }
                               onKeyDown={event =>
                                 handleDraftFieldKeyDown(
                                   event,
                                   index,
-                                  "unitCost"
+                                  "productName"
                                 )
                               }
                             />
-                            {poDraftFieldErrors[item.tempId]?.unitCost && (
-                              <p className="text-xs text-red-500 text-right">
-                                {poDraftFieldErrors[item.tempId]?.unitCost}
+                            <div className="flex items-center gap-2 text-xs">
+                              {matchedProduct ? (
+                                <Badge variant="secondary">
+                                  Matched existing product
+                                </Badge>
+                              ) : item.productName.trim() ? (
+                                <Badge variant="outline">
+                                  New product will be created
+                                </Badge>
+                              ) : null}
+                              {productsLoading && (
+                                <span className="text-muted-foreground">
+                                  Loading products...
+                                </span>
+                              )}
+                            </div>
+                            {poDraftFieldErrors[item.tempId]?.productName && (
+                              <p className="text-xs text-red-500">
+                                {poDraftFieldErrors[item.tempId]?.productName}
                               </p>
                             )}
-                          </>
-                        ) : (
-                          <div className="grid grid-cols-2 gap-2">
-                            <div>
-                              <Input
-                                type="number"
-                                className={cn(
-                                  "text-right",
-                                  poDraftFieldErrors[item.tempId]
-                                    ?.unitCostMin && "border-red-500"
-                                )}
-                                placeholder="Min"
-                                min="0"
-                                step="0.01"
-                                value={item.unitCostMin}
-                                onChange={e =>
-                                  handleLineItemFieldChange(
-                                    index,
-                                    "unitCostMin",
-                                    e.target.value
-                                  )
-                                }
-                                onBlur={e =>
-                                  handleLineItemFieldBlur(
-                                    {
-                                      ...item,
-                                      unitCostMin: e.target.value,
-                                    },
-                                    "unitCostMin"
-                                  )
-                                }
-                              />
-                              {poDraftFieldErrors[item.tempId]?.unitCostMin && (
-                                <p className="mt-1 text-xs text-red-500">
-                                  {poDraftFieldErrors[item.tempId]?.unitCostMin}
-                                </p>
+                          </TableCell>
+                          <TableCell className="space-y-2 align-top">
+                            <Select
+                              value={item.category}
+                              onValueChange={value =>
+                                handleLineItemFieldChange(
+                                  index,
+                                  "category",
+                                  value
+                                )
+                              }
+                            >
+                              <SelectTrigger className="h-9">
+                                <SelectValue placeholder="Category" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {CATEGORY_OPTIONS.map(option => (
+                                  <SelectItem
+                                    key={option.value}
+                                    value={option.value}
+                                  >
+                                    {option.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <Input
+                              placeholder="Subcategory"
+                              value={item.subcategory}
+                              onChange={e =>
+                                handleLineItemFieldChange(
+                                  index,
+                                  "subcategory",
+                                  e.target.value
+                                )
+                              }
+                            />
+                          </TableCell>
+                          <TableCell className="align-top">
+                            <Input
+                              type="number"
+                              className={cn(
+                                "text-right",
+                                poDraftFieldErrors[item.tempId]
+                                  ?.quantityOrdered && "border-red-500"
                               )}
-                            </div>
-                            <div>
-                              <Input
-                                type="number"
-                                className={cn(
-                                  "text-right",
+                              placeholder="0"
+                              min="0.01"
+                              step="0.01"
+                              data-po-draft-row-id={item.tempId}
+                              data-po-draft-field="quantityOrdered"
+                              value={item.quantityOrdered}
+                              onChange={e =>
+                                handleLineItemFieldChange(
+                                  index,
+                                  "quantityOrdered",
+                                  e.target.value
+                                )
+                              }
+                              onBlur={e =>
+                                handleLineItemFieldBlur(
+                                  {
+                                    ...item,
+                                    quantityOrdered: e.target.value,
+                                  },
+                                  "quantityOrdered"
+                                )
+                              }
+                              onKeyDown={event =>
+                                handleDraftFieldKeyDown(
+                                  event,
+                                  index,
+                                  "quantityOrdered"
+                                )
+                              }
+                            />
+                            {poDraftFieldErrors[item.tempId]
+                              ?.quantityOrdered && (
+                              <p className="mt-1 text-xs text-red-500 text-right">
+                                {
                                   poDraftFieldErrors[item.tempId]
-                                    ?.unitCostMax && "border-red-500"
+                                    ?.quantityOrdered
+                                }
+                              </p>
+                            )}
+                          </TableCell>
+                          <TableCell className="align-top">
+                            <Select
+                              value={item.cogsMode}
+                              onValueChange={value => {
+                                const nextMode = value as PoCogsMode;
+                                setFormData(prev => ({
+                                  ...prev,
+                                  items: prev.items.map(existing =>
+                                    existing.tempId === item.tempId
+                                      ? {
+                                          ...existing,
+                                          cogsMode: nextMode,
+                                          unitCost:
+                                            nextMode === "FIXED"
+                                              ? existing.unitCost ||
+                                                existing.unitCostMin
+                                              : existing.unitCost,
+                                        }
+                                      : existing
+                                  ),
+                                }));
+                              }}
+                            >
+                              <SelectTrigger className="h-9">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="FIXED">
+                                  Fixed COGS
+                                </SelectItem>
+                                <SelectItem value="RANGE">
+                                  Range COGS
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </TableCell>
+                          <TableCell className="align-top">
+                            {item.cogsMode === "FIXED" ? (
+                              <>
+                                <Input
+                                  type="number"
+                                  className={cn(
+                                    "text-right",
+                                    poDraftFieldErrors[item.tempId]?.unitCost &&
+                                      "border-red-500"
+                                  )}
+                                  placeholder="0.00"
+                                  min="0"
+                                  step="0.01"
+                                  data-po-draft-row-id={item.tempId}
+                                  data-po-draft-field="unitCost"
+                                  value={item.unitCost}
+                                  onChange={e =>
+                                    handleLineItemFieldChange(
+                                      index,
+                                      "unitCost",
+                                      e.target.value
+                                    )
+                                  }
+                                  onBlur={e =>
+                                    handleLineItemFieldBlur(
+                                      {
+                                        ...item,
+                                        unitCost: e.target.value,
+                                      },
+                                      "unitCost"
+                                    )
+                                  }
+                                  onKeyDown={event =>
+                                    handleDraftFieldKeyDown(
+                                      event,
+                                      index,
+                                      "unitCost"
+                                    )
+                                  }
+                                />
+                                {poDraftFieldErrors[item.tempId]?.unitCost && (
+                                  <p className="mt-1 text-xs text-red-500 text-right">
+                                    {poDraftFieldErrors[item.tempId]?.unitCost}
+                                  </p>
                                 )}
-                                placeholder="Max"
-                                min="0"
-                                step="0.01"
-                                value={item.unitCostMax}
-                                onChange={e =>
-                                  handleLineItemFieldChange(
-                                    index,
-                                    "unitCostMax",
-                                    e.target.value
-                                  )
-                                }
-                                onBlur={e =>
-                                  handleLineItemFieldBlur(
-                                    {
-                                      ...item,
-                                      unitCostMax: e.target.value,
-                                    },
-                                    "unitCostMax"
-                                  )
-                                }
-                              />
-                              {poDraftFieldErrors[item.tempId]?.unitCostMax && (
-                                <p className="mt-1 text-xs text-red-500">
-                                  {poDraftFieldErrors[item.tempId]?.unitCostMax}
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                      <div className="col-span-1 text-right text-sm font-medium">
-                        {formatCurrency(rowTotal)}
-                      </div>
-                      <div className="col-span-1 flex justify-end">
-                        {formData.items.length > 1 && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => handleRemoveItem(index)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+                              </>
+                            ) : (
+                              <div className="grid grid-cols-2 gap-2">
+                                <div>
+                                  <Input
+                                    type="number"
+                                    className={cn(
+                                      "text-right",
+                                      poDraftFieldErrors[item.tempId]
+                                        ?.unitCostMin && "border-red-500"
+                                    )}
+                                    placeholder="Min"
+                                    min="0"
+                                    step="0.01"
+                                    value={item.unitCostMin}
+                                    onChange={e =>
+                                      handleLineItemFieldChange(
+                                        index,
+                                        "unitCostMin",
+                                        e.target.value
+                                      )
+                                    }
+                                    onBlur={e =>
+                                      handleLineItemFieldBlur(
+                                        {
+                                          ...item,
+                                          unitCostMin: e.target.value,
+                                        },
+                                        "unitCostMin"
+                                      )
+                                    }
+                                  />
+                                  {poDraftFieldErrors[item.tempId]
+                                    ?.unitCostMin && (
+                                    <p className="mt-1 text-xs text-red-500">
+                                      {
+                                        poDraftFieldErrors[item.tempId]
+                                          ?.unitCostMin
+                                      }
+                                    </p>
+                                  )}
+                                </div>
+                                <div>
+                                  <Input
+                                    type="number"
+                                    className={cn(
+                                      "text-right",
+                                      poDraftFieldErrors[item.tempId]
+                                        ?.unitCostMax && "border-red-500"
+                                    )}
+                                    placeholder="Max"
+                                    min="0"
+                                    step="0.01"
+                                    value={item.unitCostMax}
+                                    onChange={e =>
+                                      handleLineItemFieldChange(
+                                        index,
+                                        "unitCostMax",
+                                        e.target.value
+                                      )
+                                    }
+                                    onBlur={e =>
+                                      handleLineItemFieldBlur(
+                                        {
+                                          ...item,
+                                          unitCostMax: e.target.value,
+                                        },
+                                        "unitCostMax"
+                                      )
+                                    }
+                                  />
+                                  {poDraftFieldErrors[item.tempId]
+                                    ?.unitCostMax && (
+                                    <p className="mt-1 text-xs text-red-500">
+                                      {
+                                        poDraftFieldErrors[item.tempId]
+                                          ?.unitCostMax
+                                      }
+                                    </p>
+                                  )}
+                                </div>
+                              </div>
+                            )}
+                          </TableCell>
+                          <TableCell className="align-top text-right text-sm font-medium">
+                            {formatCurrency(rowTotal)}
+                          </TableCell>
+                          <TableCell className="align-top text-right">
+                            {formData.items.length > 1 && (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRemoveItem(index)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
               </div>
               <div className="flex items-center justify-between text-sm text-muted-foreground">
                 <span>

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -313,6 +313,23 @@ async function startServer() {
 
     // Request logging
     app.use(requestLogger);
+
+    // GitHub webhook endpoint must run before the JSON parser so signature
+    // verification sees the untouched request body.
+    app.post(
+      "/api/webhooks/github",
+      express.raw({ type: "application/json" }),
+      async (req, res) => {
+        try {
+          const { handleGitHubWebhook } = await import("../webhooks/github.js");
+          await handleGitHubWebhook(req, res);
+        } catch (error) {
+          logger.error({ err: error, msg: "GitHub webhook route error" });
+          res.status(500).json({ error: "Internal server error" });
+        }
+      }
+    );
+
     // Configure body parser with larger size limit for file uploads
     app.use(express.json({ limit: "50mb" }));
     app.use(express.urlencoded({ limit: "50mb", extended: true }));
@@ -326,26 +343,6 @@ async function startServer() {
 
     // Simple auth routes under /api/auth
     registerSimpleAuthRoutes(app);
-
-    // GitHub webhook endpoint (must be before JSON body parser middleware)
-    // We need raw body for signature verification
-    app.post(
-      "/api/webhooks/github",
-      express.raw({ type: "application/json" }),
-      async (req, res) => {
-        try {
-          const { handleGitHubWebhook } = await import("../webhooks/github.js");
-          // Convert raw body back to JSON if it's a Buffer
-          if (Buffer.isBuffer(req.body)) {
-            req.body = JSON.parse(req.body.toString());
-          }
-          await handleGitHubWebhook(req, res);
-        } catch (error) {
-          logger.error({ err: error, msg: "GitHub webhook route error" });
-          res.status(500).json({ error: "Internal server error" });
-        }
-      }
-    );
 
     // Apply rate limiting
     app.use("/api/trpc", apiLimiter);

--- a/server/routers/inventory.test.ts
+++ b/server/routers/inventory.test.ts
@@ -531,6 +531,49 @@ describe("Inventory Router", () => {
         product: mockResult.product,
       });
     });
+
+    it("should pass range COGS intake through unchanged", async () => {
+      const mockResult = {
+        success: true,
+        batch: createMockBatch(),
+        vendor: createMockVendor(),
+        brand: createMockBrand(),
+        product: createMockProduct(),
+        lot: createMockLot(),
+      };
+
+      vi.mocked(processIntake).mockResolvedValue(mockResult);
+
+      const input = {
+        vendorName: "Evergreen Supply",
+        brandName: "Evergreen Farms",
+        productName: "Blue Dream",
+        category: "Flower",
+        subcategory: "Indoor",
+        grade: undefined,
+        strainId: null,
+        quantity: 10,
+        cogsMode: "RANGE" as const,
+        unitCogsMin: "8.50",
+        unitCogsMax: "11.25",
+        paymentTerms: "CONSIGNMENT" as const,
+        location: {
+          site: "SITE-1",
+          zone: undefined,
+          rack: undefined,
+          shelf: undefined,
+          bin: undefined,
+        },
+        metadata: undefined,
+      };
+
+      await caller.inventory.intake(input);
+
+      expect(processIntake).toHaveBeenCalledWith({
+        ...input,
+        actorId: mockUser.id,
+      });
+    });
   });
 
   describe("updateStatus", () => {

--- a/server/routers/purchaseOrders.helpers.test.ts
+++ b/server/routers/purchaseOrders.helpers.test.ts
@@ -79,6 +79,13 @@ describe("purchaseOrders helpers", () => {
       )
     ).toBe(true);
     expect(
+      shouldFallbackRecentProductsBySupplier(
+        new Error(
+          "Unknown column 'purchaseOrderItems.deletedAt' in 'where clause'"
+        )
+      )
+    ).toBe(true);
+    expect(
       shouldFallbackRecentProductsBySupplier(new Error("Connection lost"))
     ).toBe(false);
   });

--- a/server/routers/purchaseOrders.test.ts
+++ b/server/routers/purchaseOrders.test.ts
@@ -251,6 +251,33 @@ describe("Purchase Orders Router", () => {
     ).toBe(true);
   });
 
+  it("excludes soft-deleted purchase orders from supplier history queries", async () => {
+    const supplierClientId = 91501;
+
+    await seedPurchaseOrder({
+      id: 915001,
+      supplierClientId,
+      deletedAt: null,
+    });
+    await seedPurchaseOrder({
+      id: 915002,
+      supplierClientId,
+      deletedAt: new Date("2026-02-16"),
+    });
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    vi.mocked(db.select).mockClear();
+    await caller.purchaseOrders.getBySupplier({ supplierClientId });
+    const supplierWhereConditions = getWhereConditionsFromSelectMock(db);
+    expect(
+      supplierWhereConditions.some(condition =>
+        hasDeletedAtNullPredicate(condition)
+      )
+    ).toBe(true);
+  });
+
   it("supports delete then restore lifecycle for purchase orders", async () => {
     const supplierClientId = 92001;
     const activePoId = 920001;

--- a/server/routers/purchaseOrders.ts
+++ b/server/routers/purchaseOrders.ts
@@ -39,6 +39,7 @@ export function shouldFallbackRecentProductsBySupplier(error: unknown) {
     "cogsmode",
     "unitcostmin",
     "unitcostmax",
+    "deletedat",
   ]);
 }
 
@@ -852,7 +853,12 @@ export const purchaseOrdersRouter = router({
       return await db
         .select()
         .from(purchaseOrders)
-        .where(eq(purchaseOrders.supplierClientId, input.supplierClientId))
+        .where(
+          and(
+            eq(purchaseOrders.supplierClientId, input.supplierClientId),
+            isNull(purchaseOrders.deletedAt)
+          )
+        )
         .orderBy(desc(purchaseOrders.createdAt));
     }),
 
@@ -888,11 +894,7 @@ export const purchaseOrdersRouter = router({
           )
           .leftJoin(products, eq(purchaseOrderItems.productId, products.id))
           .where(
-            and(
-              eq(purchaseOrders.supplierClientId, input.supplierClientId),
-              isNull(purchaseOrders.deletedAt),
-              isNull(purchaseOrderItems.deletedAt)
-            )
+            buildRecentSupplierProductsWhereClause(input.supplierClientId, true)
           )
           .orderBy(desc(purchaseOrders.orderDate), desc(purchaseOrderItems.id));
 
@@ -927,10 +929,9 @@ export const purchaseOrdersRouter = router({
           )
           .leftJoin(products, eq(purchaseOrderItems.productId, products.id))
           .where(
-            and(
-              eq(purchaseOrders.supplierClientId, input.supplierClientId),
-              isNull(purchaseOrders.deletedAt),
-              isNull(purchaseOrderItems.deletedAt)
+            buildRecentSupplierProductsWhereClause(
+              input.supplierClientId,
+              false
             )
           )
           .orderBy(desc(purchaseOrders.orderDate), desc(purchaseOrderItems.id));
@@ -1266,6 +1267,22 @@ export function dedupeRecentSupplierProducts<
   }
 
   return recentProducts;
+}
+
+function buildRecentSupplierProductsWhereClause(
+  supplierClientId: number,
+  includeItemDeletedGuard: boolean
+) {
+  const conditions = [
+    eq(purchaseOrders.supplierClientId, supplierClientId),
+    isNull(purchaseOrders.deletedAt),
+  ];
+
+  if (includeItemDeletedGuard) {
+    conditions.push(isNull(purchaseOrderItems.deletedAt));
+  }
+
+  return and(...conditions);
 }
 
 async function findExactProductByName(

--- a/server/webhooks/github.test.ts
+++ b/server/webhooks/github.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Request, Response } from "express";
+import crypto from "crypto";
 
 vi.mock("../db", () => ({
   getDb: vi.fn(),
@@ -37,6 +38,13 @@ function createRequest(
     headers,
     body,
   } as Request;
+}
+
+function signPayload(payload: string, secret: string) {
+  return `sha256=${crypto
+    .createHmac("sha256", secret)
+    .update(payload)
+    .digest("hex")}`;
 }
 
 describe("handleGitHubWebhook", () => {
@@ -78,6 +86,36 @@ describe("handleGitHubWebhook", () => {
 
     expect(status).toHaveBeenCalledWith(403);
     expect(json).toHaveBeenCalledWith({ error: "Invalid signature" });
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("verifies signatures against the raw webhook payload", async () => {
+    process.env.WEBHOOK_SECRET = "topsecret";
+    const payload = JSON.stringify({
+      ref: "refs/heads/feature/test",
+      repository: { full_name: "EvanTenenbaum/TERP" },
+      head_commit: {
+        id: "1234567",
+        message: "test",
+        timestamp: "2026-03-10T00:00:00.000Z",
+        author: { name: "Test", email: "test@example.com" },
+      },
+      pusher: { name: "Test", email: "test@example.com" },
+      sender: { login: "tester" },
+    });
+    const req = createRequest(
+      {
+        "x-hub-signature-256": signPayload(payload, "topsecret"),
+        "x-github-event": "push",
+      },
+      Buffer.from(payload, "utf8")
+    );
+    const { response, status, json } = createResponse();
+
+    await handleGitHubWebhook(req, response);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ message: "Not a main branch push" });
     expect(getDb).not.toHaveBeenCalled();
   });
 });

--- a/server/webhooks/github.ts
+++ b/server/webhooks/github.ts
@@ -31,6 +31,43 @@ interface GitHubPushPayload {
   };
 }
 
+function getWebhookPayload(
+  req: Request
+): { rawPayload: string; parsedPayload: GitHubPushPayload | null } | null {
+  if (Buffer.isBuffer(req.body)) {
+    const rawPayload = req.body.toString("utf8");
+    try {
+      return {
+        rawPayload,
+        parsedPayload: JSON.parse(rawPayload) as GitHubPushPayload,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof req.body === "string") {
+    try {
+      return {
+        rawPayload: req.body,
+        parsedPayload: JSON.parse(req.body) as GitHubPushPayload,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  const parsedPayload =
+    req.body && typeof req.body === "object"
+      ? (req.body as GitHubPushPayload)
+      : null;
+
+  return {
+    rawPayload: JSON.stringify(parsedPayload ?? {}),
+    parsedPayload,
+  };
+}
+
 /**
  * Verify GitHub webhook signature using HMAC-SHA256
  */
@@ -80,10 +117,21 @@ export async function handleGitHubWebhook(req: Request, res: Response) {
     const event = req.headers["x-github-event"] as string;
     const deliveryId = req.headers["x-github-delivery"] as string;
 
-    // Verify signature
+    const webhookPayload = getWebhookPayload(req);
+    if (!webhookPayload) {
+      logger.error("[WEBHOOK] Invalid JSON payload");
+      return res.status(400).json({ error: "Invalid JSON payload" });
+    }
+
+    // Verify signature against the raw request body GitHub sent.
     logger.info("[WEBHOOK] Verifying signature");
-    const payload = JSON.stringify(req.body);
-    if (!verifyGitHubSignature(payload, signature, webhookSecret)) {
+    if (
+      !verifyGitHubSignature(
+        webhookPayload.rawPayload,
+        signature,
+        webhookSecret
+      )
+    ) {
       logger.error("Invalid GitHub webhook signature");
       return res.status(403).json({ error: "Invalid signature" });
     }
@@ -93,7 +141,10 @@ export async function handleGitHubWebhook(req: Request, res: Response) {
       return res.status(200).json({ message: "Event type not supported" });
     }
 
-    const pushPayload = req.body as GitHubPushPayload;
+    const pushPayload = webhookPayload.parsedPayload;
+    if (!pushPayload) {
+      return res.status(400).json({ error: "Invalid webhook payload" });
+    }
 
     // Only process pushes to main branch
     if (pushPayload.ref !== "refs/heads/main") {

--- a/tests-e2e/critical-paths/control-action-contracts.spec.ts
+++ b/tests-e2e/critical-paths/control-action-contracts.spec.ts
@@ -67,10 +67,10 @@ const ACTION_CONTRACTS: ActionContract[] = [
   },
   {
     id: "inventory-product-intake",
-    route: "/inventory",
+    route: "/operations?tab=inventory",
     selector:
-      '[data-testid="new-batch-btn"], button:has-text("Product Intake"), button:has-text("Intake")',
-    expectedUrlPattern: /\/purchase-orders\?tab=receiving/,
+      '[data-testid="new-batch-btn"], button:has-text("Receiving"), button:has-text("Product Intake"), button:has-text("Intake")',
+    expectedUrlPattern: /\/operations\?tab=receiving/,
   },
   {
     id: "relationships-add-client",

--- a/tests-e2e/critical-paths/pick-pack.spec.ts
+++ b/tests-e2e/critical-paths/pick-pack.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E Tests: Pick & Pack Workflow (WS-003)
+ * E2E Tests: Shipping Workflow (WS-003)
  *
  * Tests the critical fulfillment workflow for packing orders.
  */
@@ -7,25 +7,24 @@
 import { test, expect } from "@playwright/test";
 import { loginAsAdmin } from "../fixtures/auth";
 
-test.describe("Pick & Pack Workflow (WS-003)", () => {
+const SHIPPING_ROUTE = "/operations?tab=shipping";
+
+test.describe("Shipping Workflow (WS-003)", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
-  test("should navigate to pick and pack page", async ({ page }) => {
-    // Navigate to pick and pack
-    await page.goto("/pick-pack");
+  test("should navigate to shipping page", async ({ page }) => {
+    await page.goto(SHIPPING_ROUTE);
 
     // Verify page loaded
     await expect(
-      page.locator(
-        'h1:has-text("Pick"), h1:has-text("Pack"), [data-testid="pick-pack-page"]'
-      )
+      page.locator('h1:has-text("Shipping"), [data-testid="pick-pack-page"]')
     ).toBeVisible({ timeout: 10000 });
   });
 
   test("should display order queue", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Look for order queue/list
@@ -37,7 +36,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should filter orders by status", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Look for status filter
@@ -63,7 +62,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should open order details for packing", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order in queue
@@ -84,7 +83,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should display order items for picking", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order
@@ -110,7 +109,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should allow packing items into bags", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order
@@ -135,7 +134,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should show bag management interface", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order
@@ -166,7 +165,7 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 
   test("should mark order as ready when fully packed", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order
@@ -191,13 +190,13 @@ test.describe("Pick & Pack Workflow (WS-003)", () => {
   });
 });
 
-test.describe("Pick & Pack - Printing", () => {
+test.describe("Shipping - Printing", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
   test("should have print packing slip option", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Click on first order
@@ -221,7 +220,7 @@ test.describe("Pick & Pack - Printing", () => {
   });
 });
 
-test.describe("Pick & Pack - Mobile Responsive", () => {
+test.describe("Shipping - Mobile Responsive", () => {
   test.use({ viewport: { width: 375, height: 667 } });
 
   test.beforeEach(async ({ page }) => {
@@ -229,7 +228,7 @@ test.describe("Pick & Pack - Mobile Responsive", () => {
   });
 
   test("should be usable on mobile viewport", async ({ page }) => {
-    await page.goto("/pick-pack");
+    await page.goto(SHIPPING_ROUTE);
     await page.waitForLoadState("networkidle");
 
     // Page should be visible and not have horizontal scroll

--- a/tests-e2e/oracles/executor.ts
+++ b/tests-e2e/oracles/executor.ts
@@ -491,6 +491,7 @@ function buildSelectorCandidates(
     if (/batch-form|intake-form/i.test(dataTestId)) {
       candidates.add("[role='dialog']");
       candidates.add("[role='dialog']:has-text('New Product Intake')");
+      candidates.add("[role='dialog']:has-text('New Receiving')");
     }
 
     if (/search/i.test(dataTestId)) {

--- a/tests-e2e/oracles/inventory/create-batch.oracle.yaml
+++ b/tests-e2e/oracles/inventory/create-batch.oracle.yaml
@@ -31,7 +31,7 @@ steps:
     wait_after: 1000
 
   - action: wait
-    for: "[data-testid='batch-form'], [role='dialog']:has-text('New Product Intake'), form, .intake-form"
+    for: "[data-testid='batch-form'], [role='dialog']:has-text('New Receiving'), [role='dialog']:has-text('New Product Intake'), form, .intake-form"
     timeout: 5000
 
   - action: type

--- a/tests-e2e/oracles/inventory/create-strain.oracle.yaml
+++ b/tests-e2e/oracles/inventory/create-strain.oracle.yaml
@@ -33,7 +33,7 @@ steps:
     wait_after: 500
 
   - action: wait
-    for: "[role='dialog']:has-text('New Product Intake'), [data-testid='batch-form'], form"
+    for: "[role='dialog']:has-text('New Receiving'), [role='dialog']:has-text('New Product Intake'), [data-testid='batch-form'], form"
     timeout: 5000
 
   - action: click


### PR DESCRIPTION
## Summary
- fix GitHub webhook raw-body handling and legacy supplier-history fallback drift
- make purchase orders more spreadsheet-like with supplier history, quick add, and live typed product auto-resolution
- restore range COGS in receiving/direct intake and align high-value Receiving/Shipping naming selectors

## Verification
- pnpm check
- pnpm lint
- pnpm exec vitest run server/webhooks/github.test.ts server/routers/purchaseOrders.helpers.test.ts server/routers/purchaseOrders.test.ts server/routers/inventory.test.ts
- pnpm test
- pnpm build
