### PR TITLE
feat: unify relationship profile experience

### DIFF
--- a/client/src/components/VendorRedirect.tsx
+++ b/client/src/components/VendorRedirect.tsx
@@ -1,14 +1,15 @@
 /**
  * VendorRedirect Component
- * 
+ *
  * Handles redirects from deprecated /vendors/:id routes to /clients/:clientId
  * Maps legacy vendor IDs to client IDs via the supplier_profiles table.
- * 
+ *
  * @deprecated This component exists only for backward compatibility during migration.
  * Once all vendor links are updated, this can be removed.
  */
 import { useEffect } from "react";
 import { useParams, useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { trpc } from "../lib/trpc";
 
 export function VendorRedirect() {
@@ -16,7 +17,11 @@ export function VendorRedirect() {
   const [, setLocation] = useLocation();
 
   // Query the vendor to get the mapped client ID
-  const { data: vendorResponse, isLoading, error } = trpc.vendors.getById.useQuery(
+  const {
+    data: vendorResponse,
+    isLoading,
+    error,
+  } = trpc.vendors.getById.useQuery(
     { id: Number(id) },
     { enabled: !!id && !isNaN(Number(id)) }
   );
@@ -27,9 +32,11 @@ export function VendorRedirect() {
     if (error || !vendorResponse) {
       // Vendor not found - redirect to suppliers list
       if (import.meta.env.DEV) {
-        console.warn(`[VendorRedirect] Vendor ${id} not found, redirecting to suppliers list`);
+        console.warn(
+          `[VendorRedirect] Vendor ${id} not found, redirecting to suppliers list`
+        );
       }
-      setLocation("/clients?clientTypes=seller");
+      setLocation("/clients?tab=suppliers");
       return;
     }
 
@@ -39,22 +46,28 @@ export function VendorRedirect() {
       if (clientId) {
         // Redirect to the client profile page
         if (import.meta.env.DEV) {
-          console.info(`[VendorRedirect] Redirecting vendor ${id} to client ${clientId}`);
+          console.info(
+            `[VendorRedirect] Redirecting vendor ${id} to client ${clientId}`
+          );
         }
-        setLocation(`/clients/${clientId}`);
+        setLocation(buildRelationshipProfilePath(clientId, "supply-inventory"));
       } else {
         // Legacy vendor without client mapping - redirect to suppliers list
         if (import.meta.env.DEV) {
-          console.warn(`[VendorRedirect] Vendor ${id} has no client mapping, redirecting to suppliers list`);
+          console.warn(
+            `[VendorRedirect] Vendor ${id} has no client mapping, redirecting to suppliers list`
+          );
         }
-        setLocation("/clients?clientTypes=seller");
+        setLocation("/clients?tab=suppliers");
       }
     } else {
       // Error response - redirect to suppliers list
       if (import.meta.env.DEV) {
-        console.warn(`[VendorRedirect] Error fetching vendor ${id}, redirecting to suppliers list`);
+        console.warn(
+          `[VendorRedirect] Error fetching vendor ${id}, redirecting to suppliers list`
+        );
       }
-      setLocation("/clients?clientTypes=seller");
+      setLocation("/clients?tab=suppliers");
     }
   }, [id, vendorResponse, isLoading, error, setLocation]);
 
@@ -63,7 +76,9 @@ export function VendorRedirect() {
     <div className="flex items-center justify-center h-64">
       <div className="text-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
-        <p className="text-muted-foreground">Redirecting to supplier profile...</p>
+        <p className="text-muted-foreground">
+          Redirecting to supplier profile...
+        </p>
       </div>
     </div>
   );

--- a/client/src/components/clients/AddClientWizard.tsx
+++ b/client/src/components/clients/AddClientWizard.tsx
@@ -49,6 +49,43 @@ interface AddClientWizardProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess?: (clientId: number) => void;
+  defaultRoles?: Partial<
+    Pick<
+      AddClientWizardFormData,
+      "isBuyer" | "isSeller" | "isBrand" | "isReferee" | "isContractor"
+    >
+  >;
+}
+
+interface AddClientWizardFormData {
+  teriCode: string;
+  name: string;
+  companyName: string;
+  email: string;
+  phone: string;
+  secondaryPhone: string;
+  address: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  businessType:
+    | ""
+    | "RETAIL"
+    | "WHOLESALE"
+    | "DISPENSARY"
+    | "DELIVERY"
+    | "MANUFACTURER"
+    | "DISTRIBUTOR"
+    | "OTHER";
+  preferredContact: "" | "EMAIL" | "PHONE" | "TEXT" | "ANY";
+  paymentTerms: number;
+  notes: string;
+  isBuyer: boolean;
+  isSeller: boolean;
+  isBrand: boolean;
+  isReferee: boolean;
+  isContractor: boolean;
+  tags: string[];
 }
 
 // Step names for the wizard
@@ -61,42 +98,43 @@ const STEP_NAMES = {
 
 const TOTAL_STEPS = 4;
 
+function buildInitialFormData(
+  defaultRoles?: AddClientWizardProps["defaultRoles"]
+): AddClientWizardFormData {
+  return {
+    teriCode: "",
+    name: "",
+    companyName: "",
+    email: "",
+    phone: "",
+    secondaryPhone: "",
+    address: "",
+    city: "",
+    state: "",
+    zipCode: "",
+    businessType: "",
+    preferredContact: "",
+    paymentTerms: 30,
+    notes: "",
+    isBuyer: defaultRoles?.isBuyer ?? false,
+    isSeller: defaultRoles?.isSeller ?? false,
+    isBrand: defaultRoles?.isBrand ?? false,
+    isReferee: defaultRoles?.isReferee ?? false,
+    isContractor: defaultRoles?.isContractor ?? false,
+    tags: [],
+  };
+}
+
 export function AddClientWizard({
   open,
   onOpenChange,
   onSuccess,
+  defaultRoles,
 }: AddClientWizardProps) {
   const [step, setStep] = useState(1);
-  const [formData, setFormData] = useState({
-    teriCode: "",
-    name: "",
-    companyName: "", // FEAT-001: Added company name field
-    email: "",
-    phone: "",
-    secondaryPhone: "", // FEAT-001: Added secondary phone
-    address: "",
-    city: "", // FEAT-001: Added city
-    state: "", // FEAT-001: Added state
-    zipCode: "", // FEAT-001: Added zip code
-    businessType: "" as
-      | ""
-      | "RETAIL"
-      | "WHOLESALE"
-      | "DISPENSARY"
-      | "DELIVERY"
-      | "MANUFACTURER"
-      | "DISTRIBUTOR"
-      | "OTHER", // FEAT-001: Business type
-    preferredContact: "" as "" | "EMAIL" | "PHONE" | "TEXT" | "ANY", // FEAT-001: Preferred contact method
-    paymentTerms: 30, // FEAT-001: Payment terms in days
-    notes: "", // FEAT-001: Added notes field
-    isBuyer: false,
-    isSeller: false,
-    isBrand: false,
-    isReferee: false,
-    isContractor: false,
-    tags: [] as string[],
-  });
+  const [formData, setFormData] = useState<AddClientWizardFormData>(() =>
+    buildInitialFormData(defaultRoles)
+  );
   const [newTag, setNewTag] = useState("");
   const [deleteTagConfirm, setDeleteTagConfirm] = useState<string | null>(null);
 
@@ -205,28 +243,7 @@ export function AddClientWizard({
 
   const resetForm = () => {
     setStep(1);
-    setFormData({
-      teriCode: "",
-      name: "",
-      companyName: "",
-      email: "",
-      phone: "",
-      secondaryPhone: "",
-      address: "",
-      city: "",
-      state: "",
-      zipCode: "",
-      businessType: "",
-      preferredContact: "",
-      paymentTerms: 30,
-      notes: "",
-      isBuyer: false,
-      isSeller: false,
-      isBrand: false,
-      isReferee: false,
-      isContractor: false,
-      tags: [],
-    });
+    setFormData(buildInitialFormData(defaultRoles));
     setNewTag("");
   };
 

--- a/client/src/components/clients/ProfileQuickPanel.tsx
+++ b/client/src/components/clients/ProfileQuickPanel.tsx
@@ -1,0 +1,592 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import {
+  ArrowRightLeft,
+  CircleDollarSign,
+  ExternalLink,
+  FileStack,
+  Package,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
+import {
+  buildProcurementWorkspacePath,
+  buildSalesWorkspacePath,
+} from "@/lib/workspaceRoutes";
+
+type QuickPanelSection =
+  | "overview"
+  | "sales-pricing"
+  | "money"
+  | "supply-inventory";
+
+interface ProfileQuickPanelProps {
+  clientId: number;
+  initialSection?: QuickPanelSection;
+  onNavigate?: (path: string) => void;
+  onClose?: () => void;
+}
+
+const formatMoney = (value: number | null | undefined) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value ?? 0);
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) return "No activity yet";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "No activity yet";
+  return parsed.toLocaleString();
+};
+
+function QuickStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="rounded-xl border border-border/70 bg-muted/40 p-3">
+      <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+export function ProfileQuickPanel({
+  clientId,
+  initialSection = "overview",
+  onNavigate,
+  onClose,
+}: ProfileQuickPanelProps) {
+  const [, setLocation] = useLocation();
+  const [section, setSection] = useState<QuickPanelSection>(initialSection);
+
+  useEffect(() => {
+    setSection(initialSection);
+  }, [initialSection]);
+
+  const navigate = useCallback(
+    (path: string) => {
+      if (onNavigate) {
+        onNavigate(path);
+      } else {
+        setLocation(path);
+      }
+      onClose?.();
+    },
+    [onClose, onNavigate, setLocation]
+  );
+
+  const shellQuery = trpc.relationshipProfile.getShell.useQuery({ clientId });
+  const salesQuery = trpc.relationshipProfile.getSalesPricing.useQuery(
+    { clientId },
+    { enabled: section === "sales-pricing" }
+  );
+  const moneyQuery = trpc.relationshipProfile.getMoney.useQuery(
+    { clientId },
+    { enabled: section === "money" }
+  );
+  const supplyQuery = trpc.relationshipProfile.getSupplyInventory.useQuery(
+    { clientId },
+    { enabled: section === "supply-inventory" }
+  );
+
+  const shell = shellQuery.data;
+  const moneySummary =
+    moneyQuery.data?.summary ?? shell?.financials.moneySummary;
+
+  const primaryActions = useMemo(() => {
+    if (!shell) return [];
+
+    const isCustomer = shell.roles.includes("Customer");
+    const isSupplier = shell.roles.includes("Supplier");
+
+    const actions = [
+      {
+        label: "Open full profile",
+        icon: ExternalLink,
+        action: () => navigate(buildRelationshipProfilePath(clientId, section)),
+      },
+      {
+        label: "Money",
+        icon: CircleDollarSign,
+        action: () => navigate(buildRelationshipProfilePath(clientId, "money")),
+      },
+      {
+        label: "Open ledger",
+        icon: FileStack,
+        action: () => navigate(`/clients/${clientId}/ledger`),
+      },
+    ];
+
+    if (isCustomer) {
+      actions.push(
+        {
+          label: "Pricing",
+          icon: FileStack,
+          action: () =>
+            navigate(buildRelationshipProfilePath(clientId, "sales-pricing")),
+        },
+        {
+          label: "New order",
+          icon: ArrowRightLeft,
+          action: () =>
+            navigate(buildSalesWorkspacePath("create-order", { clientId })),
+        }
+      );
+    }
+
+    if (isSupplier) {
+      actions.push({
+        label: "New PO",
+        icon: Package,
+        action: () =>
+          navigate(
+            buildProcurementWorkspacePath(undefined, {
+              supplierClientId: clientId,
+            })
+          ),
+      });
+    }
+
+    return actions;
+  }, [clientId, navigate, section, shell]);
+
+  if (shellQuery.isLoading) {
+    return (
+      <div className="space-y-3">
+        <div className="h-8 w-2/3 animate-pulse rounded bg-muted" />
+        <div className="grid grid-cols-2 gap-3">
+          <div className="h-20 animate-pulse rounded-xl bg-muted" />
+          <div className="h-20 animate-pulse rounded-xl bg-muted" />
+          <div className="h-20 animate-pulse rounded-xl bg-muted" />
+          <div className="h-20 animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!shell) {
+    return (
+      <div className="rounded-xl border border-dashed border-border p-6 text-sm text-muted-foreground">
+        Profile data is unavailable.
+      </div>
+    );
+  }
+
+  const compactInventoryItems = shell.roles.includes("Supplier")
+    ? (supplyQuery.data?.supplier?.batches ?? []).map(item => ({
+        id: item.id,
+        title: item.productName,
+        sku: item.sku,
+        status: item.status,
+        onHandQty: item.onHandQty,
+      }))
+    : (supplyQuery.data?.systemInventory ?? []).map(item => ({
+        id: item.id,
+        title: item.productName,
+        sku: item.sku,
+        status: item.status,
+        onHandQty: item.onHandQty,
+      }));
+
+  const primaryMoneyMetric =
+    moneySummary?.mode === "supplier"
+      ? {
+          label: "Payable due",
+          value: formatMoney(moneySummary.payable.amountDue),
+        }
+      : moneySummary?.mode === "hybrid"
+        ? {
+            label: "Net position",
+            value: formatMoney(moneySummary.netPosition),
+          }
+        : {
+            label: "Receivable",
+            value: formatMoney(
+              moneySummary?.receivable.computedBalance ??
+                shell.financials.balance.computedBalance
+            ),
+          };
+
+  const secondaryMoneyMetric =
+    moneySummary?.mode === "supplier"
+      ? {
+          label: "Paid to supplier",
+          value: formatMoney(moneySummary.payable.amountPaid),
+        }
+      : moneySummary?.mode === "hybrid"
+        ? {
+            label: "Payable due",
+            value: formatMoney(moneySummary.payable.amountDue),
+          }
+        : {
+            label: "Credit limit",
+            value: formatMoney(shell.financials.creditLimit),
+          };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+              Relationship Profile
+            </p>
+            <h2 className="truncate text-xl font-semibold">{shell.name}</h2>
+            <p className="text-sm text-muted-foreground">
+              {shell.teriCode ? `${shell.teriCode} · ` : ""}
+              {formatDateTime(shell.lastTouchAt)}
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-end gap-1">
+            {shell.roles.map(role => (
+              <Badge key={role} variant="secondary">
+                {role}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        {shell.alerts.length > 0 ? (
+          <div className="space-y-2">
+            {shell.alerts.slice(0, 2).map(alert => (
+              <div
+                key={alert.label}
+                className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950"
+              >
+                <p className="font-medium">{alert.label}</p>
+                <p className="text-xs text-amber-900/80">{alert.detail}</p>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <QuickStat
+          label={primaryMoneyMetric.label}
+          value={primaryMoneyMetric.value}
+        />
+        <QuickStat
+          label={secondaryMoneyMetric.label}
+          value={secondaryMoneyMetric.value}
+        />
+        <QuickStat
+          label="Drafts"
+          value={
+            shell.openArtifacts.salesSheetDrafts +
+            shell.openArtifacts.orderDrafts
+          }
+        />
+        <QuickStat label="Open quotes" value={shell.openArtifacts.openQuotes} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {primaryActions.map(action => (
+          <Button
+            key={action.label}
+            variant="outline"
+            className="justify-start"
+            onClick={action.action}
+          >
+            <action.icon className="mr-2 h-4 w-4" />
+            {action.label}
+          </Button>
+        ))}
+      </div>
+
+      <Tabs
+        value={section}
+        onValueChange={value => setSection(value as QuickPanelSection)}
+        className="space-y-4"
+      >
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="sales-pricing">Sales</TabsTrigger>
+          <TabsTrigger value="money">Money</TabsTrigger>
+          <TabsTrigger value="supply-inventory">Supply</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {section === "overview" ? (
+        <div className="space-y-3">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Identity</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p>{shell.email || "No email on file"}</p>
+              <p>{shell.phone || "No phone on file"}</p>
+              <p>{shell.address || "No address on file"}</p>
+              <p className="text-muted-foreground">
+                Referrer: {shell.referrer?.name || "None"}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Open Work</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span>Sales sheet drafts</span>
+                <span className="font-medium">
+                  {shell.openArtifacts.salesSheetDrafts}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Sent sales sheets</span>
+                <span className="font-medium">
+                  {shell.openArtifacts.sentSalesSheets}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Order drafts</span>
+                <span className="font-medium">
+                  {shell.openArtifacts.orderDrafts}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Active needs</span>
+                <span className="font-medium">
+                  {shell.openArtifacts.activeNeeds}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      {section === "sales-pricing" ? (
+        <div className="space-y-3">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Pricing</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p className="font-medium">
+                {salesQuery.data?.pricingProfile?.name || "No pricing profile"}
+              </p>
+              <p className="text-muted-foreground">
+                {salesQuery.data?.pricingProfile?.description ||
+                  "Apply a pricing profile or manage rules from the full profile."}
+              </p>
+              <div className="pt-1 text-xs text-muted-foreground">
+                {salesQuery.data?.rules.length || 0} active rule
+                {(salesQuery.data?.rules.length || 0) === 1 ? "" : "s"}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Recent Artifacts</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {(salesQuery.data?.mergedArtifacts || [])
+                .slice(0, 5)
+                .map(item => (
+                  <div
+                    key={item.id}
+                    className="flex items-start justify-between gap-3 text-sm"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{item.label}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.sublabel}
+                      </p>
+                    </div>
+                    <div className="shrink-0 text-right text-xs text-muted-foreground">
+                      <p>{formatMoney(item.amount)}</p>
+                    </div>
+                  </div>
+                ))}
+              {!salesQuery.data?.mergedArtifacts?.length ? (
+                <p className="text-sm text-muted-foreground">
+                  No pricing or sales artifacts yet.
+                </p>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      {section === "money" ? (
+        <div className="space-y-3">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Balance Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <QuickStat
+                label={
+                  moneySummary?.mode === "supplier"
+                    ? "Payable due"
+                    : moneySummary?.mode === "hybrid"
+                      ? "Net position"
+                      : "Receivable"
+                }
+                value={formatMoney(
+                  moneySummary?.mode === "supplier"
+                    ? moneySummary?.payable.amountDue
+                    : moneySummary?.mode === "hybrid"
+                      ? moneySummary?.netPosition
+                      : (moneyQuery.data?.balance.computedBalance ??
+                        shell.financials.balance.computedBalance)
+                )}
+              />
+              <QuickStat
+                label={
+                  moneySummary?.mode === "supplier"
+                    ? "Paid to supplier"
+                    : "Ledger net"
+                }
+                value={formatMoney(
+                  moneySummary?.mode === "supplier"
+                    ? moneySummary?.payable.amountPaid
+                    : moneyQuery.data?.ledgerTotals.netBalance
+                )}
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Recent Money Events</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {(moneyQuery.data?.ledgerTimeline || []).slice(0, 5).map(item => (
+                <div
+                  key={item.id}
+                  className="flex items-start justify-between gap-3 text-sm"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{item.label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.date
+                        ? new Date(item.date).toLocaleDateString()
+                        : "No date"}
+                    </p>
+                  </div>
+                  <p className="shrink-0 font-medium">
+                    {item.creditAmount > 0 ? "-" : "+"}
+                    {formatMoney(item.creditAmount || item.debitAmount)}
+                  </p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      {section === "supply-inventory" ? (
+        <div className="space-y-3">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">
+                {shell.roles.includes("Supplier")
+                  ? "Supplier Inventory"
+                  : "Current System Inventory"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {compactInventoryItems.slice(0, 5).map(item => (
+                <div
+                  key={item.id}
+                  className="flex items-start justify-between gap-3 text-sm"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{item.title}</p>
+                    <p className="text-xs text-muted-foreground">{item.sku}</p>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-muted-foreground">
+                    <p>{item.status || "-"}</p>
+                    <p>{Number(item.onHandQty).toLocaleString()}</p>
+                  </div>
+                </div>
+              ))}
+              {shell.roles.includes("Supplier") &&
+              compactInventoryItems.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No supplier inventory is active right now.
+                </p>
+              ) : null}
+              {!shell.roles.includes("Supplier") &&
+              !supplyQuery.data?.systemInventory?.length ? (
+                <p className="text-sm text-muted-foreground">
+                  No inventory is currently visible.
+                </p>
+              ) : null}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">
+                {shell.roles.includes("Supplier")
+                  ? "Purchase Orders"
+                  : "Customer Needs"}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {(shell.roles.includes("Supplier")
+                ? supplyQuery.data?.supplier?.purchaseOrders?.map(item => ({
+                    id: item.id,
+                    label: item.poNumber,
+                    sublabel: item.status,
+                    meta: formatMoney(item.total),
+                  }))
+                : supplyQuery.data?.buyerNeeds?.map(item => ({
+                    id: item.id,
+                    label: item.label,
+                    sublabel: item.priority,
+                    meta: item.status,
+                  }))
+              )
+                ?.slice(0, 5)
+                .map(item => (
+                  <div
+                    key={item.id}
+                    className="flex items-start justify-between gap-3 text-sm"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{item.label}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.sublabel}
+                      </p>
+                    </div>
+                    <p className="shrink-0 text-xs text-muted-foreground">
+                      {item.meta}
+                    </p>
+                  </div>
+                ))}
+              {shell.roles.includes("Supplier") &&
+              !supplyQuery.data?.supplier?.purchaseOrders?.length ? (
+                <p className="text-sm text-muted-foreground">
+                  No purchase orders are linked to this supplier yet.
+                </p>
+              ) : null}
+              {!shell.roles.includes("Supplier") &&
+              !supplyQuery.data?.buyerNeeds?.length ? (
+                <p className="text-sm text-muted-foreground">
+                  No active customer needs are attached to this profile.
+                </p>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default ProfileQuickPanel;

--- a/client/src/components/clients/QuickCreateClient.tsx
+++ b/client/src/components/clients/QuickCreateClient.tsx
@@ -36,6 +36,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { toast } from "sonner";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { UserPlus, Search, Check, ExternalLink, Loader2 } from "lucide-react";
 import { useLocation } from "wouter";
 
@@ -122,7 +123,9 @@ export function QuickCreateClient({
               variant="link"
               size="sm"
               className="h-auto p-0 text-primary"
-              onClick={() => setLocation(`/clients/${result.client.id}`)}
+              onClick={() =>
+                setLocation(buildRelationshipProfilePath(result.client.id))
+              }
             >
               <ExternalLink className="h-3 w-3 mr-1" />
               View

--- a/client/src/components/clients/ReferrerLookup.tsx
+++ b/client/src/components/clients/ReferrerLookup.tsx
@@ -10,6 +10,7 @@
 
 import React, { useState } from "react";
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import {
   Card,
   CardContent,
@@ -171,7 +172,9 @@ export function ReferrerLookup({ onSelectClient }: ReferrerLookupProps) {
                             if (onSelectClient) {
                               onSelectClient(client.id);
                             } else {
-                              setLocation(`/clients/${client.id}`);
+                              setLocation(
+                                buildRelationshipProfilePath(client.id)
+                              );
                             }
                           }}
                         >
@@ -333,7 +336,13 @@ export function ReferralStatsCard() {
                 <div
                   key={referrer.referrerId}
                   className="flex items-center justify-between p-3 border rounded-lg hover:bg-accent cursor-pointer"
-                  onClick={() => setLocation(`/clients/${referrer.referrerId}`)}
+                  onClick={() => {
+                    if (referrer.referrerId) {
+                      setLocation(
+                        buildRelationshipProfilePath(referrer.referrerId)
+                      );
+                    }
+                  }}
                 >
                   <div className="flex items-center gap-3">
                     <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-sm font-medium">
@@ -418,7 +427,9 @@ export function ReferralTreeView({ clientId }: ReferralTreeViewProps) {
                   variant="ghost"
                   size="sm"
                   className="h-auto py-1 px-2"
-                  onClick={() => setLocation(`/clients/${referrer.id}`)}
+                  onClick={() =>
+                    setLocation(buildRelationshipProfilePath(referrer.id))
+                  }
                 >
                   <User className="h-4 w-4 mr-2" />
                   {referrer.name} ({referrer.teriCode})
@@ -441,7 +452,9 @@ export function ReferralTreeView({ clientId }: ReferralTreeViewProps) {
                 key={referral.id}
                 variant="outline"
                 className="justify-start h-auto py-2"
-                onClick={() => setLocation(`/clients/${referral.id}`)}
+                onClick={() =>
+                  setLocation(buildRelationshipProfilePath(referral.id))
+                }
               >
                 <User className="h-4 w-4 mr-2" />
                 <span className="truncate">{referral.name}</span>

--- a/client/src/components/clients/VIPPortalSettings.tsx
+++ b/client/src/components/clients/VIPPortalSettings.tsx
@@ -88,6 +88,7 @@ export function VIPPortalSettings({
         setEmail("");
         setPassword("");
         utils.clients.getById.invalidate({ clientId });
+        utils.relationshipProfile.getShell.invalidate({ clientId });
       },
       onError: error => {
         toast.error(error.message || "Failed to enable VIP Portal");
@@ -101,6 +102,7 @@ export function VIPPortalSettings({
         toast.success("VIP Portal disabled");
         setDisableDialogOpen(false);
         utils.clients.getById.invalidate({ clientId });
+        utils.relationshipProfile.getShell.invalidate({ clientId });
       },
       onError: error => {
         toast.error(error.message || "Failed to disable VIP Portal");

--- a/client/src/components/dashboard/LeaderboardWidget.tsx
+++ b/client/src/components/dashboard/LeaderboardWidget.tsx
@@ -27,9 +27,14 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 
 // Types
-type MetricOption = "master_score" | "ytd_revenue" | "order_frequency" | "on_time_payment_rate";
+type MetricOption =
+  | "master_score"
+  | "ytd_revenue"
+  | "order_frequency"
+  | "on_time_payment_rate";
 type ModeOption = "top" | "bottom";
 type ClientType = "ALL" | "CUSTOMER" | "SUPPLIER";
 
@@ -53,12 +58,21 @@ const RankIcon = React.memo(function RankIcon({ rank }: { rank: number }) {
   if (rank === 1) return <Trophy className="h-4 w-4 text-yellow-500" />;
   if (rank === 2) return <Medal className="h-4 w-4 text-gray-400" />;
   if (rank === 3) return <Award className="h-4 w-4 text-amber-600" />;
-  return <span className="w-4 text-center text-xs text-muted-foreground">{rank}</span>;
+  return (
+    <span className="w-4 text-center text-xs text-muted-foreground">
+      {rank}
+    </span>
+  );
 });
 
-const TrendIcon = React.memo(function TrendIcon({ trend }: { trend: "up" | "down" | "stable" }) {
+const TrendIcon = React.memo(function TrendIcon({
+  trend,
+}: {
+  trend: "up" | "down" | "stable";
+}) {
   if (trend === "up") return <TrendingUp className="h-3 w-3 text-green-500" />;
-  if (trend === "down") return <TrendingDown className="h-3 w-3 text-red-500" />;
+  if (trend === "down")
+    return <TrendingDown className="h-3 w-3 text-red-500" />;
   return <Minus className="h-3 w-3 text-muted-foreground" />;
 });
 
@@ -83,7 +97,7 @@ export const LeaderboardWidget = React.memo(function LeaderboardWidget({
 
   const handleClientClick = useCallback(
     (clientId: number) => {
-      navigate(`/clients/${clientId}`);
+      navigate(buildRelationshipProfilePath(clientId));
     },
     [navigate]
   );
@@ -116,13 +130,20 @@ export const LeaderboardWidget = React.memo(function LeaderboardWidget({
             {mode === "top" ? "Top Performers" : "Needs Attention"}
           </CardTitle>
           <div className="flex items-center gap-2">
-            <Select value={metric} onValueChange={(v) => setMetric(v as MetricOption)}>
+            <Select
+              value={metric}
+              onValueChange={v => setMetric(v as MetricOption)}
+            >
               <SelectTrigger className="h-7 w-[130px] text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {METRIC_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                {METRIC_OPTIONS.map(opt => (
+                  <SelectItem
+                    key={opt.value}
+                    value={opt.value}
+                    className="text-xs"
+                  >
                     {opt.label}
                   </SelectItem>
                 ))}
@@ -146,7 +167,9 @@ export const LeaderboardWidget = React.memo(function LeaderboardWidget({
             {Array.from({ length: limit }).map((_, i) => (
               <Skeleton
                 // eslint-disable-next-line react/no-array-index-key
-                key={`leaderboard-skeleton-${i}`} className="h-10 w-full" />
+                key={`leaderboard-skeleton-${i}`}
+                className="h-10 w-full"
+              />
             ))}
           </div>
         )}
@@ -163,7 +186,7 @@ export const LeaderboardWidget = React.memo(function LeaderboardWidget({
         {!isLoading && !error && data && (
           <>
             <div className="space-y-1">
-              {data.entries.map((entry) => (
+              {data.entries.map(entry => (
                 <div
                   key={entry.clientId}
                   className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"

--- a/client/src/components/dashboard/widgets-v2/MatchmakingOpportunitiesWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/MatchmakingOpportunitiesWidget.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { Target, AlertTriangle, TrendingUp, ArrowRight } from "lucide-react";
 import { useLocation } from "wouter";
 
@@ -153,7 +154,12 @@ export const MatchmakingOpportunitiesWidget = memo(
                         key={`${match.clientId}-${match.type}-${match.confidence}-${match.strain || "any"}`}
                         className="border rounded-lg p-3 hover:bg-accent cursor-pointer transition-colors"
                         onClick={() =>
-                          setLocation(`/clients/${match.clientId}?tab=needs`)
+                          setLocation(
+                            buildRelationshipProfilePath(
+                              match.clientId,
+                              "sales-pricing"
+                            )
+                          )
                         }
                       >
                         <div className="flex items-start justify-between mb-1">
@@ -199,7 +205,9 @@ export const MatchmakingOpportunitiesWidget = memo(
                         key={`${prediction.clientId}-${prediction.strain || prediction.category || "regular"}-${prediction.daysUntilPredictedOrder}`}
                         className="border border-destructive/30 rounded-lg p-3 hover:bg-accent cursor-pointer transition-colors"
                         onClick={() =>
-                          setLocation(`/clients/${prediction.clientId}`)
+                          setLocation(
+                            buildRelationshipProfilePath(prediction.clientId)
+                          )
                         }
                       >
                         <div className="flex items-start justify-between mb-1">
@@ -240,7 +248,12 @@ export const MatchmakingOpportunitiesWidget = memo(
                         key={`${need.clientId}-${need.strain || "any"}-${need.priority || "none"}-${need.confidence}`}
                         className="border border-orange-300/30 rounded-lg p-3 hover:bg-accent cursor-pointer transition-colors"
                         onClick={() =>
-                          setLocation(`/clients/${need.clientId}?tab=needs`)
+                          setLocation(
+                            buildRelationshipProfilePath(
+                              need.clientId,
+                              "sales-pricing"
+                            )
+                          )
                         }
                       >
                         <div className="flex items-start justify-between mb-1">

--- a/client/src/components/dashboard/widgets-v2/SalesByClientWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/SalesByClientWidget.tsx
@@ -6,6 +6,7 @@
 
 import { useState, memo } from "react";
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -102,7 +103,11 @@ export const SalesByClientWidget = memo(function SalesByClientWidget() {
                   <TableRow
                     key={client.customerId}
                     className="cursor-pointer hover:bg-muted/50 transition-colors"
-                    onClick={() => setLocation(`/clients/${client.customerId}`)}
+                    onClick={() =>
+                      setLocation(
+                        buildRelationshipProfilePath(client.customerId)
+                      )
+                    }
                   >
                     <TableCell className="text-muted-foreground">
                       {index + 1}

--- a/client/src/components/dashboard/widgets-v2/SmartOpportunitiesWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/SmartOpportunitiesWidget.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { MatchBadge } from "@/components/needs/MatchBadge";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { Lightbulb, ArrowRight, Loader2, TrendingUp } from "lucide-react";
 import { useLocation } from "wouter";
 
@@ -132,7 +133,11 @@ export const SmartOpportunitiesWidget = memo(function SmartOpportunitiesWidget({
             <div
               key={`opp-${opp.clientId}`}
               className="flex items-start justify-between p-3 rounded-lg border hover:bg-accent cursor-pointer transition-colors"
-              onClick={() => setLocation(`/clients/${opp.clientId}?tab=needs`)}
+              onClick={() =>
+                setLocation(
+                  buildRelationshipProfilePath(opp.clientId, "sales-pricing")
+                )
+              }
             >
               <div className="flex-1 space-y-1">
                 <div className="flex items-center gap-2">

--- a/client/src/components/inbox/InboxItem.tsx
+++ b/client/src/components/inbox/InboxItem.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -104,7 +105,7 @@ export const InboxItem = memo(function InboxItem({ item }: InboxItemProps) {
     const entityRoutes: Record<string, string> = {
       order: `/orders/${item.referenceId}`,
       invoice: `/accounting/invoices/${item.referenceId}`,
-      client: `/clients/${item.referenceId}`,
+      client: buildRelationshipProfilePath(Number(item.referenceId)),
       batch: `/inventory?batchId=${item.referenceId}`,
       inventory_batch: `/inventory?batchId=${item.referenceId}`,
       calendar_event: `/calendar?eventId=${item.referenceId}`,
@@ -181,14 +182,16 @@ export const InboxItem = memo(function InboxItem({ item }: InboxItemProps) {
               {item.sourceType.replace("_", " ")}
             </Badge>
             <span className="text-xs text-muted-foreground">
-              {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+              {formatDistanceToNow(new Date(item.createdAt), {
+                addSuffix: true,
+              })}
             </span>
           </div>
         </div>
 
         {/* Actions */}
         <DropdownMenu>
-          <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+          <DropdownMenuTrigger asChild onClick={e => e.stopPropagation()}>
             <Button
               variant="ghost"
               size="icon"
@@ -203,7 +206,7 @@ export const InboxItem = memo(function InboxItem({ item }: InboxItemProps) {
           <DropdownMenuContent align="end">
             {item.status !== "completed" && (
               <DropdownMenuItem
-                onClick={(e) => {
+                onClick={e => {
                   e.stopPropagation();
                   handleMarkCompleted();
                 }}
@@ -214,7 +217,7 @@ export const InboxItem = memo(function InboxItem({ item }: InboxItemProps) {
             )}
             {!item.isArchived && (
               <DropdownMenuItem
-                onClick={(e) => {
+                onClick={e => {
                   e.stopPropagation();
                   handleArchive();
                 }}
@@ -224,7 +227,7 @@ export const InboxItem = memo(function InboxItem({ item }: InboxItemProps) {
               </DropdownMenuItem>
             )}
             <DropdownMenuItem
-              onClick={(e) => {
+              onClick={e => {
                 e.stopPropagation();
                 handleDelete();
               }}

--- a/client/src/components/inbox/InboxWidget.tsx
+++ b/client/src/components/inbox/InboxWidget.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { trpc } from "@/lib/trpc";
 import { Inbox, ArrowRight, CheckCheck } from "lucide-react";
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { formatDistanceToNow } from "date-fns";
 
 export function InboxWidget() {
@@ -48,7 +49,7 @@ export function InboxWidget() {
       const referenceId = item.referenceId;
 
       if (referenceType === "client" && referenceId) {
-        setLocation(`/clients/${referenceId}`);
+        setLocation(buildRelationshipProfilePath(referenceId));
       } else if (referenceType === "inventory_batch" && referenceId) {
         setLocation(`/inventory`);
       } else if (referenceType === "dashboard" && referenceId) {

--- a/client/src/components/interest-list/InterestDetailSheet.tsx
+++ b/client/src/components/interest-list/InterestDetailSheet.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -184,7 +185,9 @@ export function InterestDetailSheet({
             <Button
               variant="outline"
               className="w-full"
-              onClick={() => setLocation(`/clients/${item.clientId}`)}
+              onClick={() =>
+                setLocation(buildRelationshipProfilePath(item.clientId))
+              }
             >
               <User className="h-4 w-4 mr-2" />
               View Client Profile

--- a/client/src/components/inventory/ClientInterestWidget.tsx
+++ b/client/src/components/inventory/ClientInterestWidget.tsx
@@ -1,4 +1,5 @@
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { useAuth } from "@/hooks/useAuth";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -225,7 +226,9 @@ export function ClientInterestWidget({ batchId }: ClientInterestWidgetProps) {
                   size="sm"
                   variant="outline"
                   onClick={() => {
-                    window.location.href = `/clients/${match.clientId}`;
+                    window.location.href = buildRelationshipProfilePath(
+                      match.clientId
+                    );
                   }}
                 >
                   <MessageSquare className="h-4 w-4 mr-2" />

--- a/client/src/components/inventory/PotentialBuyersWidget.tsx
+++ b/client/src/components/inventory/PotentialBuyersWidget.tsx
@@ -12,6 +12,7 @@ import {
   Target,
 } from "lucide-react";
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 
 /**
  * Potential Buyers Widget
@@ -166,7 +167,12 @@ export function PotentialBuyersWidget({
                 key={`match-${match.clientId}-${match.needId || idx}`}
                 className="p-3 hover:bg-accent cursor-pointer transition-colors"
                 onClick={() =>
-                  setLocation(`/clients/${match.clientId}?tab=needs`)
+                  setLocation(
+                    buildRelationshipProfilePath(
+                      match.clientId,
+                      "sales-pricing"
+                    )
+                  )
                 }
               >
                 <div className="flex items-start justify-between mb-2">
@@ -218,9 +224,12 @@ export function PotentialBuyersWidget({
               <Card
                 key={`buyer-${buyer.sourceData?.client?.id || idx}`}
                 className="p-3 hover:bg-accent cursor-pointer transition-colors"
-                onClick={() =>
-                  setLocation(`/clients/${buyer.sourceData?.client?.id}`)
-                }
+                onClick={() => {
+                  const targetId = buyer.sourceData?.client?.id;
+                  if (targetId) {
+                    setLocation(buildRelationshipProfilePath(targetId));
+                  }
+                }}
               >
                 <div className="flex items-start justify-between mb-2">
                   <div className="flex-1">
@@ -277,7 +286,11 @@ export function PotentialBuyersWidget({
                       ? "border-destructive/30"
                       : ""
                   }`}
-                  onClick={() => setLocation(`/clients/${prediction.clientId}`)}
+                  onClick={() =>
+                    setLocation(
+                      buildRelationshipProfilePath(prediction.clientId)
+                    )
+                  }
                 >
                   <div className="flex items-start justify-between mb-2">
                     <div className="flex-1">

--- a/client/src/components/inventory/ProductConnections.tsx
+++ b/client/src/components/inventory/ProductConnections.tsx
@@ -12,6 +12,7 @@
 
 import React, { useState } from "react";
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import {
   Card,
   CardContent,
@@ -283,7 +284,11 @@ export function ProductConnections({
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem
                                 onClick={() =>
-                                  setLocation(`/clients/${connection.clientId}`)
+                                  setLocation(
+                                    buildRelationshipProfilePath(
+                                      connection.clientId
+                                    )
+                                  )
                                 }
                               >
                                 <ExternalLink className="h-4 w-4 mr-2" />

--- a/client/src/components/inventory/SuggestedBuyers.tsx
+++ b/client/src/components/inventory/SuggestedBuyers.tsx
@@ -27,6 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import {
   Users,
   Mail,
@@ -152,7 +153,9 @@ export function SuggestedBuyers({
               <div
                 key={buyer.clientId}
                 className="flex items-center justify-between p-2 border rounded hover:bg-accent cursor-pointer"
-                onClick={() => setLocation(`/clients/${buyer.clientId}`)}
+                onClick={() =>
+                  setLocation(buildRelationshipProfilePath(buyer.clientId))
+                }
               >
                 <div className="flex items-center gap-2">
                   <Avatar className="h-6 w-6">
@@ -323,7 +326,9 @@ export function SuggestedBuyers({
                             size="icon"
                             onClick={e => {
                               e.stopPropagation();
-                              setLocation(`/clients/${buyer.clientId}`);
+                              setLocation(
+                                buildRelationshipProfilePath(buyer.clientId)
+                              );
                             }}
                           >
                             <ExternalLink className="h-4 w-4" />

--- a/client/src/components/work-surface/ClientsWorkSurface.tsx
+++ b/client/src/components/work-surface/ClientsWorkSurface.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input";
 // Label used in form fields - import available if needed
 import { Badge } from "@/components/ui/badge";
 import { AddClientWizard } from "@/components/clients/AddClientWizard"; // TERP-0003
+import { ProfileQuickPanel } from "@/components/clients/ProfileQuickPanel";
 import {
   Table,
   TableBody,
@@ -82,6 +83,7 @@ import {
   ArrowDown,
 } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 
 // ============================================================================
 // TYPES & SCHEMAS
@@ -139,7 +141,7 @@ const CLIENT_TYPE_FILTERS: {
   label: string;
 }[] = [
   { value: "all", label: "All Types" },
-  { value: "buyer", label: "Buyers" },
+  { value: "buyer", label: "Customers" },
   { value: "seller", label: "Suppliers" },
   { value: "brand", label: "Brands" },
   { value: "referee", label: "Referees" },
@@ -178,7 +180,7 @@ const formatDate = (dateString: string | null | undefined): string => {
 function ClientTypeBadges({ client }: { client: Client }) {
   const badges: { label: string; className: string }[] = [];
   if (client.isBuyer)
-    badges.push({ label: "Buyer", className: "bg-blue-100 text-blue-800" });
+    badges.push({ label: "Customer", className: "bg-blue-100 text-blue-800" });
   if (client.isSeller)
     badges.push({
       label: "Supplier",
@@ -1037,7 +1039,9 @@ export function ClientsWorkSurface() {
                         setSelectedIndex(index);
                         inspector.open();
                       }}
-                      onDoubleClick={() => setLocation(`/clients/${client.id}`)}
+                      onDoubleClick={() =>
+                        setLocation(buildRelationshipProfilePath(client.id))
+                      }
                     >
                       <TableCell className="font-medium">
                         {client.name}
@@ -1071,7 +1075,9 @@ export function ClientsWorkSurface() {
                           onClick={e => {
                             e.preventDefault();
                             e.stopPropagation();
-                            setLocation(`/clients/${client.id}`);
+                            setLocation(
+                              buildRelationshipProfilePath(client.id)
+                            );
                           }}
                           aria-label={`Open ${client.name}`}
                         >
@@ -1119,15 +1125,19 @@ export function ClientsWorkSurface() {
         <InspectorPanel
           isOpen={inspector.isOpen}
           onClose={inspector.close}
-          title={selectedClient?.name || "Client Details"}
+          title={selectedClient?.name || "Relationship Profile"}
           subtitle={selectedClient?.email ?? undefined}
         >
-          <ClientInspectorContent
-            client={selectedClient}
-            onUpdate={handleUpdateClient}
-            onNavigate={id => setLocation(`/clients/${id}`)}
-            onArchive={handleArchive}
-          />
+          {selectedClient ? (
+            <ProfileQuickPanel clientId={selectedClient.id} />
+          ) : (
+            <ClientInspectorContent
+              client={selectedClient}
+              onUpdate={handleUpdateClient}
+              onNavigate={id => setLocation(buildRelationshipProfilePath(id))}
+              onArchive={handleArchive}
+            />
+          )}
         </InspectorPanel>
       </div>
 
@@ -1167,7 +1177,7 @@ export function ClientsWorkSurface() {
         onSuccess={clientId => {
           refetch();
           toast.success("Client created successfully");
-          setLocation(`/clients/${clientId}`);
+          setLocation(buildRelationshipProfilePath(clientId));
         }}
       />
 

--- a/client/src/components/work-surface/VendorsWorkSurface.tsx
+++ b/client/src/components/work-surface/VendorsWorkSurface.tsx
@@ -14,6 +14,8 @@
 
 import React, { useState, useMemo, useCallback, useRef } from "react";
 import { useLocation } from "wouter";
+import { AddClientWizard } from "@/components/clients/AddClientWizard";
+import { ProfileQuickPanel } from "@/components/clients/ProfileQuickPanel";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 
@@ -29,13 +31,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
 // Work Surface Hooks
 import { useWorkSurfaceKeyboard } from "@/hooks/work-surface/useWorkSurfaceKeyboard";
@@ -65,6 +60,7 @@ import {
   ArrowDown,
 } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 
 // ============================================================================
 // TYPES
@@ -94,12 +90,6 @@ interface Vendor {
 // ============================================================================
 // CONSTANTS
 // ============================================================================
-
-const VENDOR_STATUS_FILTERS = [
-  { value: "all", label: "All Suppliers" },
-  { value: "active", label: "Active" },
-  { value: "inactive", label: "Inactive" },
-];
 
 // ============================================================================
 // HELPERS
@@ -135,7 +125,7 @@ function VendorTypeBadges({ vendor }: { vendor: Vendor }) {
   badges.push({ label: "Supplier", className: "bg-green-100 text-green-800" });
 
   if (vendor.isBuyer)
-    badges.push({ label: "Buyer", className: "bg-blue-100 text-blue-800" });
+    badges.push({ label: "Customer", className: "bg-blue-100 text-blue-800" });
   if (vendor.isBrand)
     badges.push({ label: "Brand", className: "bg-purple-100 text-purple-800" });
 
@@ -329,11 +319,11 @@ function VendorInspectorContent({
 
 export function VendorsWorkSurface() {
   const [, setLocation] = useLocation();
+  const [isAddSupplierOpen, setIsAddSupplierOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // State
   const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
   const [page, setPage] = useState(0);
   const [selectedVendorId, setSelectedVendorId] = useState<number | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -483,13 +473,12 @@ export function VendorsWorkSurface() {
   };
 
   const handleAddVendor = useCallback(() => {
-    // TER-290: Navigate to client creation with seller type pre-selected
-    setLocation("/clients/new?type=seller");
-  }, [setLocation]);
+    setIsAddSupplierOpen(true);
+  }, []);
 
   const handleNavigate = useCallback(
     (vendorId: number) => {
-      setLocation(`/clients/${vendorId}`);
+      setLocation(buildRelationshipProfilePath(vendorId));
     },
     [setLocation]
   );
@@ -563,24 +552,6 @@ export function VendorsWorkSurface() {
               className="pl-10"
             />
           </div>
-          <Select
-            value={statusFilter}
-            onValueChange={v => {
-              setStatusFilter(v);
-              setPage(0);
-            }}
-          >
-            <SelectTrigger className="w-36">
-              <SelectValue placeholder="Status" />
-            </SelectTrigger>
-            <SelectContent>
-              {VENDOR_STATUS_FILTERS.map(filter => (
-                <SelectItem key={filter.value} value={filter.value}>
-                  {filter.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
           <Button variant="outline" size="icon" onClick={() => refetch()}>
             <RefreshCw className="h-4 w-4" />
           </Button>
@@ -625,7 +596,7 @@ export function VendorsWorkSurface() {
                 <Store className="h-12 w-12 text-muted-foreground mx-auto mb-4 opacity-50" />
                 <p className="font-medium">No suppliers found</p>
                 <p className="text-sm text-muted-foreground mt-1">
-                  {search || statusFilter !== "all"
+                  {search
                     ? "Try adjusting your filters"
                     : "Add your first supplier"}
                 </p>
@@ -704,7 +675,17 @@ export function VendorsWorkSurface() {
                         {vendor.orderCount || 0}
                       </TableCell>
                       <TableCell>
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          onClick={event => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            handleNavigate(vendor.id);
+                          }}
+                          aria-label={`Open ${vendor.name}`}
+                        >
                           <ChevronRight className="h-4 w-4" />
                         </Button>
                       </TableCell>
@@ -749,16 +730,36 @@ export function VendorsWorkSurface() {
         <InspectorPanel
           isOpen={inspector.isOpen}
           onClose={inspector.close}
-          title={selectedVendor?.name || "Supplier Details"}
+          title={selectedVendor?.name || "Supplier Profile"}
           subtitle={selectedVendor?.teriCode ?? undefined}
         >
-          <VendorInspectorContent
-            vendor={selectedVendor}
-            onNavigate={handleNavigate}
-            onViewPurchaseOrders={handleViewPurchaseOrders}
-          />
+          {selectedVendor ? (
+            <ProfileQuickPanel
+              clientId={selectedVendor.id}
+              initialSection="supply-inventory"
+            />
+          ) : (
+            <VendorInspectorContent
+              vendor={selectedVendor}
+              onNavigate={handleNavigate}
+              onViewPurchaseOrders={handleViewPurchaseOrders}
+            />
+          )}
         </InspectorPanel>
       </div>
+
+      {isAddSupplierOpen ? (
+        <AddClientWizard
+          open={isAddSupplierOpen}
+          onOpenChange={setIsAddSupplierOpen}
+          defaultRoles={{ isSeller: true }}
+          onSuccess={clientId => {
+            setLocation(
+              buildRelationshipProfilePath(clientId, "supply-inventory")
+            );
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/client/src/lib/relationshipProfile.test.ts
+++ b/client/src/lib/relationshipProfile.test.ts
@@ -1,0 +1,29 @@
+import {
+  buildRelationshipProfilePath,
+  resolveRelationshipProfileSection,
+} from "./relationshipProfile";
+
+describe("relationshipProfile helpers", () => {
+  it("prefers the section query parameter", () => {
+    expect(resolveRelationshipProfileSection("?section=money")).toBe("money");
+  });
+
+  it("maps legacy tab names into the new sections", () => {
+    expect(resolveRelationshipProfileSection("?tab=needs")).toBe(
+      "sales-pricing"
+    );
+    expect(resolveRelationshipProfileSection("?tab=payments")).toBe("money");
+    expect(resolveRelationshipProfileSection("?tab=calendar")).toBe("activity");
+  });
+
+  it("falls back to overview", () => {
+    expect(resolveRelationshipProfileSection("")).toBe("overview");
+    expect(resolveRelationshipProfileSection("?tab=unknown")).toBe("overview");
+  });
+
+  it("builds canonical section paths", () => {
+    expect(buildRelationshipProfilePath(42, "activity")).toBe(
+      "/clients/42?section=activity"
+    );
+  });
+});

--- a/client/src/lib/relationshipProfile.ts
+++ b/client/src/lib/relationshipProfile.ts
@@ -1,0 +1,63 @@
+export const RELATIONSHIP_PROFILE_SECTIONS = [
+  "overview",
+  "sales-pricing",
+  "money",
+  "supply-inventory",
+  "activity",
+] as const;
+
+export type RelationshipProfileSection =
+  (typeof RELATIONSHIP_PROFILE_SECTIONS)[number];
+
+const SECTION_SET = new Set<RelationshipProfileSection>(
+  RELATIONSHIP_PROFILE_SECTIONS
+);
+
+export const LEGACY_PROFILE_TAB_TO_SECTION: Record<
+  string,
+  RelationshipProfileSection
+> = {
+  overview: "overview",
+  supplier: "overview",
+  "live-catalog": "overview",
+  pricing: "sales-pricing",
+  needs: "sales-pricing",
+  history: "money",
+  transactions: "money",
+  payments: "money",
+  communications: "activity",
+  calendar: "activity",
+  notes: "activity",
+};
+
+export function isRelationshipProfileSection(
+  value: string | null | undefined
+): value is RelationshipProfileSection {
+  return Boolean(value && SECTION_SET.has(value as RelationshipProfileSection));
+}
+
+export function resolveRelationshipProfileSection(
+  search: string
+): RelationshipProfileSection {
+  const params = new URLSearchParams(search);
+  const section = params.get("section");
+  if (isRelationshipProfileSection(section)) {
+    return section;
+  }
+
+  const legacyTab = params.get("tab");
+  if (legacyTab && LEGACY_PROFILE_TAB_TO_SECTION[legacyTab]) {
+    return LEGACY_PROFILE_TAB_TO_SECTION[legacyTab];
+  }
+
+  return "overview";
+}
+
+export function buildRelationshipProfilePath(
+  clientId: number,
+  section: RelationshipProfileSection = "overview"
+): string {
+  const params = new URLSearchParams();
+  params.set("section", section);
+  return `/clients/${clientId}?${params.toString()}`;
+}

--- a/client/src/pages/ClientProfilePage.tsx
+++ b/client/src/pages/ClientProfilePage.tsx
@@ -1,18 +1,43 @@
 import { useEffect, useState } from "react";
 import { useLocation, useParams, useSearch } from "wouter";
-import { trpc } from "@/lib/trpc";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { PageErrorBoundary } from "@/components/common/PageErrorBoundary";
+import { toast } from "sonner";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+  Activity,
+  ArrowRightLeft,
+  CircleDollarSign,
+  Edit,
+  Receipt,
+  ShieldAlert,
+} from "lucide-react";
+import { AddCommunicationModal } from "@/components/clients/AddCommunicationModal";
+import { ClientCalendarTab } from "@/components/clients/ClientCalendarTab";
+import { CommunicationTimeline } from "@/components/clients/CommunicationTimeline";
+import { SupplierProfileSection } from "@/components/clients/SupplierProfileSection";
+import { VIPPortalSettings } from "@/components/clients/VIPPortalSettings";
+import { CommentWidget } from "@/components/comments/CommentWidget";
+import { BackButton } from "@/components/common/BackButton";
+import { CreditStatusCard } from "@/components/credit/CreditStatusCard";
+import { FreeformNoteWidget } from "@/components/dashboard/widgets-v2";
+import {
+  LinearWorkspacePanel,
+  LinearWorkspaceShell,
+} from "@/components/layout/LinearWorkspaceShell";
+import { ClientNeedsTab } from "@/components/needs/ClientNeedsTab";
+import { PricingConfigTab } from "@/components/pricing/PricingConfigTab";
+import { LiveCatalogConfig } from "@/components/vip-portal/LiveCatalogConfig";
+import { InspectorPanel } from "@/components/work-surface/InspectorPanel";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -21,1458 +46,1615 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { FreeformNoteWidget } from "@/components/dashboard/widgets-v2";
-import { CreditStatusCard } from "@/components/credit/CreditStatusCard";
-import { PricingConfigTab } from "@/components/pricing/PricingConfigTab";
-import { ClientNeedsTab } from "@/components/needs/ClientNeedsTab";
-import { CommunicationTimeline } from "@/components/clients/CommunicationTimeline";
-import { AddCommunicationModal } from "@/components/clients/AddCommunicationModal";
-import { PurchasePatternsWidget } from "@/components/clients/PurchasePatternsWidget";
-import { ClientCalendarTab } from "@/components/clients/ClientCalendarTab";
-import { SupplierProfileSection } from "@/components/clients/SupplierProfileSection";
-import { CommentWidget } from "@/components/comments/CommentWidget";
-import { LiveCatalogConfig } from "@/components/vip-portal/LiveCatalogConfig";
-import { VIPPortalSettings } from "@/components/clients/VIPPortalSettings";
-import { CustomerWishlistCard } from "@/components/clients/CustomerWishlistCard";
-import { BackButton } from "@/components/common/BackButton";
-import { AuditIcon } from "@/components/audit";
 import { PageSkeleton } from "@/components/ui/skeleton-loaders";
 import { useCreditVisibility } from "@/hooks/useCreditVisibility";
-import { useOptimisticLocking } from "@/hooks/useOptimisticLocking";
 import {
-  Edit,
-  DollarSign,
-  TrendingUp,
-  AlertCircle,
-  Calendar,
-  Search,
-  Plus,
-  CheckCircle,
-  Settings,
-  BookOpen,
-  ChevronRight,
-} from "lucide-react";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
+  buildRelationshipProfilePath,
+  resolveRelationshipProfileSection,
+  type RelationshipProfileSection,
+} from "@/lib/relationshipProfile";
+import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
+import type { RelationshipProfileMoneyData } from "@/types/relationshipProfile";
 
-// TER-626: Reduced to 2 primary tabs; old deep-link tab params map to these
-const TABBABLE_SECTIONS = new Set([
-  "overview",
-  "history",
-  // Legacy tab names kept for backward-compat deep links
-  "supplier",
-  "transactions",
-  "payments",
-  "pricing",
-  "needs",
-  "communications",
-  "calendar",
-  "notes",
-  "live-catalog",
-]);
+const PROFILE_TABS: Array<{
+  value: RelationshipProfileSection;
+  label: string;
+}> = [
+  { value: "overview", label: "Overview" },
+  { value: "sales-pricing", label: "Sales & Pricing" },
+  { value: "money", label: "Money" },
+  { value: "supply-inventory", label: "Supply & Inventory" },
+  { value: "activity", label: "Activity" },
+];
 
-// TER-626: Old tab names redirect to one of the 2 new tabs
-const LEGACY_TAB_MAP: Record<string, string> = {
-  supplier: "overview",
-  pricing: "overview",
-  needs: "overview",
-  communications: "overview",
-  calendar: "overview",
-  notes: "overview",
-  "live-catalog": "overview",
-  transactions: "history",
-  payments: "history",
+const formatMoney = (value: number | null | undefined) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value ?? 0);
+
+const formatDate = (value: string | null | undefined) => {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "-";
+  return parsed.toLocaleString();
 };
 
-function getInitialClientTab(search: string): string {
-  const tabParam = new URLSearchParams(search).get("tab");
-  if (!tabParam) return "overview";
-  if (LEGACY_TAB_MAP[tabParam]) return LEGACY_TAB_MAP[tabParam];
-  if (TABBABLE_SECTIONS.has(tabParam)) return tabParam;
-  return "overview";
+const sourcePathForLedgerEntry = (
+  entry: RelationshipProfileMoneyData["ledgerTimeline"][number]
+) => {
+  switch (entry.sourceType) {
+    case "ORDER":
+      return `/orders?id=${entry.sourceId}`;
+    case "PAYMENT":
+      return `/accounting/payments?id=${entry.sourceId}`;
+    case "PURCHASE_ORDER":
+      return `/purchase-orders?id=${entry.sourceId}`;
+    default:
+      return null;
+  }
+};
+
+function MetricCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <Card className="border-border/70">
+      <CardContent className="p-4">
+        <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="mt-1 text-xl font-semibold">{value}</p>
+        {hint ? (
+          <p className="mt-1 text-xs text-muted-foreground">{hint}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
 }
 
-// TER-289: Typed interfaces to replace `any` in transaction/activity callbacks
-interface ClientTransaction {
-  id: number;
-  transactionNumber?: string | null;
-  transactionType: string;
-  transactionDate?: string | Date | null;
-  amount?: string | number | null;
-  paymentAmount?: string | number | null;
-  paymentStatus?: string | null;
-  paymentDate?: string | Date | null;
-  notes?: string | null;
+function EmptyCard({ message }: { message: string }) {
+  return (
+    <Card>
+      <CardContent className="py-10 text-sm text-muted-foreground">
+        {message}
+      </CardContent>
+    </Card>
+  );
 }
-
-interface ClientActivity {
-  id: number;
-  activityType: string;
-  description?: string | null;
-  createdAt?: string | Date | null;
-  userName?: string | null;
-}
-
-type TransactionType =
-  | "INVOICE"
-  | "PAYMENT"
-  | "QUOTE"
-  | "ORDER"
-  | "REFUND"
-  | "CREDIT";
 
 export default function ClientProfilePage() {
   const params = useParams<{ id: string }>();
   const search = useSearch();
   const [, setLocation] = useLocation();
-  const clientId = parseInt(params.id || "0", 10);
-  const [activeTab, setActiveTab] = useState(() => getInitialClientTab(search));
+  const clientId = Number(params.id);
+  const [activeSection, setActiveSection] =
+    useState<RelationshipProfileSection>(() =>
+      resolveRelationshipProfileSection(search)
+    );
   const [editDialogOpen, setEditDialogOpen] = useState(false);
-  const [transactionDialogOpen, setTransactionDialogOpen] = useState(false);
-  const [paymentDialogOpen, setPaymentDialogOpen] = useState(false);
-  const [selectedTransaction, setSelectedTransaction] =
-    useState<ClientTransaction | null>(null);
-  const [transactionSearch, setTransactionSearch] = useState("");
-  const [paymentSearch, setPaymentSearch] = useState("");
   const [communicationModalOpen, setCommunicationModalOpen] = useState(false);
-  const [newTag, setNewTag] = useState("");
-  const [showTagInput, setShowTagInput] = useState(false);
+  const [selectedTransaction, setSelectedTransaction] = useState<
+    RelationshipProfileMoneyData["transactionHistory"][number] | null
+  >(null);
+  const [selectedLedgerEntry, setSelectedLedgerEntry] = useState<
+    RelationshipProfileMoneyData["ledgerTimeline"][number] | null
+  >(null);
+  const [selectedPayment, setSelectedPayment] = useState<
+    RelationshipProfileMoneyData["paymentHistory"][number] | null
+  >(null);
+  const [moneyAction, setMoneyAction] = useState<"receive" | "pay" | null>(
+    null
+  );
+  const [transactionForm, setTransactionForm] = useState({
+    transactionDate: "",
+    amount: "",
+    paymentStatus: "PENDING",
+    paymentDate: "",
+    paymentAmount: "",
+    notes: "",
+  });
+  const [adjustmentForm, setAdjustmentForm] = useState({
+    amount: "",
+    description: "",
+    effectiveDate: new Date().toISOString().slice(0, 10),
+  });
+  const [editForm, setEditForm] = useState({
+    name: "",
+    email: "",
+    phone: "",
+    address: "",
+    paymentTerms: "",
+    wishlist: "",
+    tags: "",
+    isBuyer: false,
+    isSeller: false,
+    isBrand: false,
+    isReferee: false,
+    isContractor: false,
+  });
 
-  useEffect(() => {
-    const nextTab = getInitialClientTab(search);
-    setActiveTab(currentTab => (currentTab === nextTab ? currentTab : nextTab));
-  }, [search]);
-
-  // Credit visibility settings
+  const utils = trpc.useUtils();
   const { shouldShowCreditWidgetInProfile } = useCreditVisibility();
 
-  // BUG-090 fix: Get utils for cache invalidation
-  const utils = trpc.useUtils();
+  useEffect(() => {
+    const nextSection = resolveRelationshipProfileSection(search);
+    setActiveSection(current =>
+      current === nextSection ? current : nextSection
+    );
 
-  // ST-026: Optimistic locking for concurrent edit detection
-  const { handleMutationError, ConflictDialogComponent } = useOptimisticLocking(
+    const paramsSearch = new URLSearchParams(search);
+    if (
+      clientId > 0 &&
+      paramsSearch.get("tab") &&
+      !paramsSearch.get("section")
+    ) {
+      setLocation(buildRelationshipProfilePath(clientId, nextSection));
+    }
+  }, [clientId, search, setLocation]);
+
+  const shellQuery = trpc.relationshipProfile.getShell.useQuery(
+    { clientId },
+    { enabled: Number.isInteger(clientId) && clientId > 0 }
+  );
+  const salesQuery = trpc.relationshipProfile.getSalesPricing.useQuery(
+    { clientId },
     {
-      entityType: "Client",
-      onRefresh: () => refetchClient(),
-      onDiscard: () => setEditDialogOpen(false),
+      enabled:
+        Number.isInteger(clientId) &&
+        clientId > 0 &&
+        activeSection === "sales-pricing",
     }
   );
+  const moneyQuery = trpc.relationshipProfile.getMoney.useQuery(
+    { clientId },
+    {
+      enabled:
+        Number.isInteger(clientId) && clientId > 0 && activeSection === "money",
+    }
+  );
+  const supplyQuery = trpc.relationshipProfile.getSupplyInventory.useQuery(
+    { clientId },
+    {
+      enabled:
+        Number.isInteger(clientId) &&
+        clientId > 0 &&
+        activeSection === "supply-inventory",
+    }
+  );
+  const activityQuery = trpc.relationshipProfile.getActivity.useQuery(
+    { clientId },
+    {
+      enabled:
+        Number.isInteger(clientId) &&
+        clientId > 0 &&
+        activeSection === "activity",
+    }
+  );
+  const noteIdQuery = trpc.clients.notes.getNoteId.useQuery(
+    { clientId },
+    { enabled: Number.isInteger(clientId) && clientId > 0 }
+  );
 
-  // Fetch client data
-  const {
-    data: client,
-    isLoading: clientLoading,
-    isError,
-    refetch: refetchClient,
-  } = trpc.clients.getById.useQuery({
-    clientId,
-  });
+  useEffect(() => {
+    const shell = shellQuery.data;
+    if (!shell) return;
 
-  // Fetch transactions
-  const {
-    data: transactions,
-    isLoading: transactionsLoading,
-    refetch: refetchTransactions,
-  } = trpc.clients.transactions.list.useQuery({
-    clientId,
-    search: transactionSearch || undefined,
-  });
+    setEditForm({
+      name: shell.name,
+      email: shell.email ?? "",
+      phone: shell.phone ?? "",
+      address: shell.address ?? "",
+      paymentTerms: shell.paymentTermsDays
+        ? String(shell.paymentTermsDays)
+        : "",
+      wishlist: shell.wishlist ?? "",
+      tags: shell.tags.join(", "),
+      isBuyer: shell.roles.includes("Customer"),
+      isSeller: shell.roles.includes("Supplier"),
+      isBrand: shell.roles.includes("Brand"),
+      isReferee: shell.roles.includes("Referee"),
+      isContractor: shell.roles.includes("Contractor"),
+    });
+  }, [shellQuery.data]);
 
-  // Fetch activity log
-  const { data: activities } = trpc.clients.activity.list.useQuery({
-    clientId,
-  });
+  useEffect(() => {
+    if (!selectedTransaction) return;
+    setTransactionForm({
+      transactionDate: selectedTransaction.transactionDate
+        ? new Date(selectedTransaction.transactionDate)
+            .toISOString()
+            .slice(0, 10)
+        : "",
+      amount: String(selectedTransaction.amount ?? ""),
+      paymentStatus: selectedTransaction.paymentStatus ?? "PENDING",
+      paymentDate: selectedTransaction.paymentDate
+        ? new Date(selectedTransaction.paymentDate).toISOString().slice(0, 10)
+        : "",
+      paymentAmount: String(selectedTransaction.paymentAmount ?? ""),
+      notes: selectedTransaction.notes ?? "",
+    });
+  }, [selectedTransaction]);
 
-  // Fetch client note ID
-  const { data: noteId } = trpc.clients.notes.getNoteId.useQuery({
-    clientId,
-  });
-
-  // Mutations
-  // BUG-090 fix: Add proper cache invalidation and refetch on success
-  // ST-026: Add optimistic locking error handling
   const updateClientMutation = trpc.clients.update.useMutation({
-    onSuccess: () => {
-      // Invalidate all client-related caches to ensure fresh data
-      utils.clients.getById.invalidate({ clientId });
-      utils.clients.list.invalidate();
-      // Refetch the current client to show updated data
-      refetchClient();
+    onSuccess: async () => {
+      await Promise.all([
+        utils.relationshipProfile.getShell.invalidate({ clientId }),
+        utils.clients.getById.invalidate({ clientId }),
+        utils.clients.list.invalidate(),
+      ]);
+      toast.success("Profile updated");
       setEditDialogOpen(false);
     },
     onError: error => {
-      // ST-026: Handle concurrent edit conflicts
-      if (!handleMutationError(error)) {
-        // If it's not an optimistic lock error, show generic error
-        console.error("Error updating client:", error);
-      }
+      toast.error(error.message);
     },
   });
-  const createTransactionMutation =
-    trpc.clients.transactions.create.useMutation({
-      onSuccess: () => {
-        refetchTransactions();
-        setTransactionDialogOpen(false);
+
+  const updateTransactionMutation =
+    trpc.clients.transactions.update.useMutation({
+      onSuccess: async () => {
+        await Promise.all([
+          utils.relationshipProfile.getMoney.invalidate({ clientId }),
+          utils.relationshipProfile.getShell.invalidate({ clientId }),
+        ]);
+        toast.success("Transaction updated");
+        setSelectedTransaction(null);
+      },
+      onError: error => {
+        toast.error(error.message);
       },
     });
-  const recordPaymentMutation =
-    trpc.clients.transactions.recordPayment.useMutation();
-  const addTagMutation = trpc.clients.tags.add.useMutation({
-    onSuccess: () => {
-      refetchClient();
-      setNewTag("");
-      setShowTagInput(false);
-    },
-  });
 
-  // TER-626: Tab validation — only "overview" and "history" are valid tabs now
-  useEffect(() => {
-    if (activeTab !== "overview" && activeTab !== "history") {
-      setActiveTab("overview");
-    }
-  }, [activeTab]);
+  const addLedgerAdjustmentMutation =
+    trpc.clientLedger.addLedgerAdjustment.useMutation({
+      onSuccess: async () => {
+        await Promise.all([
+          utils.relationshipProfile.getMoney.invalidate({ clientId }),
+          utils.relationshipProfile.getShell.invalidate({ clientId }),
+        ]);
+        toast.success(
+          moneyAction === "receive"
+            ? "Money received was added to the ledger"
+            : "Money paid was added to the ledger"
+        );
+        setMoneyAction(null);
+        setAdjustmentForm({
+          amount: "",
+          description: "",
+          effectiveDate: new Date().toISOString().slice(0, 10),
+        });
+      },
+      onError: error => {
+        toast.error(error.message);
+      },
+    });
 
-  if (clientLoading) {
+  const handleSectionChange = (section: RelationshipProfileSection) => {
+    setActiveSection(section);
+    setLocation(buildRelationshipProfilePath(clientId, section));
+  };
+
+  const shell = shellQuery.data;
+  const money = moneyQuery.data;
+  const moneySummary = money?.summary ?? shell?.financials.moneySummary;
+  const isCustomer = shell?.roles.includes("Customer") ?? false;
+  const isSupplier = shell?.roles.includes("Supplier") ?? false;
+
+  const commandStrip = (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button variant="outline" onClick={() => setEditDialogOpen(true)}>
+        <Edit className="mr-2 h-4 w-4" />
+        Edit Profile
+      </Button>
+      <Button variant="outline" onClick={() => setMoneyAction("receive")}>
+        <CircleDollarSign className="mr-2 h-4 w-4" />
+        Receive Money
+      </Button>
+      <Button variant="outline" onClick={() => setMoneyAction("pay")}>
+        <ArrowRightLeft className="mr-2 h-4 w-4" />
+        Pay Money
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => setLocation(`/clients/${clientId}/ledger`)}
+      >
+        <Receipt className="mr-2 h-4 w-4" />
+        Ledger
+      </Button>
+    </div>
+  );
+
+  const meta = shell
+    ? [
+        {
+          label:
+            moneySummary?.mode === "supplier"
+              ? "Payable Due"
+              : moneySummary?.mode === "hybrid"
+                ? "Net Position"
+                : "Receivable",
+          value: formatMoney(
+            moneySummary?.mode === "supplier"
+              ? moneySummary.payable.amountDue
+              : moneySummary?.mode === "hybrid"
+                ? moneySummary.netPosition
+                : shell.financials.balance.computedBalance
+          ),
+        },
+        {
+          label:
+            moneySummary?.mode === "supplier" ? "Paid Out" : "Credit Limit",
+          value: formatMoney(
+            moneySummary?.mode === "supplier"
+              ? moneySummary.payable.amountPaid
+              : shell.financials.creditLimit
+          ),
+        },
+        {
+          label: "Open Work",
+          value: `${shell.openArtifacts.orderDrafts + shell.openArtifacts.salesSheetDrafts} drafts`,
+        },
+        {
+          label: "Last Touch",
+          value: formatDate(shell.lastTouchAt),
+        },
+      ]
+    : [];
+
+  const inspectorOpen = Boolean(
+    selectedTransaction || selectedLedgerEntry || selectedPayment || moneyAction
+  );
+
+  if (shellQuery.isLoading) {
     return <PageSkeleton variant="dashboard" />;
   }
 
-  if (isError || !client) {
+  if (!shell) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="text-center">
-          <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
-          <div className="text-lg font-medium">Client not found</div>
-          <p className="text-sm text-muted-foreground mt-2">
-            The client you are looking for does not exist or could not be
-            loaded.
-          </p>
-        </div>
+      <div className="space-y-4 p-4 md:p-6">
+        <BackButton />
+        <EmptyCard message="This relationship profile could not be loaded." />
       </div>
     );
   }
 
-  // Get client type badges
-  const getClientTypeBadges = () => {
-    const badges: {
-      label: string;
-      variant: "default" | "secondary" | "outline";
-    }[] = [];
-    if (client.isBuyer) badges.push({ label: "Buyer", variant: "default" });
-    if (client.isSeller)
-      badges.push({ label: "Supplier", variant: "secondary" });
-    if (client.isBrand) badges.push({ label: "Brand", variant: "outline" });
-    if (client.isReferee)
-      badges.push({ label: "Referee", variant: "secondary" });
-    if (client.isContractor)
-      badges.push({ label: "Contractor", variant: "outline" });
-    return badges;
-  };
-
-  // Format currency
-  const formatCurrency = (value: string | number) => {
-    const num = typeof value === "string" ? parseFloat(value) : value;
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-    }).format(num);
-  };
-
-  // Format percentage
-  const formatPercentage = (value: string | number) => {
-    const num = typeof value === "string" ? parseFloat(value) : value;
-    return `${num.toFixed(2)}%`;
-  };
-
-  // Format date
-  const formatDate = (date: string | Date) => {
-    return new Date(date).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  };
-
-  // Get payment status badge
-  const getPaymentStatusBadge = (status: string) => {
-    const variants: Record<
-      string,
-      "default" | "secondary" | "destructive" | "outline"
-    > = {
-      PAID: "default",
-      PENDING: "secondary",
-      OVERDUE: "destructive",
-      PARTIAL: "outline",
-    };
-    return <Badge variant={variants[status] || "outline"}>{status}</Badge>;
-  };
-
-  // Get transaction type badge
-  const getTransactionTypeBadge = (type: string) => {
-    const variants: Record<
-      string,
-      "default" | "secondary" | "destructive" | "outline"
-    > = {
-      INVOICE: "default",
-      PAYMENT: "default",
-      QUOTE: "secondary",
-      ORDER: "outline",
-      REFUND: "destructive",
-      CREDIT: "outline",
-    };
-    return <Badge variant={variants[type] || "outline"}>{type}</Badge>;
-  };
-
-  // Filter paid transactions for payment history
-  const paidTransactions =
-    transactions?.filter(
-      (txn: ClientTransaction) =>
-        txn.paymentStatus === "PAID" && txn.paymentDate
-    ) || [];
-
-  // Filter by payment search
-  const filteredPayments = paidTransactions.filter((txn: ClientTransaction) => {
-    if (!paymentSearch) return true;
-    return (
-      txn.transactionNumber
-        ?.toLowerCase()
-        .includes(paymentSearch.toLowerCase()) ||
-      txn.transactionType?.toLowerCase().includes(paymentSearch.toLowerCase())
-    );
-  });
-
-  // Handle record payment
-  const handleRecordPayment = async (
-    transactionId: number,
-    paymentAmount: number,
-    paymentDate: Date
-  ) => {
-    await recordPaymentMutation.mutateAsync({
-      transactionId,
-      paymentAmount,
-      paymentDate,
-    });
-    refetchTransactions();
-    setPaymentDialogOpen(false);
-    setSelectedTransaction(null);
-  };
-
-  const handleAddTag = async () => {
-    const tag = newTag.trim();
-    if (!tag) return;
-    await addTagMutation.mutateAsync({ clientId, tag });
-  };
-
   return (
-    <PageErrorBoundary pageName="ClientProfile">
-      <div className="space-y-6">
-        {/* Breadcrumb and Header */}
-        <BackButton label="Back to Clients" to="/clients" />
+    <div className="space-y-4 px-4 py-4 md:px-6">
+      <BackButton />
 
-        {/* Client Header */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-start justify-between">
-              <div className="space-y-2">
-                <div className="flex items-center gap-3">
-                  <CardTitle className="text-3xl" data-testid="client-id">
-                    {client.teriCode}
-                  </CardTitle>
-                  <div className="flex gap-2">
-                    {getClientTypeBadges().map(badge => (
-                      <Badge key={badge.label} variant={badge.variant}>
-                        {badge.label}
-                      </Badge>
-                    ))}
+      <LinearWorkspaceShell
+        title={shell.name}
+        description="Unified customer and supplier workspace with money, pricing, inventory, and activity in one place."
+        section="Relationships"
+        activeTab={activeSection}
+        tabs={PROFILE_TABS}
+        onTabChange={handleSectionChange}
+        meta={meta}
+        commandStrip={commandStrip}
+      >
+        <LinearWorkspacePanel value="overview">
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-[1.35fr_0.95fr]">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Identity</CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2 text-sm">
+                    <p className="font-medium">Contact</p>
+                    <p>{shell.email || "No email on file"}</p>
+                    <p>{shell.phone || "No phone on file"}</p>
+                    <p>{shell.address || "No address on file"}</p>
                   </div>
-                </div>
-                <CardDescription className="text-base">
-                  {client.name}
-                </CardDescription>
-                {client.email && (
-                  <p className="text-sm text-muted-foreground">
-                    {client.email}
-                  </p>
-                )}
-                {client.phone && (
-                  <p className="text-sm text-muted-foreground">
-                    {client.phone}
-                  </p>
-                )}
-              </div>
-              <div className="flex gap-2">
-                {client.vipPortalEnabled && (
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      setLocation(`/clients/${clientId}/vip-portal-config`)
-                    }
-                  >
-                    <Settings className="h-4 w-4 mr-2" />
-                    VIP Portal Config
-                  </Button>
-                )}
-                <Button
-                  variant="outline"
-                  onClick={() => setLocation(`/clients/${clientId}/ledger`)}
-                >
-                  <BookOpen className="h-4 w-4 mr-2" />
-                  View Ledger
-                </Button>
-                <Button onClick={() => setEditDialogOpen(true)}>
-                  <Edit className="h-4 w-4 mr-2" />
-                  Edit Client
-                </Button>
-              </div>
-            </div>
-          </CardHeader>
-        </Card>
-
-        {/* Quick Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Total Spent</CardTitle>
-              <DollarSign className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {formatCurrency(client.totalSpent || 0)}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">
-                Total Profit
-              </CardTitle>
-              <TrendingUp className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {formatCurrency(client.totalProfit || 0)}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">
-                Avg Profit Margin
-              </CardTitle>
-              <TrendingUp className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {formatPercentage(client.avgProfitMargin || 0)}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Amount Owed</CardTitle>
-              <div className="flex items-center gap-1">
-                <AuditIcon
-                  type="client"
-                  entityId={clientId}
-                  fieldName="totalOwed"
-                />
-                <AlertCircle className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div
-                className={`text-2xl font-bold ${parseFloat(client.totalOwed as string) > 0 ? "text-destructive" : ""}`}
-                data-testid="total-owed"
-              >
-                {formatCurrency(client.totalOwed || 0)}
-              </div>
-              {client.oldestDebtDays && client.oldestDebtDays > 0 && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  Oldest: {client.oldestDebtDays} days
-                </p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* TER-626: Tabbed Content — reduced to 2 tabs */}
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0 scrollbar-hide">
-            <TabsList className="inline-flex w-full min-w-max md:w-auto h-auto gap-1">
-              <TabsTrigger
-                value="overview"
-                className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2"
-              >
-                Overview
-              </TabsTrigger>
-              <TabsTrigger
-                value="history"
-                data-testid="transactions-tab"
-                className="whitespace-nowrap text-xs sm:text-sm px-2 sm:px-3 py-1.5 sm:py-2"
-              >
-                History
-              </TabsTrigger>
-            </TabsList>
-          </div>
-
-          {/* TER-626: Overview Tab — combined key info + collapsible sections */}
-          <TabsContent value="overview" className="space-y-4">
-            {/* Credit Status Card (only for buyers with visibility enabled) */}
-            {client.isBuyer && shouldShowCreditWidgetInProfile && (
-              <CreditStatusCard
-                clientId={clientId}
-                clientName={client.name}
-                showOverrideButton={true}
-                showRecalculateButton={true}
-              />
-            )}
-
-            {/* Purchase Patterns Widget (only for buyers) */}
-            {client.isBuyer && <PurchasePatternsWidget clientId={clientId} />}
-
-            {/* VIP Portal Settings (only for buyers) */}
-            {client.isBuyer && (
-              <VIPPortalSettings
-                clientId={clientId}
-                clientName={client.name}
-                vipPortalEnabled={client.vipPortalEnabled || false}
-                vipPortalLastLogin={client.vipPortalLastLogin}
-              />
-            )}
-
-            {/* Customer Wishlist (WS-015) - only for buyers */}
-            {client.isBuyer && (
-              <CustomerWishlistCard
-                clientId={clientId}
-                wishlist={client.wishlist || ""}
-                version={client.version}
-                onRefresh={refetchClient}
-              />
-            )}
-
-            <Card>
-              <CardHeader>
-                <CardTitle>Client Information</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      TERI Code
-                    </Label>
-                    <p className="text-base">{client.teriCode}</p>
-                  </div>
-                  <div>
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Name
-                    </Label>
-                    <p className="text-base">{client.name}</p>
-                  </div>
-                  <div>
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Email
-                    </Label>
-                    <p className="text-base">{client.email || "-"}</p>
-                  </div>
-                  <div>
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Phone
-                    </Label>
-                    <p className="text-base">{client.phone || "-"}</p>
-                  </div>
-                  <div className="col-span-2" data-testid="tags-section">
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Address
-                    </Label>
-                    <p className="text-base">{client.address || "-"}</p>
-                  </div>
-                  <div className="col-span-2">
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Tags
-                    </Label>
-                    <div
-                      className="flex flex-wrap gap-2 mt-1"
-                      data-testid="tags-list"
-                    >
-                      {client.tags &&
-                      Array.isArray(client.tags) &&
-                      client.tags.length > 0 ? (
-                        (client.tags as string[]).map(tag => (
-                          <Badge key={tag} variant="outline">
-                            {tag}
-                          </Badge>
-                        ))
-                      ) : (
-                        <span className="text-muted-foreground">No tags</span>
-                      )}
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      {showTagInput ? (
-                        <>
-                          <Input
-                            data-testid="tag-input"
-                            value={newTag}
-                            onChange={e => setNewTag(e.target.value)}
-                            placeholder="Enter tag"
-                            className="w-48"
-                          />
-                          <Button
-                            size="sm"
-                            data-testid="save-tag-btn"
-                            onClick={handleAddTag}
-                            disabled={
-                              addTagMutation.isPending || !newTag.trim()
-                            }
-                          >
-                            {addTagMutation.isPending
-                              ? "Saving..."
-                              : "Save Tag"}
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => {
-                              setShowTagInput(false);
-                              setNewTag("");
-                            }}
-                          >
-                            Cancel
-                          </Button>
-                        </>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          data-testid="add-tag-btn"
-                          onClick={() => setShowTagInput(true)}
-                        >
-                          Add Tag
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Recent Activity */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Recent Activity</CardTitle>
-              </CardHeader>
-              <CardContent>
-                {activities && activities.length > 0 ? (
                   <div className="space-y-3">
-                    {activities.slice(0, 5).map((activity: ClientActivity) => (
+                    <div>
+                      <p className="text-sm font-medium">Roles</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {shell.roles.map(role => (
+                          <Badge key={role} variant="secondary">
+                            {role}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="text-sm">
+                      <p className="font-medium">Referrer</p>
+                      <p className="mt-1 text-muted-foreground">
+                        {shell.referrer?.name || "No referrer assigned"}
+                      </p>
+                    </div>
+                    <div className="text-sm">
+                      <p className="font-medium">Tags</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {shell.tags.length ? (
+                          shell.tags.map(tag => (
+                            <Badge key={tag} variant="outline">
+                              {tag}
+                            </Badge>
+                          ))
+                        ) : (
+                          <span className="text-muted-foreground">
+                            No tags yet
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Signals</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {shell.alerts.length ? (
+                    shell.alerts.map(alert => (
                       <div
-                        key={activity.id}
-                        className="flex items-start gap-3 text-sm"
+                        key={alert.label}
+                        className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2"
                       >
-                        <Calendar className="h-4 w-4 text-muted-foreground mt-0.5" />
-                        <div className="flex-1">
-                          <p className="font-medium">
-                            {activity.activityType.replace(/_/g, " ")}
-                          </p>
-                          <p className="text-muted-foreground">
-                            by {activity.userName || "Unknown"} •{" "}
-                            {activity.createdAt
-                              ? formatDate(activity.createdAt)
-                              : "-"}
-                          </p>
+                        <div className="flex items-start gap-2">
+                          <ShieldAlert className="mt-0.5 h-4 w-4 text-amber-700" />
+                          <div>
+                            <p className="text-sm font-medium text-amber-950">
+                              {alert.label}
+                            </p>
+                            <p className="text-xs text-amber-900/75">
+                              {alert.detail}
+                            </p>
+                          </div>
                         </div>
                       </div>
-                    ))}
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No active risk flags on this profile.
+                    </p>
+                  )}
+                  <div className="grid grid-cols-2 gap-3">
+                    <MetricCard
+                      label="VIP Portal"
+                      value={shell.vipPortalEnabled ? "Enabled" : "Disabled"}
+                    />
+                    <MetricCard
+                      label="Last Login"
+                      value={
+                        shell.vipPortalLastLogin
+                          ? formatDate(shell.vipPortalLastLogin)
+                          : "Never"
+                      }
+                    />
                   </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <MetricCard
+                label="Lifetime Value"
+                value={formatMoney(shell.financials.lifetimeValue)}
+              />
+              <MetricCard
+                label="Profit"
+                value={formatMoney(shell.financials.profitability)}
+              />
+              <MetricCard
+                label="Average Margin"
+                value={`${shell.financials.averageMarginPercent.toFixed(1)}%`}
+              />
+              <MetricCard
+                label="Open Quotes"
+                value={String(shell.openArtifacts.openQuotes)}
+              />
+            </div>
+
+            {shell.wishlist ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Wishlist & Notes</CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm text-muted-foreground whitespace-pre-wrap">
+                  {shell.wishlist}
+                </CardContent>
+              </Card>
+            ) : null}
+
+            {isCustomer ? (
+              <div className="grid gap-4 xl:grid-cols-[0.9fr_1.1fr]">
+                <VIPPortalSettings
+                  clientId={clientId}
+                  clientName={shell.name}
+                  vipPortalEnabled={shell.vipPortalEnabled}
+                  vipPortalLastLogin={shell.vipPortalLastLogin}
+                />
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      Live Catalog & Interest Intake
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <LiveCatalogConfig clientId={clientId} />
+                  </CardContent>
+                </Card>
+              </div>
+            ) : null}
+
+            {isSupplier ? (
+              <SupplierProfileSection
+                clientId={clientId}
+                clientName={shell.name}
+              />
+            ) : null}
+          </div>
+        </LinearWorkspacePanel>
+
+        <LinearWorkspacePanel value="sales-pricing">
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+              <div className="space-y-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Commercial Feed</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {salesQuery.data?.mergedArtifacts?.length ? (
+                      salesQuery.data.mergedArtifacts.map(item => (
+                        <div
+                          key={item.id}
+                          className="flex items-start justify-between gap-3 rounded-xl border border-border/70 p-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">
+                              {item.label}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {item.sublabel}
+                            </p>
+                          </div>
+                          <div className="shrink-0 text-right text-xs text-muted-foreground">
+                            <p>{formatMoney(item.amount)}</p>
+                            <p>{formatDate(item.updatedAt)}</p>
+                          </div>
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No sales sheets or order drafts are attached to this
+                        profile yet.
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      Wishlist Snapshot
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {salesQuery.data?.wishlist ? (
+                      <div className="rounded-xl bg-muted/40 p-3 text-sm text-muted-foreground">
+                        {salesQuery.data.wishlist}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No wishlist notes are recorded yet.
+                      </p>
+                    )}
+                    {salesQuery.data?.needs?.length ? (
+                      <div className="rounded-xl border border-border/70 p-3 text-sm">
+                        <p className="font-medium">
+                          {salesQuery.data.needs.length} active need
+                          {salesQuery.data.needs.length === 1 ? "" : "s"}
+                        </p>
+                        <p className="mt-1 text-muted-foreground">
+                          Use the needs workspace below to create, match, and
+                          convert demand without leaving the profile.
+                        </p>
+                      </div>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              </div>
+
+              <div className="space-y-4">
+                <PricingConfigTab
+                  clientId={clientId}
+                  onProfileApplied={() => {
+                    void Promise.all([
+                      utils.relationshipProfile.getSalesPricing.invalidate({
+                        clientId,
+                      }),
+                      utils.relationshipProfile.getShell.invalidate({
+                        clientId,
+                      }),
+                    ]);
+                  }}
+                />
+                <Button
+                  className="w-full"
+                  onClick={() =>
+                    setLocation(
+                      buildSalesWorkspacePath("create-order", { clientId })
+                    )
+                  }
+                >
+                  <ArrowRightLeft className="mr-2 h-4 w-4" />
+                  Start Sales Order
+                </Button>
+              </div>
+            </div>
+
+            {isCustomer ? <ClientNeedsTab clientId={clientId} /> : null}
+          </div>
+        </LinearWorkspacePanel>
+
+        <LinearWorkspacePanel value="money">
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              {moneySummary?.mode === "supplier" ? (
+                <>
+                  <MetricCard
+                    label="Payable Due"
+                    value={formatMoney(moneySummary.payable.amountDue)}
+                  />
+                  <MetricCard
+                    label="Paid Out"
+                    value={formatMoney(moneySummary.payable.amountPaid)}
+                  />
+                  <MetricCard
+                    label="Open Payables"
+                    value={String(moneySummary.payable.openPayableCount)}
+                  />
+                </>
+              ) : moneySummary?.mode === "hybrid" ? (
+                <>
+                  <MetricCard
+                    label="Receivable"
+                    value={formatMoney(moneySummary.receivable.computedBalance)}
+                  />
+                  <MetricCard
+                    label="Payable Due"
+                    value={formatMoney(moneySummary.payable.amountDue)}
+                  />
+                  <MetricCard
+                    label="Net Position"
+                    value={formatMoney(moneySummary.netPosition)}
+                  />
+                </>
+              ) : (
+                <>
+                  <MetricCard
+                    label="Receivable"
+                    value={formatMoney(
+                      money?.balance.computedBalance ??
+                        shell.financials.balance.computedBalance
+                    )}
+                  />
+                  <MetricCard
+                    label="Stored Balance"
+                    value={formatMoney(
+                      money?.balance.storedBalance ??
+                        shell.financials.balance.storedBalance
+                    )}
+                    hint={`Variance ${formatMoney(
+                      money?.balance.discrepancy ??
+                        shell.financials.balance.discrepancy
+                    )}`}
+                  />
+                  <MetricCard
+                    label="Credit Limit"
+                    value={formatMoney(
+                      money?.credit?.creditLimit ?? shell.financials.creditLimit
+                    )}
+                  />
+                </>
+              )}
+              <MetricCard
+                label="Ledger Net"
+                value={formatMoney(money?.ledgerTotals.netBalance)}
+              />
+            </div>
+
+            {shouldShowCreditWidgetInProfile && isCustomer ? (
+              <CreditStatusCard clientId={clientId} clientName={shell.name} />
+            ) : null}
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="text-base">Transaction History</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Click a row to edit supported transactions.
+                </p>
+              </CardHeader>
+              <CardContent>
+                {money?.transactionHistory.length ? (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Reference</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="text-right">Amount</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {money.transactionHistory.map(transaction => (
+                        <TableRow
+                          key={transaction.id}
+                          className="cursor-pointer"
+                          onClick={() => setSelectedTransaction(transaction)}
+                        >
+                          <TableCell>{transaction.transactionType}</TableCell>
+                          <TableCell>
+                            {transaction.transactionNumber ||
+                              `#${transaction.id}`}
+                          </TableCell>
+                          <TableCell>
+                            {formatDate(transaction.transactionDate)}
+                          </TableCell>
+                          <TableCell>
+                            {transaction.paymentStatus || "-"}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {formatMoney(transaction.amount)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
                 ) : (
-                  <p className="text-muted-foreground text-center py-4">
-                    No activity yet
+                  <p className="text-sm text-muted-foreground">
+                    No editable transaction history is stored on this profile.
                   </p>
                 )}
               </CardContent>
             </Card>
 
-            {/* Comments */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Comments</CardTitle>
-                <CardDescription>
-                  Team notes and discussions about this client
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <CommentWidget
-                  commentableType="client"
-                  commentableId={clientId}
-                />
-              </CardContent>
-            </Card>
+            <div className="grid gap-4 xl:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Payment History</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {money?.paymentHistory.length ? (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Payment</TableHead>
+                          <TableHead>Date</TableHead>
+                          <TableHead>Method</TableHead>
+                          <TableHead className="text-right">Amount</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {money.paymentHistory.map(payment => (
+                          <TableRow
+                            key={payment.id}
+                            className="cursor-pointer"
+                            onClick={() => setSelectedPayment(payment)}
+                          >
+                            <TableCell>{payment.paymentNumber}</TableCell>
+                            <TableCell>
+                              {formatDate(payment.paymentDate)}
+                            </TableCell>
+                            <TableCell>{payment.paymentMethod}</TableCell>
+                            <TableCell className="text-right">
+                              {formatMoney(payment.amount)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No payments are linked to this relationship yet.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
 
-            {/* TER-626: Collapsible sections absorbed into Overview */}
-            {client.isSeller && (
-              <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-                <CollapsibleTrigger asChild>
-                  <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                    <CardHeader className="py-3">
-                      <div className="flex items-center gap-2">
-                        <ChevronRight className="h-4 w-4 transition-transform duration-200" />
-                        <CardTitle className="text-base">
-                          Supplier Profile
-                        </CardTitle>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Ledger Timeline</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {money?.ledgerTimeline.length ? (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Entry</TableHead>
+                          <TableHead>Date</TableHead>
+                          <TableHead className="text-right">Net</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {money.ledgerTimeline.map(entry => (
+                          <TableRow
+                            key={entry.id}
+                            className="cursor-pointer"
+                            onClick={() => setSelectedLedgerEntry(entry)}
+                          >
+                            <TableCell>
+                              <div>
+                                <p className="font-medium">{entry.label}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {entry.transactionType}
+                                </p>
+                              </div>
+                            </TableCell>
+                            <TableCell>{formatDate(entry.date)}</TableCell>
+                            <TableCell className="text-right">
+                              {entry.netEffect > 0 ? "+" : ""}
+                              {formatMoney(entry.netEffect)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No ledger activity has been generated yet.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </LinearWorkspacePanel>
+
+        <LinearWorkspacePanel value="supply-inventory">
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-[1.05fr_0.95fr]">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">System Inventory</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {supplyQuery.data?.systemInventory.length ? (
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>SKU</TableHead>
+                          <TableHead>Product</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead className="text-right">On Hand</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {supplyQuery.data.systemInventory.map(item => (
+                          <TableRow key={item.id}>
+                            <TableCell>{item.sku}</TableCell>
+                            <TableCell>{item.productName}</TableCell>
+                            <TableCell>{item.status}</TableCell>
+                            <TableCell className="text-right">
+                              {item.onHandQty.toLocaleString()}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No inventory is visible right now.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Customer Needs</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {supplyQuery.data?.buyerNeeds.length ? (
+                    supplyQuery.data.buyerNeeds.map(need => (
+                      <div
+                        key={need.id}
+                        className="rounded-xl border border-border/70 p-3"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-medium">{need.label}</p>
+                          <Badge variant="outline">{need.priority}</Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {need.status} · Updated {formatDate(need.updatedAt)}
+                        </p>
                       </div>
-                    </CardHeader>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No active needs are attached to this customer.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            {shell.roles.includes("Supplier") && supplyQuery.data?.supplier ? (
+              <div className="space-y-4">
+                {supplyQuery.data.supplier.contextError ? (
+                  <Card className="border-amber-300 bg-amber-50">
+                    <CardContent className="py-4 text-sm text-amber-950">
+                      Supplier context metrics could not be loaded:{" "}
+                      {supplyQuery.data.supplier.contextError}
+                    </CardContent>
                   </Card>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="mt-2">
-                  <SupplierProfileSection
-                    clientId={clientId}
-                    clientName={client.name}
+                ) : null}
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                  <MetricCard
+                    label="Lots Received"
+                    value={String(
+                      supplyQuery.data.supplier.context?.aggregateMetrics
+                        .totalLotsReceived ?? 0
+                    )}
                   />
-                </CollapsibleContent>
-              </Collapsible>
-            )}
+                  <MetricCard
+                    label="Units Supplied"
+                    value={String(
+                      supplyQuery.data.supplier.context?.aggregateMetrics
+                        .totalUnitsSupplied ?? 0
+                    )}
+                  />
+                  <MetricCard
+                    label="Units Sold"
+                    value={String(
+                      supplyQuery.data.supplier.context?.aggregateMetrics
+                        .totalUnitsSold ?? 0
+                    )}
+                  />
+                  <MetricCard
+                    label="Revenue"
+                    value={formatMoney(
+                      supplyQuery.data.supplier.context?.aggregateMetrics
+                        .totalRevenue
+                    )}
+                  />
+                </div>
 
-            <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-              <CollapsibleTrigger asChild>
-                <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                  <CardHeader className="py-3">
-                    <div className="flex items-center gap-2">
-                      <ChevronRight className="h-4 w-4 transition-transform duration-200" />
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <Card>
+                    <CardHeader>
                       <CardTitle className="text-base">
-                        Pricing Config
+                        Supplier Batches
                       </CardTitle>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2">
-                <PricingConfigTab clientId={clientId} />
-              </CollapsibleContent>
-            </Collapsible>
+                    </CardHeader>
+                    <CardContent>
+                      {supplyQuery.data.supplier.batches.length ? (
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>SKU</TableHead>
+                              <TableHead>Product</TableHead>
+                              <TableHead>Status</TableHead>
+                              <TableHead className="text-right">
+                                On Hand
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {supplyQuery.data.supplier.batches.map(batch => (
+                              <TableRow key={batch.id}>
+                                <TableCell>{batch.sku}</TableCell>
+                                <TableCell>{batch.productName}</TableCell>
+                                <TableCell>{batch.status}</TableCell>
+                                <TableCell className="text-right">
+                                  {batch.onHandQty.toLocaleString()}
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">
+                          No active supplier batches were found.
+                        </p>
+                      )}
+                    </CardContent>
+                  </Card>
 
-            <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-              <CollapsibleTrigger asChild>
-                <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                  <CardHeader className="py-3">
-                    <div className="flex items-center gap-2">
-                      <ChevronRight className="h-4 w-4 transition-transform duration-200" />
+                  <Card>
+                    <CardHeader>
                       <CardTitle className="text-base">
-                        Needs & Wishlist
+                        Purchase Orders
                       </CardTitle>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2 space-y-4">
-                <ClientNeedsTab clientId={clientId} />
-              </CollapsibleContent>
-            </Collapsible>
+                    </CardHeader>
+                    <CardContent>
+                      {supplyQuery.data.supplier.purchaseOrders.length ? (
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>PO</TableHead>
+                              <TableHead>Status</TableHead>
+                              <TableHead>Date</TableHead>
+                              <TableHead className="text-right">
+                                Total
+                              </TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {supplyQuery.data.supplier.purchaseOrders.map(
+                              po => (
+                                <TableRow key={po.id}>
+                                  <TableCell>{po.poNumber}</TableCell>
+                                  <TableCell>{po.status}</TableCell>
+                                  <TableCell>
+                                    {formatDate(po.orderDate)}
+                                  </TableCell>
+                                  <TableCell className="text-right">
+                                    {formatMoney(po.total)}
+                                  </TableCell>
+                                </TableRow>
+                              )
+                            )}
+                          </TableBody>
+                        </Table>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">
+                          No purchase orders are linked to this supplier.
+                        </p>
+                      )}
+                    </CardContent>
+                  </Card>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </LinearWorkspacePanel>
 
-            <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-              <CollapsibleTrigger asChild>
-                <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                  <CardHeader className="py-3">
-                    <div className="flex items-center gap-2">
-                      <ChevronRight className="h-4 w-4 transition-transform duration-200" />
-                      <CardTitle className="text-base">
-                        Communications
-                      </CardTitle>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2">
-                <CommunicationTimeline
-                  clientId={clientId}
-                  onAddClick={() => setCommunicationModalOpen(true)}
-                />
-              </CollapsibleContent>
-            </Collapsible>
+        <LinearWorkspacePanel value="activity">
+          <div className="space-y-4">
+            <div className="grid gap-4 xl:grid-cols-[1fr_0.9fr]">
+              <CommunicationTimeline
+                clientId={clientId}
+                onAddClick={() => setCommunicationModalOpen(true)}
+              />
 
-            <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-              <CollapsibleTrigger asChild>
-                <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                  <CardHeader className="py-3">
-                    <div className="flex items-center gap-2">
-                      <ChevronRight className="h-4 w-4 transition-transform duration-200" />
-                      <CardTitle className="text-base">Calendar</CardTitle>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Recent Activity</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {activityQuery.data?.activity.length ? (
+                    activityQuery.data.activity.map(item => (
+                      <div
+                        key={item.id}
+                        className="rounded-xl border border-border/70 p-3"
+                      >
+                        <div className="flex items-center gap-2">
+                          <Activity className="h-4 w-4 text-muted-foreground" />
+                          <p className="text-sm font-medium">
+                            {item.activityType.replace(/_/g, " ")}
+                          </p>
+                        </div>
+                        <p className="mt-2 text-xs text-muted-foreground">
+                          {item.userName || "System"} ·{" "}
+                          {formatDate(item.createdAt)}
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No activity has been logged yet.
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[0.85fr_1.15fr]">
+              <div className="space-y-4">
                 <ClientCalendarTab clientId={clientId} />
-              </CollapsibleContent>
-            </Collapsible>
-
-            <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-              <CollapsibleTrigger asChild>
-                <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                  <CardHeader className="py-3">
-                    <div className="flex items-center gap-2">
-                      <ChevronRight className="h-4 w-4 transition-transform duration-200" />
-                      <CardTitle className="text-base">Notes</CardTitle>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="mt-2">
                 <Card>
-                  <CardContent className="pt-4">
-                    <div className="h-[400px]">
-                      <FreeformNoteWidget noteId={noteId || undefined} />
-                    </div>
+                  <CardHeader>
+                    <CardTitle className="text-base">Comments</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CommentWidget
+                      commentableType="client"
+                      commentableId={clientId}
+                    />
                   </CardContent>
                 </Card>
-              </CollapsibleContent>
-            </Collapsible>
-
-            {client.isBuyer && (
-              <Collapsible className="[&[data-state=open]>div>svg]:rotate-90">
-                <CollapsibleTrigger asChild>
-                  <Card className="cursor-pointer hover:bg-muted/30 transition-colors">
-                    <CardHeader className="py-3">
-                      <div className="flex items-center gap-2">
-                        <ChevronRight className="h-4 w-4 transition-transform duration-200" />
-                        <CardTitle className="text-base">
-                          Live Catalog
-                        </CardTitle>
-                      </div>
-                    </CardHeader>
-                  </Card>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="mt-2">
-                  <LiveCatalogConfig clientId={clientId} />
-                </CollapsibleContent>
-              </Collapsible>
-            )}
-          </TabsContent>
-
-          {/* TER-626: History Tab — transactions + payments combined */}
-          <TabsContent value="history" className="space-y-4">
-            {/* Transactions Section */}
-            <div>
-              <Card>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <CardTitle>Transaction History</CardTitle>
-                      <CardDescription>
-                        All transactions (invoices, quotes, orders, etc.)
-                      </CardDescription>
-                    </div>
-                    <Button
-                      data-testid="add-transaction-btn"
-                      onClick={() => setTransactionDialogOpen(true)}
-                    >
-                      <Plus className="h-4 w-4 mr-2" />
-                      Add Transaction
-                    </Button>
-                  </div>
-                </CardHeader>
-                <CardContent
-                  className="space-y-4"
-                  data-testid="transactions-list"
-                >
-                  {/* Search */}
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      placeholder="Search transactions..."
-                      value={transactionSearch}
-                      onChange={e => setTransactionSearch(e.target.value)}
-                      className="pl-9"
-                    />
-                  </div>
-
-                  {/* Transactions Table */}
-                  {transactionsLoading ? (
-                    <div className="text-center py-8 text-muted-foreground">
-                      Loading transactions...
-                    </div>
-                  ) : !transactions || transactions.length === 0 ? (
-                    <div className="text-center py-8 text-muted-foreground">
-                      <p className="text-lg font-medium">
-                        No transactions found
-                      </p>
-                      <p className="text-sm mt-2">
-                        Add a transaction to get started
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="overflow-x-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Transaction #</TableHead>
-                            <TableHead>Type</TableHead>
-                            <TableHead>Date</TableHead>
-                            <TableHead className="text-right">Amount</TableHead>
-                            <TableHead>Payment Status</TableHead>
-                            <TableHead>Notes</TableHead>
-                            <TableHead>Audit</TableHead>
-                            <TableHead className="text-right">
-                              Actions
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {transactions.map((txn: ClientTransaction) => (
-                            <TableRow
-                              key={txn.id}
-                              data-testid={`transaction-row-${txn.id}`}
-                              data-status={txn.paymentStatus}
-                            >
-                              <TableCell className="font-medium">
-                                {txn.transactionNumber || "-"}
-                              </TableCell>
-                              <TableCell>
-                                {getTransactionTypeBadge(txn.transactionType)}
-                              </TableCell>
-                              <TableCell>
-                                {txn.transactionDate
-                                  ? formatDate(txn.transactionDate)
-                                  : "-"}
-                              </TableCell>
-                              <TableCell className="text-right font-medium">
-                                {txn.amount !== null && txn.amount !== undefined
-                                  ? formatCurrency(txn.amount)
-                                  : "-"}
-                              </TableCell>
-                              <TableCell>
-                                {getPaymentStatusBadge(
-                                  txn.paymentStatus || "PENDING"
-                                )}
-                              </TableCell>
-                              <TableCell className="max-w-xs truncate">
-                                {txn.notes || "-"}
-                              </TableCell>
-                              <TableCell>
-                                <AuditIcon
-                                  entityType="transaction"
-                                  entityId={txn.id}
-                                  size="sm"
-                                />
-                              </TableCell>
-                              <TableCell className="text-right">
-                                {txn.paymentStatus !== "PAID" && (
-                                  <Button
-                                    data-testid="record-payment-btn"
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => {
-                                      setSelectedTransaction(txn);
-                                      setPaymentDialogOpen(true);
-                                    }}
-                                  >
-                                    Record Payment
-                                  </Button>
-                                )}
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Payments Section */}
-            <div>
-              <Card>
-                <CardHeader>
-                  <div>
-                    <CardTitle>Payment History</CardTitle>
-                    <CardDescription>
-                      All completed payments for this client
-                    </CardDescription>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  {/* Search */}
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      placeholder="Search payments..."
-                      value={paymentSearch}
-                      onChange={e => setPaymentSearch(e.target.value)}
-                      className="pl-9"
-                    />
-                  </div>
-
-                  {/* Payments Table */}
-                  {transactionsLoading ? (
-                    <div className="text-center py-8 text-muted-foreground">
-                      Loading payments...
-                    </div>
-                  ) : filteredPayments.length === 0 ? (
-                    <div className="text-center py-8 text-muted-foreground">
-                      <CheckCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-                      <p className="text-lg font-medium">No payments found</p>
-                      <p className="text-sm mt-2">
-                        Payments will appear here once transactions are marked
-                        as paid
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="overflow-x-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Transaction #</TableHead>
-                            <TableHead>Type</TableHead>
-                            <TableHead>Transaction Date</TableHead>
-                            <TableHead>Payment Date</TableHead>
-                            <TableHead className="text-right">
-                              Amount Paid
-                            </TableHead>
-                            <TableHead className="text-right">
-                              Transaction Amount
-                            </TableHead>
-                            <TableHead>Status</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {filteredPayments.map((txn: ClientTransaction) => (
-                            <TableRow key={txn.id}>
-                              <TableCell className="font-medium">
-                                {txn.transactionNumber || "-"}
-                              </TableCell>
-                              <TableCell>
-                                {getTransactionTypeBadge(txn.transactionType)}
-                              </TableCell>
-                              <TableCell>
-                                {txn.transactionDate
-                                  ? formatDate(txn.transactionDate)
-                                  : "-"}
-                              </TableCell>
-                              <TableCell className="font-medium">
-                                {txn.paymentDate
-                                  ? formatDate(txn.paymentDate)
-                                  : "-"}
-                              </TableCell>
-                              <TableCell className="text-right font-medium text-green-600">
-                                {(txn.paymentAmount ?? txn.amount) !== null &&
-                                (txn.paymentAmount ?? txn.amount) !== undefined
-                                  ? formatCurrency(
-                                      txn.paymentAmount ?? txn.amount ?? 0
-                                    )
-                                  : "-"}
-                              </TableCell>
-                              <TableCell className="text-right">
-                                {txn.amount !== null && txn.amount !== undefined
-                                  ? formatCurrency(txn.amount)
-                                  : "-"}
-                              </TableCell>
-                              <TableCell>
-                                <div className="flex items-center gap-2">
-                                  <CheckCircle className="h-4 w-4 text-green-600" />
-                                  <span className="text-green-600 font-medium">
-                                    Paid
-                                  </span>
-                                </div>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          </TabsContent>
-        </Tabs>
-
-        {/* Add Communication Modal */}
-        <AddCommunicationModal
-          clientId={clientId}
-          open={communicationModalOpen}
-          onOpenChange={setCommunicationModalOpen}
-          onSuccess={() => {
-            // Refetch communications will happen automatically via tRPC
-          }}
-        />
-
-        {/* Record Payment Dialog */}
-        <Dialog open={paymentDialogOpen} onOpenChange={setPaymentDialogOpen}>
-          <DialogContent data-testid="payment-form">
-            <DialogHeader>
-              <DialogTitle>Record Payment</DialogTitle>
-              <DialogDescription>
-                Record a payment for transaction{" "}
-                {selectedTransaction?.transactionNumber}
-              </DialogDescription>
-            </DialogHeader>
-            <form
-              onSubmit={e => {
-                e.preventDefault();
-                const formData = new FormData(e.currentTarget);
-                const paymentAmount = parseFloat(
-                  formData.get("paymentAmount") as string
-                );
-                const paymentDate = new Date(
-                  formData.get("paymentDate") as string
-                );
-                if (!selectedTransaction) return;
-                handleRecordPayment(
-                  selectedTransaction.id,
-                  paymentAmount,
-                  paymentDate
-                );
-              }}
-            >
-              <div className="space-y-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="paymentAmount">Payment Amount</Label>
-                  <Input
-                    id="paymentAmount"
-                    name="paymentAmount"
-                    type="number"
-                    step="0.01"
-                    defaultValue={selectedTransaction?.amount || ""}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="paymentDate">Payment Date</Label>
-                  <Input
-                    id="paymentDate"
-                    name="paymentDate"
-                    type="date"
-                    defaultValue={new Date().toISOString().split("T")[0]}
-                    required
-                  />
-                </div>
               </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setPaymentDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button type="submit" data-testid="submit-payment-btn">
-                  Record Payment
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
 
-        {/* Edit Client Dialog */}
-        <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-          <DialogContent className="w-full sm:max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>Edit Client</DialogTitle>
-              <DialogDescription>
-                Update client information for {client.teriCode}
-              </DialogDescription>
-            </DialogHeader>
-            <form
-              onSubmit={e => {
-                e.preventDefault();
-                const formData = new FormData(e.currentTarget);
+              <FreeformNoteWidget noteId={noteIdQuery.data || undefined} />
+            </div>
+          </div>
+        </LinearWorkspacePanel>
+      </LinearWorkspaceShell>
+
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent className="sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Edit Relationship Profile</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-3">
+              <Label htmlFor="profile-name">Name</Label>
+              <Input
+                id="profile-name"
+                value={editForm.name}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-3">
+              <Label htmlFor="profile-email">Email</Label>
+              <Input
+                id="profile-email"
+                value={editForm.email}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    email: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-3">
+              <Label htmlFor="profile-phone">Phone</Label>
+              <Input
+                id="profile-phone"
+                value={editForm.phone}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    phone: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-3">
+              <Label htmlFor="profile-payment-terms">
+                Payment Terms (days)
+              </Label>
+              <Input
+                id="profile-payment-terms"
+                value={editForm.paymentTerms}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    paymentTerms: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-3 md:col-span-2">
+              <Label htmlFor="profile-address">Address</Label>
+              <Textarea
+                id="profile-address"
+                value={editForm.address}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    address: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-3 md:col-span-2">
+              <Label htmlFor="profile-tags">Tags</Label>
+              <Input
+                id="profile-tags"
+                value={editForm.tags}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    tags: event.target.value,
+                  }))
+                }
+                placeholder="Comma-separated tags"
+              />
+            </div>
+            <div className="space-y-3 md:col-span-2">
+              <Label htmlFor="profile-wishlist">Wishlist / Notes</Label>
+              <Textarea
+                id="profile-wishlist"
+                value={editForm.wishlist}
+                onChange={event =>
+                  setEditForm(current => ({
+                    ...current,
+                    wishlist: event.target.value,
+                  }))
+                }
+                rows={4}
+              />
+            </div>
+            <div className="space-y-3 md:col-span-2">
+              <Label>Roles</Label>
+              <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
+                {[
+                  ["isBuyer", "Customer"],
+                  ["isSeller", "Supplier"],
+                  ["isBrand", "Brand"],
+                  ["isReferee", "Referee"],
+                  ["isContractor", "Contractor"],
+                ].map(([key, label]) => (
+                  <Button
+                    key={key}
+                    type="button"
+                    variant={
+                      editForm[key as keyof typeof editForm]
+                        ? "default"
+                        : "outline"
+                    }
+                    onClick={() =>
+                      setEditForm(current => ({
+                        ...current,
+                        [key]: !current[key as keyof typeof current],
+                      }))
+                    }
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() =>
                 updateClientMutation.mutate({
-                  clientId: client.id,
-                  version: client.version, // ST-026: Include version for optimistic locking
-                  name: formData.get("name") as string,
-                  email: (formData.get("email") as string) || undefined,
-                  phone: (formData.get("phone") as string) || undefined,
-                  address: (formData.get("address") as string) || undefined,
-                  isBuyer: formData.get("isBuyer") === "on",
-                  isSeller: formData.get("isSeller") === "on",
-                  isBrand: formData.get("isBrand") === "on",
-                  isReferee: formData.get("isReferee") === "on",
-                  isContractor: formData.get("isContractor") === "on",
-                });
-              }}
+                  clientId,
+                  name: editForm.name.trim(),
+                  email: editForm.email.trim() || undefined,
+                  phone: editForm.phone.trim() || undefined,
+                  address: editForm.address.trim() || undefined,
+                  paymentTerms: editForm.paymentTerms
+                    ? Number(editForm.paymentTerms)
+                    : undefined,
+                  wishlist: editForm.wishlist.trim() || undefined,
+                  tags: editForm.tags
+                    .split(",")
+                    .map(tag => tag.trim())
+                    .filter(Boolean),
+                  isBuyer: editForm.isBuyer,
+                  isSeller: editForm.isSeller,
+                  isBrand: editForm.isBrand,
+                  isReferee: editForm.isReferee,
+                  isContractor: editForm.isContractor,
+                })
+              }
+              disabled={updateClientMutation.isPending}
             >
-              <div className="space-y-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="edit-name">Client Name *</Label>
-                  <Input
-                    id="edit-name"
-                    name="name"
-                    defaultValue={client.name}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-email">Email</Label>
-                  <Input
-                    id="edit-email"
-                    name="email"
-                    type="email"
-                    defaultValue={client.email || ""}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-phone">Phone</Label>
-                  <Input
-                    id="edit-phone"
-                    name="phone"
-                    defaultValue={client.phone || ""}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="edit-address">Address</Label>
-                  <Textarea
-                    id="edit-address"
-                    name="address"
-                    defaultValue={client.address || ""}
-                    rows={3}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label>Client Types</Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="edit-isBuyer"
-                        name="isBuyer"
-                        checked={client.isBuyer || false}
-                      />
-                      <Label
-                        htmlFor="edit-isBuyer"
-                        className="font-normal cursor-pointer"
-                      >
-                        Buyer
-                      </Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="edit-isSeller"
-                        name="isSeller"
-                        checked={client.isSeller || false}
-                      />
-                      <Label
-                        htmlFor="edit-isSeller"
-                        className="font-normal cursor-pointer"
-                      >
-                        Supplier
-                      </Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="edit-isBrand"
-                        name="isBrand"
-                        checked={client.isBrand || false}
-                      />
-                      <Label
-                        htmlFor="edit-isBrand"
-                        className="font-normal cursor-pointer"
-                      >
-                        Brand
-                      </Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="edit-isReferee"
-                        name="isReferee"
-                        checked={client.isReferee || false}
-                      />
-                      <Label
-                        htmlFor="edit-isReferee"
-                        className="font-normal cursor-pointer"
-                      >
-                        Referee
-                      </Label>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="edit-isContractor"
-                        name="isContractor"
-                        checked={client.isContractor || false}
-                      />
-                      <Label
-                        htmlFor="edit-isContractor"
-                        className="font-normal cursor-pointer"
-                      >
-                        Contractor
-                      </Label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setEditDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={updateClientMutation.isPending}>
-                  {updateClientMutation.isPending
-                    ? "Saving..."
-                    : "Save Changes"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+              {updateClientMutation.isPending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-        {/* Add Transaction Dialog */}
-        <Dialog
-          open={transactionDialogOpen}
-          onOpenChange={setTransactionDialogOpen}
-        >
-          <DialogContent
-            className="w-full sm:max-w-2xl"
-            data-testid="transaction-form"
-          >
-            <DialogHeader>
-              <DialogTitle>Add Transaction</DialogTitle>
-              <DialogDescription>
-                Create a new transaction for {client.teriCode}
-              </DialogDescription>
-            </DialogHeader>
-            <form
-              onSubmit={e => {
-                e.preventDefault();
-                const formData = new FormData(e.currentTarget);
-                createTransactionMutation.mutate({
-                  clientId: client.id,
-                  transactionType: formData.get(
-                    "transactionType"
-                  ) as TransactionType,
-                  transactionNumber:
-                    (formData.get("transactionNumber") as string) || undefined,
-                  transactionDate: new Date(
-                    formData.get("transactionDate") as string
-                  ),
-                  amount: Number(formData.get("amount") as string),
-                  paymentStatus:
-                    (formData.get("paymentStatus") as
-                      | "PENDING"
-                      | "PAID"
-                      | "PARTIAL"
-                      | "OVERDUE") || "PENDING",
-                  notes: (formData.get("notes") as string) || undefined,
-                });
-              }}
+      <AddCommunicationModal
+        clientId={clientId}
+        open={communicationModalOpen}
+        onOpenChange={setCommunicationModalOpen}
+        onSuccess={() => {
+          void Promise.all([
+            activityQuery.refetch(),
+            utils.relationshipProfile.getActivity.invalidate({ clientId }),
+            utils.relationshipProfile.getShell.invalidate({ clientId }),
+          ]);
+        }}
+      />
+
+      <InspectorPanel
+        isOpen={inspectorOpen}
+        onClose={() => {
+          setSelectedTransaction(null);
+          setSelectedLedgerEntry(null);
+          setSelectedPayment(null);
+          setMoneyAction(null);
+        }}
+        title={
+          moneyAction
+            ? moneyAction === "receive"
+              ? "Receive Money"
+              : "Pay Money"
+            : selectedTransaction
+              ? `Edit ${selectedTransaction.transactionType}`
+              : selectedPayment
+                ? selectedPayment.paymentNumber ||
+                  `Payment #${selectedPayment.id}`
+                : selectedLedgerEntry?.label || "Ledger Entry"
+        }
+        subtitle={
+          moneyAction
+            ? "Quick ledger adjustment from the profile"
+            : selectedTransaction
+              ? "Editable legacy client transaction"
+              : selectedPayment
+                ? "Payment detail with source link"
+                : "Read-only source-linked ledger entry"
+        }
+        width={460}
+      >
+        {selectedTransaction ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="transaction-date">Transaction Date</Label>
+              <Input
+                id="transaction-date"
+                type="date"
+                value={transactionForm.transactionDate}
+                onChange={event =>
+                  setTransactionForm(current => ({
+                    ...current,
+                    transactionDate: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="transaction-amount">Amount</Label>
+              <Input
+                id="transaction-amount"
+                type="number"
+                value={transactionForm.amount}
+                onChange={event =>
+                  setTransactionForm(current => ({
+                    ...current,
+                    amount: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="transaction-status">Payment Status</Label>
+              <Input
+                id="transaction-status"
+                value={transactionForm.paymentStatus}
+                onChange={event =>
+                  setTransactionForm(current => ({
+                    ...current,
+                    paymentStatus: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="payment-date">Payment Date</Label>
+                <Input
+                  id="payment-date"
+                  type="date"
+                  value={transactionForm.paymentDate}
+                  onChange={event =>
+                    setTransactionForm(current => ({
+                      ...current,
+                      paymentDate: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="payment-amount">Payment Amount</Label>
+                <Input
+                  id="payment-amount"
+                  type="number"
+                  value={transactionForm.paymentAmount}
+                  onChange={event =>
+                    setTransactionForm(current => ({
+                      ...current,
+                      paymentAmount: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="transaction-notes">Notes</Label>
+              <Textarea
+                id="transaction-notes"
+                value={transactionForm.notes}
+                onChange={event =>
+                  setTransactionForm(current => ({
+                    ...current,
+                    notes: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={() =>
+                updateTransactionMutation.mutate({
+                  transactionId: selectedTransaction.id,
+                  transactionDate: transactionForm.transactionDate
+                    ? new Date(transactionForm.transactionDate)
+                    : undefined,
+                  amount: transactionForm.amount
+                    ? Number(transactionForm.amount)
+                    : undefined,
+                  paymentStatus: transactionForm.paymentStatus as
+                    | "PAID"
+                    | "PENDING"
+                    | "OVERDUE"
+                    | "PARTIAL",
+                  paymentDate: transactionForm.paymentDate
+                    ? new Date(transactionForm.paymentDate)
+                    : undefined,
+                  paymentAmount: transactionForm.paymentAmount
+                    ? Number(transactionForm.paymentAmount)
+                    : undefined,
+                  notes: transactionForm.notes.trim() || undefined,
+                })
+              }
+              disabled={updateTransactionMutation.isPending}
             >
-              <div className="space-y-4 py-4">
-                <div className="space-y-2">
-                  <Label htmlFor="transactionType">Transaction Type *</Label>
-                  <Select name="transactionType" required>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select type" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="INVOICE">Invoice</SelectItem>
-                      <SelectItem value="PAYMENT">Payment</SelectItem>
-                      <SelectItem value="QUOTE">Quote</SelectItem>
-                      <SelectItem value="ORDER">Order</SelectItem>
-                      <SelectItem value="REFUND">Refund</SelectItem>
-                      <SelectItem value="CREDIT">Credit</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="transactionNumber">Transaction Number</Label>
-                  <Input
-                    id="transactionNumber"
-                    name="transactionNumber"
-                    placeholder="e.g., INV-001"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="transactionDate">Transaction Date *</Label>
-                  <Input
-                    id="transactionDate"
-                    name="transactionDate"
-                    type="date"
-                    defaultValue={new Date().toISOString().split("T")[0]}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="amount">Amount *</Label>
-                  <Input
-                    id="amount"
-                    name="amount"
-                    type="number"
-                    step="0.01"
-                    placeholder="0.00"
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="paymentStatus">Payment Status</Label>
-                  <Select name="paymentStatus" defaultValue="PENDING">
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="PENDING">Pending</SelectItem>
-                      <SelectItem value="PAID">Paid</SelectItem>
-                      <SelectItem value="OVERDUE">Overdue</SelectItem>
-                      <SelectItem value="PARTIAL">Partial</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="notes">Notes</Label>
-                  <Textarea
-                    id="notes"
-                    name="notes"
-                    placeholder="Additional notes..."
-                    rows={3}
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setTransactionDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  type="submit"
-                  data-testid="save-transaction-btn"
-                  disabled={createTransactionMutation.isPending}
-                >
-                  {createTransactionMutation.isPending
-                    ? "Creating..."
-                    : "Create Transaction"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
+              {updateTransactionMutation.isPending
+                ? "Saving..."
+                : "Save Transaction"}
+            </Button>
+          </div>
+        ) : null}
 
-        {/* ST-026: Conflict dialog for concurrent edit detection */}
-        {ConflictDialogComponent}
-      </div>
-    </PageErrorBoundary>
+        {selectedLedgerEntry ? (
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="space-y-2 p-4 text-sm">
+                <p className="font-medium">{selectedLedgerEntry.label}</p>
+                <p className="text-muted-foreground">
+                  {selectedLedgerEntry.transactionType}
+                </p>
+                <p>Date: {formatDate(selectedLedgerEntry.date)}</p>
+                <p>Created by: {selectedLedgerEntry.actorName || "System"}</p>
+                <p>Net effect: {formatMoney(selectedLedgerEntry.netEffect)}</p>
+                {selectedLedgerEntry.description ? (
+                  <p className="text-muted-foreground">
+                    {selectedLedgerEntry.description}
+                  </p>
+                ) : null}
+              </CardContent>
+            </Card>
+            {sourcePathForLedgerEntry(selectedLedgerEntry) ? (
+              <Button
+                className="w-full"
+                variant="outline"
+                onClick={() => {
+                  const path = sourcePathForLedgerEntry(selectedLedgerEntry);
+                  if (path) {
+                    setLocation(path);
+                  }
+                }}
+              >
+                Open Source Record
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {selectedPayment ? (
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="space-y-2 p-4 text-sm">
+                <p className="font-medium">
+                  {selectedPayment.paymentNumber ||
+                    `Payment #${selectedPayment.id}`}
+                </p>
+                <p className="text-muted-foreground">
+                  {selectedPayment.paymentType}
+                </p>
+                <p>Date: {formatDate(selectedPayment.paymentDate)}</p>
+                <p>Method: {selectedPayment.paymentMethod || "-"}</p>
+                <p>Reference: {selectedPayment.referenceNumber || "-"}</p>
+                <p>Amount: {formatMoney(selectedPayment.amount)}</p>
+                <p>Created by: {selectedPayment.createdByName || "System"}</p>
+                {selectedPayment.notes ? (
+                  <p className="text-muted-foreground">
+                    {selectedPayment.notes}
+                  </p>
+                ) : null}
+              </CardContent>
+            </Card>
+            <Button
+              className="w-full"
+              variant="outline"
+              onClick={() =>
+                setLocation(`/accounting/payments?id=${selectedPayment.id}`)
+              }
+            >
+              Open Payment Record
+            </Button>
+          </div>
+        ) : null}
+
+        {moneyAction ? (
+          <div className="space-y-4">
+            <Card>
+              <CardContent className="space-y-2 p-4 text-sm text-muted-foreground">
+                <p>
+                  {moneyAction === "receive"
+                    ? "Use a credit entry to reduce what this relationship owes."
+                    : "Use a debit entry to reduce what you owe this relationship."}
+                </p>
+              </CardContent>
+            </Card>
+            <div className="space-y-2">
+              <Label htmlFor="adjustment-amount">Amount</Label>
+              <Input
+                id="adjustment-amount"
+                type="number"
+                value={adjustmentForm.amount}
+                onChange={event =>
+                  setAdjustmentForm(current => ({
+                    ...current,
+                    amount: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="adjustment-date">Effective Date</Label>
+              <Input
+                id="adjustment-date"
+                type="date"
+                value={adjustmentForm.effectiveDate}
+                onChange={event =>
+                  setAdjustmentForm(current => ({
+                    ...current,
+                    effectiveDate: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="adjustment-description">Description</Label>
+              <Textarea
+                id="adjustment-description"
+                value={adjustmentForm.description}
+                onChange={event =>
+                  setAdjustmentForm(current => ({
+                    ...current,
+                    description: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={() =>
+                addLedgerAdjustmentMutation.mutate({
+                  clientId,
+                  transactionType:
+                    moneyAction === "receive" ? "CREDIT" : "DEBIT",
+                  amount: Number(adjustmentForm.amount),
+                  description: adjustmentForm.description.trim(),
+                  effectiveDate: new Date(adjustmentForm.effectiveDate),
+                })
+              }
+              disabled={addLedgerAdjustmentMutation.isPending}
+            >
+              {addLedgerAdjustmentMutation.isPending
+                ? "Saving..."
+                : moneyAction === "receive"
+                  ? "Record Money Received"
+                  : "Record Money Paid"}
+            </Button>
+          </div>
+        ) : null}
+      </InspectorPanel>
+    </div>
   );
 }

--- a/client/src/pages/LeaderboardPage.tsx
+++ b/client/src/pages/LeaderboardPage.tsx
@@ -39,6 +39,7 @@ import {
   Settings2,
 } from "lucide-react";
 import { useLocation } from "wouter";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { ExportButton, WeightCustomizer } from "@/components/leaderboard";
 
 // Types
@@ -206,7 +207,7 @@ export const LeaderboardPage = React.memo(function LeaderboardPage() {
 
   const handleClientClick = useCallback(
     (clientId: number) => {
-      navigate(`/clients/${clientId}`);
+      navigate(buildRelationshipProfilePath(clientId));
     },
     [navigate]
   );

--- a/client/src/pages/MatchmakingServicePage.tsx
+++ b/client/src/pages/MatchmakingServicePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { trpc } from "@/lib/trpc";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -441,7 +442,12 @@ export default function MatchmakingServicePage({
                     key={need.id}
                     className="border rounded-lg p-3 hover:bg-accent cursor-pointer transition-colors"
                     onClick={() =>
-                      setLocation(`/clients/${need.clientId}?tab=needs`)
+                      setLocation(
+                        buildRelationshipProfilePath(
+                          need.clientId,
+                          "sales-pricing"
+                        )
+                      )
                     }
                   >
                     <div className="flex items-start justify-between mb-2">
@@ -678,7 +684,12 @@ export default function MatchmakingServicePage({
                   className="border rounded-lg p-3 hover:bg-accent cursor-pointer transition-colors"
                   onClick={() => {
                     setBuyersModalOpen(false);
-                    setLocation(`/clients/${buyer.clientId}?tab=needs`);
+                    setLocation(
+                      buildRelationshipProfilePath(
+                        buyer.clientId,
+                        "sales-pricing"
+                      )
+                    );
                   }}
                 >
                   <div className="flex items-center justify-between mb-1">

--- a/client/src/pages/NeedsManagementPage.tsx
+++ b/client/src/pages/NeedsManagementPage.tsx
@@ -31,6 +31,7 @@ import { BackButton } from "@/components/common/BackButton";
 import { useLocation } from "wouter";
 // UX-012: Import centralized date formatting utility
 import { formatDate } from "@/lib/utils";
+import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
 
 /**
  * Needs Management Page
@@ -75,10 +76,11 @@ interface OpportunityItem {
   potentialRevenue?: string | number;
 }
 
-const formatCurrencyValue = (value: string | number | undefined): string | null => {
+const formatCurrencyValue = (
+  value: string | number | undefined
+): string | null => {
   if (value === undefined || value === null) return null;
-  const parsed =
-    typeof value === "number" ? value : Number.parseFloat(value);
+  const parsed = typeof value === "number" ? value : Number.parseFloat(value);
   if (Number.isNaN(parsed)) return null;
   return parsed.toFixed(2);
 };
@@ -116,9 +118,9 @@ export default function NeedsManagementPage({
       limit: 10,
     });
 
-  const needs = ((needsData?.data ?? []) as unknown) as NeedItem[];
-  const opportunities =
-    ((opportunitiesData?.data ?? []) as unknown) as OpportunityItem[];
+  const needs = (needsData?.data ?? []) as unknown as NeedItem[];
+  const opportunities = (opportunitiesData?.data ??
+    []) as unknown as OpportunityItem[];
 
   // Filter needs based on search and priority
   const filteredNeeds = needs.filter(need => {
@@ -251,9 +253,7 @@ export default function NeedsManagementPage({
             <Select
               value={priorityFilter || "all"}
               onValueChange={v =>
-                setPriorityFilter(
-                  v === "all" ? undefined : (v as NeedPriority)
-                )
+                setPriorityFilter(v === "all" ? undefined : (v as NeedPriority))
               }
             >
               <SelectTrigger className="w-[180px]">
@@ -307,7 +307,12 @@ export default function NeedsManagementPage({
                   key={need.id}
                   className="hover:shadow-md transition-shadow cursor-pointer"
                   onClick={() =>
-                    setLocation(`/clients/${need.clientId}?tab=needs`)
+                    setLocation(
+                      buildRelationshipProfilePath(
+                        need.clientId,
+                        "sales-pricing"
+                      )
+                    )
                   }
                 >
                   <CardHeader>
@@ -397,7 +402,12 @@ export default function NeedsManagementPage({
                   key={`${opp.id ?? "opp"}-${opp.clientId}-${opp.needDescription}`}
                   className="hover:shadow-md transition-shadow cursor-pointer"
                   onClick={() =>
-                    setLocation(`/clients/${opp.clientId}?tab=needs`)
+                    setLocation(
+                      buildRelationshipProfilePath(
+                        opp.clientId,
+                        "sales-pricing"
+                      )
+                    )
                   }
                 >
                   <CardHeader>

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -41,7 +41,6 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { toast } from "sonner";
 import {
@@ -78,9 +77,10 @@ import { CreditLimitBanner } from "@/components/orders/CreditLimitBanner";
 import { CreditWarningDialog } from "@/components/orders/CreditWarningDialog";
 import { ReferredBySelector } from "@/components/orders/ReferredBySelector";
 import { ReferralCreditsPanel } from "@/components/orders/ReferralCreditsPanel";
-import { InventoryBrowser } from "@/components/sales/InventoryBrowser";
 import { CreditLimitWidget } from "@/components/credit/CreditLimitWidget";
 import { PricingConfigTab } from "@/components/pricing/PricingConfigTab";
+import { InventoryBrowser } from "@/components/sales/InventoryBrowser";
+import { ProfileQuickPanel } from "@/components/clients/ProfileQuickPanel";
 import { KeyboardHintBar } from "@/components/work-surface/KeyboardHintBar";
 import { WorkSurfaceStatusBar } from "@/components/work-surface/WorkSurfaceStatusBar";
 import {
@@ -117,7 +117,7 @@ interface InventoryItemForOrder {
   quantity?: number; // Available stock quantity
 }
 
-type CustomerDrawerSection = "credit" | "pricing";
+type CustomerDrawerSection = "money" | "sales-pricing";
 
 const orderValidationSchema = z.object({
   clientId: z.number().positive("Select a client"),
@@ -277,7 +277,7 @@ export default function OrderCreatorPageV2() {
   const [showFinalizeConfirm, setShowFinalizeConfirm] = useState(false);
   const [customerDrawerOpen, setCustomerDrawerOpen] = useState(false);
   const [customerDrawerSection, setCustomerDrawerSection] =
-    useState<CustomerDrawerSection>("credit");
+    useState<CustomerDrawerSection>("money");
   const customerDrawerOriginRef = useRef<HTMLElement | null>(null);
 
   // CHAOS-007: Unsaved changes warning
@@ -402,8 +402,17 @@ export default function OrderCreatorPageV2() {
     }
 
     const drawerSection = searchParams.get("customerDrawer");
-    if (drawerSection === "credit" || drawerSection === "pricing") {
-      setCustomerDrawerSection(drawerSection);
+    if (
+      drawerSection === "credit" ||
+      drawerSection === "pricing" ||
+      drawerSection === "money" ||
+      drawerSection === "sales-pricing"
+    ) {
+      setCustomerDrawerSection(
+        drawerSection === "credit" || drawerSection === "money"
+          ? "money"
+          : "sales-pricing"
+      );
       setCustomerDrawerOpen(true);
     }
   }, [clientId, searchParams]);
@@ -722,63 +731,6 @@ export default function OrderCreatorPageV2() {
     },
     [closeCustomerDrawer, refetchClientDetails]
   );
-
-  const refreshProfilePricingInOrder = useCallback(async () => {
-    const refreshedInventory = await inventoryQuery.refetch();
-    const latestInventory =
-      (refreshedInventory.data as InventoryItemForOrder[] | undefined) ??
-      (inventory as InventoryItemForOrder[] | undefined) ??
-      [];
-
-    if (latestInventory.length === 0) {
-      return;
-    }
-
-    setItems(currentItems =>
-      currentItems.map(item => {
-        if (item.marginSource === "MANUAL" || item.isMarginOverridden) {
-          return item;
-        }
-
-        const profilePricing = latestInventory.find(
-          inv => inv.id === item.batchId
-        );
-        if (!profilePricing) {
-          return item;
-        }
-
-        const cogsPerUnit = item.cogsPerUnit;
-        const retailPrice =
-          profilePricing.retailPrice ?? profilePricing.basePrice ?? cogsPerUnit;
-        const marginPercent =
-          cogsPerUnit > 0
-            ? ((retailPrice - cogsPerUnit) / cogsPerUnit) * 100
-            : 0;
-        const recalculated = calculateLineItem(
-          item.batchId,
-          item.quantity,
-          cogsPerUnit,
-          marginPercent
-        );
-
-        return {
-          ...item,
-          ...recalculated,
-          marginPercent,
-          marginSource: "CUSTOMER_PROFILE",
-          isMarginOverridden: false,
-        };
-      })
-    );
-  }, [inventory, inventoryQuery]);
-
-  const handlePricingProfileApplied = useCallback(() => {
-    void (async () => {
-      await refreshProfilePricingInOrder();
-      await refetchClientDetails();
-      closeCustomerDrawer();
-    })();
-  }, [closeCustomerDrawer, refreshProfilePricingInOrder, refetchClientDetails]);
 
   // Calculations
   const { totals, warnings, isValid } = useOrderCalculations(items, adjustment);
@@ -1506,7 +1458,7 @@ export default function OrderCreatorPageV2() {
                           size="sm"
                           className="justify-start"
                           onClick={event =>
-                            openCustomerDrawer("credit", event.currentTarget)
+                            openCustomerDrawer("money", event.currentTarget)
                           }
                         >
                           Credit Limit
@@ -1517,7 +1469,10 @@ export default function OrderCreatorPageV2() {
                           size="sm"
                           className="justify-start"
                           onClick={event =>
-                            openCustomerDrawer("pricing", event.currentTarget)
+                            openCustomerDrawer(
+                              "sales-pricing",
+                              event.currentTarget
+                            )
                           }
                           disabled={!canEditPricing}
                         >
@@ -1773,50 +1728,42 @@ export default function OrderCreatorPageV2() {
         >
           <DrawerContent className="w-[760px] sm:max-w-none">
             <DrawerHeader>
-              <DrawerTitle>Customer Controls</DrawerTitle>
+              <DrawerTitle>Relationship Profile</DrawerTitle>
               <DrawerDescription>
-                Credit and pricing configuration uses a shared right-drawer
-                contract. Successful saves return focus to the source control.
+                Shared profile drawer for money, pricing, and open relationship
+                context. Successful closes return focus to the source control.
               </DrawerDescription>
             </DrawerHeader>
-            <div className="px-4 pb-4 overflow-y-auto">
-              <Tabs
-                value={customerDrawerSection}
-                onValueChange={value =>
-                  setCustomerDrawerSection(value as CustomerDrawerSection)
-                }
-                className="space-y-4"
-              >
-                <TabsList className="grid w-full grid-cols-2">
-                  <TabsTrigger value="credit">Credit Limit</TabsTrigger>
-                  <TabsTrigger value="pricing" disabled={!canEditPricing}>
-                    Pricing Profile
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="credit" className="space-y-4">
-                  {clientId ? (
+            <div className="overflow-y-auto px-4 pb-4">
+              {clientId ? (
+                <div className="space-y-4">
+                  <ProfileQuickPanel
+                    clientId={clientId}
+                    initialSection={customerDrawerSection}
+                    onClose={closeCustomerDrawer}
+                  />
+                  {customerDrawerSection === "money" ? (
                     <CreditLimitWidget
                       clientId={clientId}
-                      showAdjustControls={true}
                       defaultExpanded={true}
                     />
                   ) : null}
-                </TabsContent>
-                <TabsContent value="pricing" className="space-y-4">
-                  {clientId && canEditPricing ? (
+                  {customerDrawerSection === "sales-pricing" ? (
                     <PricingConfigTab
                       clientId={clientId}
-                      onProfileApplied={handlePricingProfileApplied}
+                      onProfileApplied={() => {
+                        void refetchClientDetails();
+                      }}
                     />
-                  ) : (
-                    <Card>
-                      <CardContent className="py-8 text-sm text-muted-foreground">
-                        You do not have permission to edit pricing profiles.
-                      </CardContent>
-                    </Card>
-                  )}
-                </TabsContent>
-              </Tabs>
+                  ) : null}
+                </div>
+              ) : (
+                <Card>
+                  <CardContent className="py-8 text-sm text-muted-foreground">
+                    Select a customer to open profile controls.
+                  </CardContent>
+                </Card>
+              )}
             </div>
           </DrawerContent>
         </Drawer>

--- a/client/src/pages/SearchResultsPage.tsx
+++ b/client/src/pages/SearchResultsPage.tsx
@@ -94,7 +94,7 @@ export default function SearchResultsPage() {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
                 type="search"
-                placeholder="Search quotes, customers, products..."
+                placeholder="Search quotes, relationships, products..."
                 className="pl-10 w-full"
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
@@ -124,7 +124,8 @@ export default function SearchResultsPage() {
           {!searchQuery.trim() && !isLoading && (
             <div className="text-center py-12 text-muted-foreground">
               <p>
-                Enter a search query to find quotes, customers, and products.
+                Enter a search query to find quotes, relationships, and
+                products.
               </p>
             </div>
           )}
@@ -188,13 +189,13 @@ export default function SearchResultsPage() {
                 </div>
               )}
 
-              {/* Customers Section - BUG-042 FIX: Use onClick handler for reliable navigation */}
+              {/* Relationships Section - BUG-042 FIX: Use onClick handler for reliable navigation */}
               {results.customers.length > 0 && (
                 <div>
                   <div className="flex items-center gap-2 mb-4">
                     <Users className="h-5 w-5" />
                     <h2 className="text-xl font-semibold">
-                      Customers ({results.customers.length})
+                      Relationships ({results.customers.length})
                     </h2>
                   </div>
                   <div className="space-y-2">
@@ -215,7 +216,16 @@ export default function SearchResultsPage() {
                                   <h3 className="font-medium">
                                     {customer.title}
                                   </h3>
-                                  <Badge variant="outline">Customer</Badge>
+                                  <Badge variant="outline">
+                                    {String(
+                                      (
+                                        customer.metadata as Record<
+                                          string,
+                                          unknown
+                                        >
+                                      )?.relationshipLabel || "Customer"
+                                    )}
+                                  </Badge>
                                 </div>
                                 {customer.description && (
                                   <p className="text-sm text-muted-foreground">

--- a/client/src/types/relationshipProfile.ts
+++ b/client/src/types/relationshipProfile.ts
@@ -1,0 +1,15 @@
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "../../../server/routers";
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+export type RelationshipProfileShellData =
+  RouterOutputs["relationshipProfile"]["getShell"];
+export type RelationshipProfileSalesPricingData =
+  RouterOutputs["relationshipProfile"]["getSalesPricing"];
+export type RelationshipProfileMoneyData =
+  RouterOutputs["relationshipProfile"]["getMoney"];
+export type RelationshipProfileSupplyInventoryData =
+  RouterOutputs["relationshipProfile"]["getSupplyInventory"];
+export type RelationshipProfileActivityData =
+  RouterOutputs["relationshipProfile"]["getActivity"];

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -109,6 +109,7 @@ import { cashAuditRouter } from "./routers/cashAudit";
 import { vendorPayablesRouter } from "./routers/vendorPayables"; // MEET-005: Payables Due When SKU Hits Zero
 import { schedulingRouter } from "./routers/scheduling"; // Sprint 4 Track D: Scheduling System
 import { client360Router } from "./routers/client360"; // Sprint 4 Track B: Client 360 View
+import { relationshipProfileRouter } from "./routers/relationshipProfile";
 import { clientWantsRouter } from "./routers/clientWants"; // Sprint 4 Track B: Client Wants/Needs (MEET-021)
 import { officeSupplyRouter } from "./routers/officeSupply"; // Sprint 4 Track B: Office Supply (MEET-055)
 import { storageRouter } from "./routers/storage"; // Sprint 5 Track E: Storage & Location (MEET-067, MEET-068)
@@ -255,6 +256,7 @@ export const appRouter = router({
   vendorPayables: vendorPayablesRouter, // MEET-005: Payables Due When SKU Hits Zero
   scheduling: schedulingRouter, // Sprint 4 Track D: Scheduling System (FEAT-005-BE, MEET-046, MEET-047, MEET-050, MEET-034)
   client360: client360Router, // Sprint 4 Track B: Client 360 View (ENH-002, MEET-007, MEET-012, MEET-013, MEET-020, MEET-021, MEET-022, WS-011)
+  relationshipProfile: relationshipProfileRouter,
   clientWants: clientWantsRouter, // Sprint 4 Track B: Client Wants/Needs Tracking (MEET-021)
   officeSupply: officeSupplyRouter, // Sprint 4 Track B: Office Supply Needs (MEET-055)
   storage: storageRouter, // Sprint 5 Track E: Storage & Location (MEET-067, MEET-068)

--- a/server/routers/relationshipProfile.ts
+++ b/server/routers/relationshipProfile.ts
@@ -1,0 +1,1111 @@
+import { TRPCError } from "@trpc/server";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+import {
+  batches,
+  clientActivity,
+  clientCommunications,
+  clientCreditLimits,
+  clientLedgerAdjustments,
+  clientNeeds,
+  clientTransactions,
+  clients,
+  orders,
+  payments,
+  products,
+  purchaseOrders,
+  salesSheetHistory,
+  supplierProfiles,
+  users,
+  vendorPayables,
+  lots,
+} from "../../drizzle/schema";
+import { getDb } from "../db";
+import * as inventoryDb from "../inventoryDb";
+import * as pricingEngine from "../pricingEngine";
+import * as salesSheetsDb from "../salesSheetsDb";
+import * as vendorContextDb from "../vendorContextDb";
+import { requirePermission } from "../_core/permissionMiddleware";
+import {
+  getAuthenticatedUserId,
+  protectedProcedure,
+  router,
+} from "../_core/trpc";
+import { getClientBalanceDetails } from "../services/clientBalanceService";
+
+const clientIdSchema = z.object({
+  clientId: z.number().int().positive(),
+});
+
+const parseMoney = (value: unknown): number => {
+  if (value === null || value === undefined) return 0;
+  const parsed =
+    typeof value === "number"
+      ? value
+      : Number.parseFloat(String(value).replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const normalizeDate = (
+  value: Date | string | null | undefined
+): string | null => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+};
+
+const formatRoleLabel = (client: {
+  isBuyer?: boolean | null;
+  isSeller?: boolean | null;
+  isBrand?: boolean | null;
+  isReferee?: boolean | null;
+  isContractor?: boolean | null;
+}) => {
+  const labels: string[] = [];
+  if (client.isBuyer) labels.push("Customer");
+  if (client.isSeller) labels.push("Supplier");
+  if (client.isBrand) labels.push("Brand");
+  if (client.isReferee) labels.push("Referee");
+  if (client.isContractor) labels.push("Contractor");
+  return labels;
+};
+
+type LedgerEntry = {
+  id: string;
+  sourceType: "ORDER" | "PURCHASE_ORDER" | "PAYMENT" | "ADJUSTMENT";
+  sourceId: number;
+  date: string | null;
+  label: string;
+  transactionType:
+    | "SALE"
+    | "PURCHASE"
+    | "PAYMENT_RECEIVED"
+    | "PAYMENT_SENT"
+    | "CREDIT"
+    | "DEBIT";
+  debitAmount: number;
+  creditAmount: number;
+  netEffect: number;
+  actorName: string | null;
+  description: string | null;
+};
+
+type RelationshipMoneyMode = "customer" | "supplier" | "hybrid" | "neutral";
+
+type VendorPayablesSummary = {
+  totalAmount: number;
+  amountPaid: number;
+  amountDue: number;
+  payableCount: number;
+  openPayableCount: number;
+};
+
+function getRelationshipMoneyMode(client: {
+  isBuyer?: boolean | null;
+  isSeller?: boolean | null;
+}): RelationshipMoneyMode {
+  if (client.isBuyer && client.isSeller) {
+    return "hybrid";
+  }
+
+  if (client.isSeller) {
+    return "supplier";
+  }
+
+  if (client.isBuyer) {
+    return "customer";
+  }
+
+  return "neutral";
+}
+
+async function getVendorPayablesSummary(
+  db: NonNullable<Awaited<ReturnType<typeof getDb>>>,
+  clientId: number
+): Promise<VendorPayablesSummary> {
+  const [row] = await db
+    .select({
+      totalAmount: sql<number>`COALESCE(SUM(CAST(${vendorPayables.totalAmount} AS DECIMAL(15,2))), 0)`,
+      amountPaid: sql<number>`COALESCE(SUM(CAST(${vendorPayables.amountPaid} AS DECIMAL(15,2))), 0)`,
+      amountDue: sql<number>`COALESCE(SUM(CAST(${vendorPayables.amountDue} AS DECIMAL(15,2))), 0)`,
+      payableCount: sql<number>`COUNT(*)`,
+      openPayableCount: sql<number>`SUM(CASE WHEN ${vendorPayables.status} IN ('PENDING', 'DUE', 'PARTIAL') AND CAST(${vendorPayables.amountDue} AS DECIMAL(15,2)) > 0 THEN 1 ELSE 0 END)`,
+    })
+    .from(vendorPayables)
+    .where(
+      and(
+        eq(vendorPayables.vendorClientId, clientId),
+        isNull(vendorPayables.deletedAt),
+        sql`${vendorPayables.status} != 'VOID'`
+      )
+    );
+
+  return {
+    totalAmount: Number(row?.totalAmount || 0),
+    amountPaid: Number(row?.amountPaid || 0),
+    amountDue: Number(row?.amountDue || 0),
+    payableCount: Number(row?.payableCount || 0),
+    openPayableCount: Number(row?.openPayableCount || 0),
+  };
+}
+
+async function getClientOrThrow(clientId: number) {
+  const db = await getDb();
+  if (!db) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Database not available",
+    });
+  }
+
+  const [client] = await db
+    .select({
+      id: clients.id,
+      teriCode: clients.teriCode,
+      name: clients.name,
+      email: clients.email,
+      phone: clients.phone,
+      address: clients.address,
+      businessType: clients.businessType,
+      preferredContact: clients.preferredContact,
+      paymentTerms: clients.paymentTerms,
+      isBuyer: clients.isBuyer,
+      isSeller: clients.isSeller,
+      isBrand: clients.isBrand,
+      isReferee: clients.isReferee,
+      isContractor: clients.isContractor,
+      tags: clients.tags,
+      pricingProfileId: clients.pricingProfileId,
+      totalSpent: clients.totalSpent,
+      totalProfit: clients.totalProfit,
+      avgProfitMargin: clients.avgProfitMargin,
+      totalOwed: clients.totalOwed,
+      oldestDebtDays: clients.oldestDebtDays,
+      creditLimit: clients.creditLimit,
+      creditLimitSource: clients.creditLimitSource,
+      creditLimitUpdatedAt: clients.creditLimitUpdatedAt,
+      creditLimitOverrideReason: clients.creditLimitOverrideReason,
+      vipPortalEnabled: clients.vipPortalEnabled,
+      vipPortalLastLogin: clients.vipPortalLastLogin,
+      wishlist: clients.wishlist,
+      referredByClientId: clients.referredByClientId,
+      createdAt: clients.createdAt,
+      updatedAt: clients.updatedAt,
+    })
+    .from(clients)
+    .where(and(eq(clients.id, clientId), isNull(clients.deletedAt)))
+    .limit(1);
+
+  if (!client) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+  }
+
+  return { client, db };
+}
+
+async function buildLedgerPreview(clientId: number): Promise<{
+  entries: LedgerEntry[];
+  totals: { debits: number; credits: number; netBalance: number };
+}> {
+  const db = await getDb();
+  if (!db) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Database not available",
+    });
+  }
+
+  const [salesRows, purchaseRows, paymentRows, adjustmentRows] =
+    await Promise.all([
+      db
+        .select({
+          id: orders.id,
+          orderNumber: orders.orderNumber,
+          total: orders.total,
+          confirmedAt: orders.confirmedAt,
+          createdAt: orders.createdAt,
+          createdByName: users.name,
+          notes: orders.notes,
+        })
+        .from(orders)
+        .leftJoin(users, eq(orders.createdBy, users.id))
+        .where(
+          and(
+            eq(orders.clientId, clientId),
+            eq(orders.orderType, "SALE"),
+            isNull(orders.deletedAt),
+            sql`(${orders.saleStatus} IS NULL OR ${orders.saleStatus} != 'CANCELLED')`
+          )
+        ),
+      db
+        .select({
+          id: purchaseOrders.id,
+          poNumber: purchaseOrders.poNumber,
+          total: purchaseOrders.total,
+          confirmedAt: purchaseOrders.confirmedAt,
+          createdAt: purchaseOrders.createdAt,
+          createdByName: users.name,
+          notes: purchaseOrders.notes,
+        })
+        .from(purchaseOrders)
+        .leftJoin(users, eq(purchaseOrders.createdBy, users.id))
+        .where(
+          and(
+            eq(purchaseOrders.supplierClientId, clientId),
+            isNull(purchaseOrders.deletedAt),
+            sql`${purchaseOrders.purchaseOrderStatus} IN ('CONFIRMED', 'RECEIVING', 'RECEIVED')`
+          )
+        ),
+      db
+        .select({
+          id: payments.id,
+          paymentNumber: payments.paymentNumber,
+          amount: payments.amount,
+          paymentType: payments.paymentType,
+          paymentDate: payments.paymentDate,
+          createdByName: users.name,
+          notes: payments.notes,
+        })
+        .from(payments)
+        .leftJoin(users, eq(payments.createdBy, users.id))
+        .where(
+          and(
+            isNull(payments.deletedAt),
+            sql`(${payments.customerId} = ${clientId} OR ${payments.vendorId} = ${clientId})`
+          )
+        ),
+      db
+        .select({
+          id: clientLedgerAdjustments.id,
+          transactionType: clientLedgerAdjustments.transactionType,
+          amount: clientLedgerAdjustments.amount,
+          effectiveDate: clientLedgerAdjustments.effectiveDate,
+          description: clientLedgerAdjustments.description,
+          createdByName: users.name,
+        })
+        .from(clientLedgerAdjustments)
+        .leftJoin(users, eq(clientLedgerAdjustments.createdBy, users.id))
+        .where(eq(clientLedgerAdjustments.clientId, clientId)),
+    ]);
+
+  const entries: LedgerEntry[] = [
+    ...salesRows.map(row => ({
+      id: `ORDER:${row.id}`,
+      sourceType: "ORDER" as const,
+      sourceId: row.id,
+      date: normalizeDate(row.confirmedAt ?? row.createdAt),
+      label: row.orderNumber ? `Sale ${row.orderNumber}` : `Sale #${row.id}`,
+      transactionType: "SALE" as const,
+      debitAmount: parseMoney(row.total),
+      creditAmount: 0,
+      netEffect: parseMoney(row.total),
+      actorName: row.createdByName ?? "System",
+      description: row.notes,
+    })),
+    ...purchaseRows.map(row => ({
+      id: `PURCHASE_ORDER:${row.id}`,
+      sourceType: "PURCHASE_ORDER" as const,
+      sourceId: row.id,
+      date: normalizeDate(row.confirmedAt ?? row.createdAt),
+      label: row.poNumber ? `PO ${row.poNumber}` : `PO #${row.id}`,
+      transactionType: "PURCHASE" as const,
+      debitAmount: 0,
+      creditAmount: parseMoney(row.total),
+      netEffect: -parseMoney(row.total),
+      actorName: row.createdByName ?? "System",
+      description: row.notes,
+    })),
+    ...paymentRows.map(row => {
+      const amount = parseMoney(row.amount);
+      const received = row.paymentType === "RECEIVED";
+      return {
+        id: `PAYMENT:${row.id}`,
+        sourceType: "PAYMENT" as const,
+        sourceId: row.id,
+        date: normalizeDate(row.paymentDate),
+        label: row.paymentNumber
+          ? `Payment ${row.paymentNumber}`
+          : `Payment #${row.id}`,
+        transactionType: received
+          ? ("PAYMENT_RECEIVED" as const)
+          : ("PAYMENT_SENT" as const),
+        debitAmount: received ? 0 : amount,
+        creditAmount: received ? amount : 0,
+        netEffect: received ? -amount : amount,
+        actorName: row.createdByName ?? "System",
+        description: row.notes,
+      };
+    }),
+    ...adjustmentRows.map(row => {
+      const amount = parseMoney(row.amount);
+      const credit = row.transactionType === "CREDIT";
+      return {
+        id: `ADJUSTMENT:${row.id}`,
+        sourceType: "ADJUSTMENT" as const,
+        sourceId: row.id,
+        date: normalizeDate(row.effectiveDate),
+        label: credit ? "Manual credit" : "Manual debit",
+        transactionType: row.transactionType,
+        debitAmount: credit ? 0 : amount,
+        creditAmount: credit ? amount : 0,
+        netEffect: credit ? -amount : amount,
+        actorName: row.createdByName ?? "System",
+        description: row.description,
+      };
+    }),
+  ].sort((a, b) => {
+    const aTime = a.date ? new Date(a.date).getTime() : 0;
+    const bTime = b.date ? new Date(b.date).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return {
+    entries,
+    totals: {
+      debits: entries.reduce((sum, entry) => sum + entry.debitAmount, 0),
+      credits: entries.reduce((sum, entry) => sum + entry.creditAmount, 0),
+      netBalance: entries.reduce((sum, entry) => sum + entry.netEffect, 0),
+    },
+  };
+}
+
+export const relationshipProfileRouter = router({
+  getShell: protectedProcedure
+    .use(requirePermission("clients:read"))
+    .input(clientIdSchema)
+    .query(async ({ ctx, input }) => {
+      const userId = getAuthenticatedUserId(ctx);
+      const { client, db } = await getClientOrThrow(input.clientId);
+      const [
+        referrer,
+        supplierProfile,
+        balance,
+        payables,
+        recentCommunication,
+        recentActivity,
+        transactionStats,
+        draftStats,
+        salesSheetStats,
+        orderStats,
+        needsStats,
+        paymentStats,
+      ] = await Promise.all([
+        client.referredByClientId
+          ? db
+              .select({
+                id: clients.id,
+                name: clients.name,
+                teriCode: clients.teriCode,
+              })
+              .from(clients)
+              .where(eq(clients.id, client.referredByClientId))
+              .limit(1)
+          : Promise.resolve([]),
+        db
+          .select({
+            contactName: supplierProfiles.contactName,
+            contactEmail: supplierProfiles.contactEmail,
+            contactPhone: supplierProfiles.contactPhone,
+            paymentTerms: supplierProfiles.paymentTerms,
+            preferredPaymentMethod: supplierProfiles.preferredPaymentMethod,
+            supplierNotes: supplierProfiles.supplierNotes,
+            licenseNumber: supplierProfiles.licenseNumber,
+            taxId: supplierProfiles.taxId,
+          })
+          .from(supplierProfiles)
+          .where(eq(supplierProfiles.clientId, input.clientId))
+          .limit(1),
+        getClientBalanceDetails(input.clientId),
+        getVendorPayablesSummary(db, input.clientId),
+        db
+          .select({
+            id: clientCommunications.id,
+            communicationType: clientCommunications.communicationType,
+            subject: clientCommunications.subject,
+            communicatedAt: clientCommunications.communicatedAt,
+          })
+          .from(clientCommunications)
+          .where(eq(clientCommunications.clientId, input.clientId))
+          .orderBy(desc(clientCommunications.communicatedAt))
+          .limit(1),
+        db
+          .select({
+            id: clientActivity.id,
+            activityType: clientActivity.activityType,
+            createdAt: clientActivity.createdAt,
+          })
+          .from(clientActivity)
+          .where(eq(clientActivity.clientId, input.clientId))
+          .orderBy(desc(clientActivity.createdAt))
+          .limit(1),
+        db
+          .select({
+            totalTransactions: sql<number>`COUNT(*)`,
+            overdueTransactions: sql<number>`SUM(CASE WHEN ${clientTransactions.paymentStatus} = 'OVERDUE' THEN 1 ELSE 0 END)`,
+          })
+          .from(clientTransactions)
+          .where(eq(clientTransactions.clientId, input.clientId)),
+        salesSheetsDb.getDrafts(userId, input.clientId),
+        db
+          .select({
+            sentSalesSheets: sql<number>`COUNT(*)`,
+          })
+          .from(salesSheetHistory)
+          .where(
+            and(
+              eq(salesSheetHistory.clientId, input.clientId),
+              isNull(salesSheetHistory.deletedAt)
+            )
+          ),
+        db
+          .select({
+            openOrderDrafts: sql<number>`SUM(CASE WHEN ${orders.isDraft} = 1 THEN 1 ELSE 0 END)`,
+            openQuotes: sql<number>`SUM(CASE WHEN ${orders.orderType} = 'QUOTE' AND ${orders.isDraft} = 0 AND ${orders.quoteStatus} IN ('UNSENT', 'SENT', 'VIEWED') THEN 1 ELSE 0 END)`,
+            totalOrders: sql<number>`SUM(CASE WHEN ${orders.orderType} = 'SALE' AND ${orders.isDraft} = 0 THEN 1 ELSE 0 END)`,
+          })
+          .from(orders)
+          .where(
+            and(eq(orders.clientId, input.clientId), isNull(orders.deletedAt))
+          ),
+        db
+          .select({
+            activeNeeds: sql<number>`SUM(CASE WHEN ${clientNeeds.status} = 'ACTIVE' THEN 1 ELSE 0 END)`,
+          })
+          .from(clientNeeds)
+          .where(eq(clientNeeds.clientId, input.clientId)),
+        db
+          .select({
+            receivedCount: sql<number>`SUM(CASE WHEN ${payments.customerId} = ${input.clientId} AND ${payments.paymentType} = 'RECEIVED' THEN 1 ELSE 0 END)`,
+            sentCount: sql<number>`SUM(CASE WHEN ${payments.vendorId} = ${input.clientId} AND ${payments.paymentType} = 'SENT' THEN 1 ELSE 0 END)`,
+          })
+          .from(payments)
+          .where(
+            and(
+              isNull(payments.deletedAt),
+              sql`(${payments.customerId} = ${input.clientId} OR ${payments.vendorId} = ${input.clientId})`
+            )
+          ),
+      ]);
+
+      const lastTouchCandidates = [
+        normalizeDate(client.updatedAt),
+        normalizeDate(recentCommunication[0]?.communicatedAt),
+        normalizeDate(recentActivity[0]?.createdAt),
+      ].filter((value): value is string => Boolean(value));
+
+      const lastTouchAt =
+        lastTouchCandidates.sort(
+          (a, b) => new Date(b).getTime() - new Date(a).getTime()
+        )[0] ?? null;
+
+      const alerts: Array<{
+        tone: "warning" | "info";
+        label: string;
+        detail: string;
+      }> = [];
+      const moneyMode = getRelationshipMoneyMode(client);
+
+      if (
+        (moneyMode === "customer" || moneyMode === "hybrid") &&
+        balance.computedBalance > parseMoney(client.creditLimit)
+      ) {
+        alerts.push({
+          tone: "warning",
+          label: "Credit exposure",
+          detail:
+            "Current receivable balance is above the stored credit limit.",
+        });
+      }
+
+      if (Number(transactionStats[0]?.overdueTransactions || 0) > 0) {
+        alerts.push({
+          tone: "warning",
+          label: "Overdue transactions",
+          detail: `${Number(transactionStats[0]?.overdueTransactions || 0)} legacy transactions are marked overdue.`,
+        });
+      }
+
+      if (client.isSeller && !supplierProfile[0]) {
+        alerts.push({
+          tone: "info",
+          label: "Supplier details missing",
+          detail:
+            "This supplier does not yet have a populated supplier profile.",
+        });
+      }
+
+      if (
+        (moneyMode === "supplier" || moneyMode === "hybrid") &&
+        payables.amountDue > 0
+      ) {
+        alerts.push({
+          tone: "info",
+          label: "Outstanding supplier payables",
+          detail: `${payables.openPayableCount} supplier payable${payables.openPayableCount === 1 ? "" : "s"} remain open for $${payables.amountDue.toFixed(2)}.`,
+        });
+      }
+
+      return {
+        id: client.id,
+        name: client.name,
+        teriCode: client.teriCode,
+        roles: formatRoleLabel(client),
+        businessType: client.businessType,
+        preferredContact: client.preferredContact,
+        email: client.email,
+        phone: client.phone,
+        address: client.address,
+        paymentTermsDays: client.paymentTerms,
+        tags: client.tags ?? [],
+        vipPortalEnabled: Boolean(client.vipPortalEnabled),
+        vipPortalLastLogin: normalizeDate(client.vipPortalLastLogin),
+        liveCatalogEnabled: Boolean(client.vipPortalEnabled),
+        wishlist: client.wishlist,
+        referrer: referrer[0] ?? null,
+        supplierProfile: supplierProfile[0] ?? null,
+        financials: {
+          lifetimeValue: parseMoney(client.totalSpent),
+          profitability: parseMoney(client.totalProfit),
+          averageMarginPercent: parseMoney(client.avgProfitMargin),
+          creditLimit: parseMoney(client.creditLimit),
+          balance,
+          moneySummary: {
+            mode: moneyMode,
+            receivable: balance,
+            payable: payables,
+            netPosition: balance.computedBalance - payables.amountDue,
+          },
+        },
+        openArtifacts: {
+          salesSheetDrafts: draftStats.length,
+          sentSalesSheets: Number(salesSheetStats[0]?.sentSalesSheets || 0),
+          orderDrafts: Number(orderStats[0]?.openOrderDrafts || 0),
+          openQuotes: Number(orderStats[0]?.openQuotes || 0),
+          activeNeeds: Number(needsStats[0]?.activeNeeds || 0),
+        },
+        metrics: {
+          totalTransactions: Number(
+            transactionStats[0]?.totalTransactions || 0
+          ),
+          totalOrders: Number(orderStats[0]?.totalOrders || 0),
+          receivedPayments: Number(paymentStats[0]?.receivedCount || 0),
+          sentPayments: Number(paymentStats[0]?.sentCount || 0),
+        },
+        lastTouchAt,
+        alerts,
+        createdAt: normalizeDate(client.createdAt),
+        updatedAt: normalizeDate(client.updatedAt),
+      };
+    }),
+
+  getSalesPricing: protectedProcedure
+    .use(requirePermission("clients:read"))
+    .input(clientIdSchema)
+    .query(async ({ ctx, input }) => {
+      const userId = getAuthenticatedUserId(ctx);
+      const { client, db } = await getClientOrThrow(input.clientId);
+
+      const [
+        profile,
+        rules,
+        profiles,
+        salesSheetHistoryRows,
+        draftRows,
+        orderDraftRows,
+        needsRows,
+      ] = await Promise.all([
+        client.pricingProfileId
+          ? pricingEngine.getPricingProfileById(client.pricingProfileId)
+          : Promise.resolve(null),
+        pricingEngine.getClientPricingRules(input.clientId),
+        pricingEngine.getPricingProfiles(),
+        db
+          .select({
+            id: salesSheetHistory.id,
+            totalValue: salesSheetHistory.totalValue,
+            itemCount: salesSheetHistory.itemCount,
+            createdAt: salesSheetHistory.createdAt,
+            shareToken: salesSheetHistory.shareToken,
+            convertedToOrderId: salesSheetHistory.convertedToOrderId,
+          })
+          .from(salesSheetHistory)
+          .where(
+            and(
+              eq(salesSheetHistory.clientId, input.clientId),
+              isNull(salesSheetHistory.deletedAt)
+            )
+          )
+          .orderBy(desc(salesSheetHistory.createdAt))
+          .limit(12),
+        salesSheetsDb.getDrafts(userId, input.clientId),
+        db
+          .select({
+            id: orders.id,
+            orderNumber: orders.orderNumber,
+            orderType: orders.orderType,
+            total: orders.total,
+            quoteStatus: orders.quoteStatus,
+            createdAt: orders.createdAt,
+            updatedAt: orders.updatedAt,
+          })
+          .from(orders)
+          .where(
+            and(
+              eq(orders.clientId, input.clientId),
+              eq(orders.isDraft, true),
+              isNull(orders.deletedAt)
+            )
+          )
+          .orderBy(desc(orders.updatedAt), desc(orders.createdAt))
+          .limit(12),
+        db
+          .select({
+            id: clientNeeds.id,
+            strain: clientNeeds.strain,
+            productName: clientNeeds.productName,
+            category: clientNeeds.category,
+            subcategory: clientNeeds.subcategory,
+            grade: clientNeeds.grade,
+            quantityMin: clientNeeds.quantityMin,
+            quantityMax: clientNeeds.quantityMax,
+            priceMax: clientNeeds.priceMax,
+            priority: clientNeeds.priority,
+            status: clientNeeds.status,
+            neededBy: clientNeeds.neededBy,
+            updatedAt: clientNeeds.updatedAt,
+          })
+          .from(clientNeeds)
+          .where(eq(clientNeeds.clientId, input.clientId))
+          .orderBy(desc(clientNeeds.updatedAt))
+          .limit(20),
+      ]);
+
+      const mergedArtifacts = [
+        ...salesSheetHistoryRows.map(row => ({
+          id: `sales-sheet:${row.id}`,
+          kind: "sent_sales_sheet" as const,
+          label: `Sales sheet #${row.id}`,
+          sublabel: row.convertedToOrderId
+            ? `Converted to order #${row.convertedToOrderId}`
+            : row.shareToken
+              ? "Shared with client"
+              : "Saved history",
+          amount: parseMoney(row.totalValue),
+          count: row.itemCount,
+          updatedAt: normalizeDate(row.createdAt),
+        })),
+        ...draftRows.map(row => ({
+          id: `sales-sheet-draft:${row.id}`,
+          kind: "sales_sheet_draft" as const,
+          label: row.name,
+          sublabel: "Sales sheet draft",
+          amount: parseMoney(row.totalValue),
+          count: row.itemCount,
+          updatedAt: normalizeDate(row.updatedAt),
+        })),
+        ...orderDraftRows.map(row => ({
+          id: `order-draft:${row.id}`,
+          kind:
+            row.orderType === "QUOTE"
+              ? ("quote_draft" as const)
+              : ("order_draft" as const),
+          label: row.orderNumber,
+          sublabel:
+            row.orderType === "QUOTE" ? "Quote draft" : "Sales order draft",
+          amount: parseMoney(row.total),
+          count: null,
+          updatedAt: normalizeDate(row.updatedAt ?? row.createdAt),
+        })),
+      ].sort((a, b) => {
+        const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+        const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+        return bTime - aTime;
+      });
+
+      return {
+        pricingProfile: profile
+          ? {
+              id: profile.id,
+              name: profile.name,
+              description: profile.description,
+            }
+          : null,
+        availableProfiles: profiles.map(profileRow => ({
+          id: profileRow.id,
+          name: profileRow.name,
+          description: profileRow.description,
+        })),
+        rules,
+        salesSheetHistory: salesSheetHistoryRows.map(row => ({
+          id: row.id,
+          totalValue: parseMoney(row.totalValue),
+          itemCount: row.itemCount,
+          createdAt: normalizeDate(row.createdAt),
+          shareToken: row.shareToken,
+          convertedToOrderId: row.convertedToOrderId,
+        })),
+        salesSheetDrafts: draftRows.map(row => ({
+          id: row.id,
+          name: row.name,
+          itemCount: row.itemCount,
+          totalValue: parseMoney(row.totalValue),
+          createdAt: normalizeDate(row.createdAt),
+          updatedAt: normalizeDate(row.updatedAt),
+        })),
+        orderDrafts: orderDraftRows.map(row => ({
+          id: row.id,
+          orderNumber: row.orderNumber,
+          orderType: row.orderType,
+          quoteStatus: row.quoteStatus,
+          total: parseMoney(row.total),
+          createdAt: normalizeDate(row.createdAt),
+          updatedAt: normalizeDate(row.updatedAt),
+        })),
+        needs: needsRows.map(row => ({
+          id: row.id,
+          label:
+            row.productName ||
+            row.strain ||
+            [row.category, row.subcategory, row.grade]
+              .filter(Boolean)
+              .join(" / ") ||
+            "Open need",
+          status: row.status,
+          priority: row.priority,
+          quantityMin: parseMoney(row.quantityMin),
+          quantityMax: parseMoney(row.quantityMax),
+          priceMax: parseMoney(row.priceMax),
+          neededBy: normalizeDate(row.neededBy),
+          updatedAt: normalizeDate(row.updatedAt),
+        })),
+        mergedArtifacts,
+        wishlist: client.wishlist,
+      };
+    }),
+
+  getMoney: protectedProcedure
+    .use(requirePermission("clients:read"))
+    .input(clientIdSchema)
+    .query(async ({ input }) => {
+      const { client, db } = await getClientOrThrow(input.clientId);
+      const [
+        balance,
+        payables,
+        creditLimitRow,
+        transactions,
+        paymentRows,
+        ledger,
+      ] = await Promise.all([
+        getClientBalanceDetails(input.clientId),
+        getVendorPayablesSummary(db, input.clientId),
+        db
+          .select({
+            creditLimit: clientCreditLimits.creditLimit,
+            currentExposure: clientCreditLimits.currentExposure,
+            utilizationPercent: clientCreditLimits.utilizationPercent,
+            creditHealthScore: clientCreditLimits.creditHealthScore,
+            updatedAt: clientCreditLimits.updatedAt,
+          })
+          .from(clientCreditLimits)
+          .where(eq(clientCreditLimits.clientId, input.clientId))
+          .limit(1),
+        db
+          .select({
+            id: clientTransactions.id,
+            transactionType: clientTransactions.transactionType,
+            transactionNumber: clientTransactions.transactionNumber,
+            transactionDate: clientTransactions.transactionDate,
+            amount: clientTransactions.amount,
+            paymentStatus: clientTransactions.paymentStatus,
+            paymentDate: clientTransactions.paymentDate,
+            paymentAmount: clientTransactions.paymentAmount,
+            notes: clientTransactions.notes,
+          })
+          .from(clientTransactions)
+          .where(eq(clientTransactions.clientId, input.clientId))
+          .orderBy(desc(clientTransactions.transactionDate))
+          .limit(50),
+        db
+          .select({
+            id: payments.id,
+            paymentNumber: payments.paymentNumber,
+            paymentType: payments.paymentType,
+            paymentDate: payments.paymentDate,
+            amount: payments.amount,
+            paymentMethod: payments.paymentMethod,
+            referenceNumber: payments.referenceNumber,
+            notes: payments.notes,
+            createdByName: users.name,
+          })
+          .from(payments)
+          .leftJoin(users, eq(payments.createdBy, users.id))
+          .where(
+            and(
+              isNull(payments.deletedAt),
+              sql`(${payments.customerId} = ${input.clientId} OR ${payments.vendorId} = ${input.clientId})`
+            )
+          )
+          .orderBy(desc(payments.paymentDate))
+          .limit(50),
+        buildLedgerPreview(input.clientId),
+      ]);
+
+      const moneyMode = getRelationshipMoneyMode(client);
+
+      return {
+        summary: {
+          mode: moneyMode,
+          receivable: balance,
+          payable: payables,
+          netPosition: balance.computedBalance - payables.amountDue,
+        },
+        balance,
+        credit: creditLimitRow[0]
+          ? {
+              creditLimit: parseMoney(creditLimitRow[0].creditLimit),
+              currentExposure: parseMoney(creditLimitRow[0].currentExposure),
+              utilizationPercent: parseMoney(
+                creditLimitRow[0].utilizationPercent
+              ),
+              creditHealthScore: parseMoney(
+                creditLimitRow[0].creditHealthScore
+              ),
+              updatedAt: normalizeDate(creditLimitRow[0].updatedAt),
+            }
+          : null,
+        transactionHistory: transactions.map(row => ({
+          id: row.id,
+          transactionType: row.transactionType,
+          transactionNumber: row.transactionNumber,
+          transactionDate: normalizeDate(row.transactionDate),
+          amount: parseMoney(row.amount),
+          paymentStatus: row.paymentStatus,
+          paymentDate: normalizeDate(row.paymentDate),
+          paymentAmount: parseMoney(row.paymentAmount),
+          notes: row.notes,
+        })),
+        paymentHistory: paymentRows.map(row => ({
+          id: row.id,
+          paymentNumber: row.paymentNumber,
+          paymentType: row.paymentType,
+          paymentDate: normalizeDate(row.paymentDate),
+          amount: parseMoney(row.amount),
+          paymentMethod: row.paymentMethod,
+          referenceNumber: row.referenceNumber,
+          notes: row.notes,
+          createdByName: row.createdByName,
+        })),
+        ledgerTimeline: ledger.entries,
+        ledgerTotals: ledger.totals,
+      };
+    }),
+
+  getSupplyInventory: protectedProcedure
+    .use(requirePermission("clients:read"))
+    .input(clientIdSchema)
+    .query(async ({ input }) => {
+      const { client, db } = await getClientOrThrow(input.clientId);
+      const [
+        inventoryPreview,
+        needsRows,
+        supplierBatches,
+        purchaseOrderRows,
+        supplierContextResult,
+      ] = await Promise.all([
+        inventoryDb.getBatchesWithDetails(50, undefined, { status: "LIVE" }),
+        db
+          .select({
+            id: clientNeeds.id,
+            productName: clientNeeds.productName,
+            strain: clientNeeds.strain,
+            category: clientNeeds.category,
+            subcategory: clientNeeds.subcategory,
+            grade: clientNeeds.grade,
+            priority: clientNeeds.priority,
+            status: clientNeeds.status,
+            updatedAt: clientNeeds.updatedAt,
+          })
+          .from(clientNeeds)
+          .where(eq(clientNeeds.clientId, input.clientId))
+          .orderBy(desc(clientNeeds.updatedAt))
+          .limit(12),
+        client.isSeller
+          ? db
+              .select({
+                id: batches.id,
+                sku: batches.sku,
+                batchStatus: batches.batchStatus,
+                onHandQty: batches.onHandQty,
+                unitCogs: batches.unitCogs,
+                createdAt: batches.createdAt,
+                productName: products.nameCanonical,
+              })
+              .from(batches)
+              .leftJoin(lots, eq(batches.lotId, lots.id))
+              .leftJoin(products, eq(batches.productId, products.id))
+              .where(
+                and(
+                  eq(lots.supplierClientId, input.clientId),
+                  isNull(batches.deletedAt)
+                )
+              )
+              .orderBy(desc(batches.createdAt))
+              .limit(20)
+          : Promise.resolve([]),
+        client.isSeller
+          ? db
+              .select({
+                id: purchaseOrders.id,
+                poNumber: purchaseOrders.poNumber,
+                purchaseOrderStatus: purchaseOrders.purchaseOrderStatus,
+                orderDate: purchaseOrders.orderDate,
+                expectedDeliveryDate: purchaseOrders.expectedDeliveryDate,
+                total: purchaseOrders.total,
+              })
+              .from(purchaseOrders)
+              .where(
+                and(
+                  eq(purchaseOrders.supplierClientId, input.clientId),
+                  isNull(purchaseOrders.deletedAt)
+                )
+              )
+              .orderBy(desc(purchaseOrders.createdAt))
+              .limit(20)
+          : Promise.resolve([]),
+        client.isSeller
+          ? vendorContextDb
+              .getVendorContext({
+                clientId: input.clientId,
+                includeActiveInventory: true,
+                includePaymentHistory: true,
+              })
+              .then(data => ({ data, error: null as string | null }))
+              .catch(error => ({
+                data: null,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Supplier context could not be loaded.",
+              }))
+          : Promise.resolve(null),
+      ]);
+
+      return {
+        systemInventory: inventoryPreview.items.map(item => ({
+          id: item.batch.id,
+          sku: item.batch.sku,
+          productName: item.product?.nameCanonical ?? "Unknown product",
+          category: item.product?.category ?? null,
+          supplierName:
+            "vendor" in item &&
+            item.vendor &&
+            typeof item.vendor === "object" &&
+            "name" in item.vendor &&
+            typeof item.vendor.name === "string"
+              ? item.vendor.name
+              : null,
+          status: item.batch.batchStatus,
+          onHandQty: parseMoney(item.batch.onHandQty),
+          unitCogs: parseMoney(item.batch.unitCogs),
+        })),
+        buyerNeeds: needsRows.map(row => ({
+          id: row.id,
+          label:
+            row.productName ||
+            row.strain ||
+            [row.category, row.subcategory, row.grade]
+              .filter(Boolean)
+              .join(" / ") ||
+            "Open need",
+          priority: row.priority,
+          status: row.status,
+          updatedAt: normalizeDate(row.updatedAt),
+        })),
+        supplier: client.isSeller
+          ? {
+              batches: supplierBatches.map(row => ({
+                id: row.id,
+                sku: row.sku,
+                status: row.batchStatus,
+                onHandQty: parseMoney(row.onHandQty),
+                unitCogs: parseMoney(row.unitCogs),
+                productName: row.productName,
+                createdAt: normalizeDate(row.createdAt),
+              })),
+              purchaseOrders: purchaseOrderRows.map(row => ({
+                id: row.id,
+                poNumber: row.poNumber,
+                status: row.purchaseOrderStatus,
+                orderDate: normalizeDate(row.orderDate),
+                expectedDeliveryDate: normalizeDate(row.expectedDeliveryDate),
+                total: parseMoney(row.total),
+              })),
+              context: supplierContextResult?.data
+                ? {
+                    aggregateMetrics:
+                      supplierContextResult.data.aggregateMetrics,
+                    activeInventory:
+                      supplierContextResult.data.activeInventory ?? [],
+                    relatedBrands: supplierContextResult.data.relatedBrands,
+                  }
+                : null,
+              contextError: supplierContextResult?.error ?? null,
+            }
+          : null,
+      };
+    }),
+
+  getActivity: protectedProcedure
+    .use(requirePermission("clients:read"))
+    .input(clientIdSchema)
+    .query(async ({ input }) => {
+      const { db } = await getClientOrThrow(input.clientId);
+      const [activityRows, communicationRows] = await Promise.all([
+        db
+          .select({
+            id: clientActivity.id,
+            activityType: clientActivity.activityType,
+            metadata: clientActivity.metadata,
+            createdAt: clientActivity.createdAt,
+            userName: users.name,
+          })
+          .from(clientActivity)
+          .leftJoin(users, eq(clientActivity.userId, users.id))
+          .where(eq(clientActivity.clientId, input.clientId))
+          .orderBy(desc(clientActivity.createdAt))
+          .limit(50),
+        db
+          .select({
+            id: clientCommunications.id,
+            communicationType: clientCommunications.communicationType,
+            subject: clientCommunications.subject,
+            notes: clientCommunications.notes,
+            communicatedAt: clientCommunications.communicatedAt,
+            loggedByName: users.name,
+          })
+          .from(clientCommunications)
+          .leftJoin(users, eq(clientCommunications.loggedBy, users.id))
+          .where(eq(clientCommunications.clientId, input.clientId))
+          .orderBy(desc(clientCommunications.communicatedAt))
+          .limit(50),
+      ]);
+
+      return {
+        activity: activityRows.map(row => ({
+          id: row.id,
+          activityType: row.activityType,
+          metadata: row.metadata,
+          createdAt: normalizeDate(row.createdAt),
+          userName: row.userName,
+        })),
+        communications: communicationRows.map(row => ({
+          id: row.id,
+          communicationType: row.communicationType,
+          subject: row.subject,
+          notes: row.notes,
+          communicatedAt: normalizeDate(row.communicatedAt),
+          loggedByName: row.loggedByName,
+        })),
+      };
+    }),
+});

--- a/server/routers/search.ts
+++ b/server/routers/search.ts
@@ -181,6 +181,8 @@ export const searchRouter = router({
               phone: clients.phone,
               teriCode: clients.teriCode,
               address: clients.address,
+              isBuyer: clients.isBuyer,
+              isSeller: clients.isSeller,
               createdAt: clients.createdAt,
             })
             .from(clients)
@@ -204,11 +206,22 @@ export const searchRouter = router({
               type: "customer" as const,
               title: c.name || "Unknown",
               description: c.email || c.teriCode || undefined,
-              url: `/clients/${c.id}`,
+              url:
+                c.isSeller && !c.isBuyer
+                  ? `/clients/${c.id}?section=supply-inventory`
+                  : `/clients/${c.id}?section=overview`,
               metadata: {
                 email: c.email,
                 phone: c.phone,
                 teriCode: c.teriCode,
+                isBuyer: c.isBuyer,
+                isSeller: c.isSeller,
+                relationshipLabel:
+                  c.isSeller && !c.isBuyer
+                    ? "Supplier"
+                    : c.isBuyer && c.isSeller
+                      ? "Customer + Supplier"
+                      : "Customer",
               },
               relevance: calculateRelevance(
                 query,


### PR DESCRIPTION
## Summary
- replace the split customer/vendor profile experience with a unified role-aware relationship profile shell
- add a shared quick panel across client, supplier, and order-creation surfaces with role-aware money and workflow actions
- fix deep links, supplier/customer copy, needs/pricing/live-catalog workflows, and supplier money semantics through the new relationship profile router

## Testing
- pnpm check
- pnpm lint
- pnpm test
- pnpm build