### PR TITLE
fix(backlog): close remaining staging workflow gaps

### DIFF
--- a/client/src/components/work-surface/PickPackWorkSurface.tsx
+++ b/client/src/components/work-surface/PickPackWorkSurface.tsx
@@ -552,10 +552,15 @@ function OrderInspector({
 // ============================================================================
 
 export function PickPackWorkSurface() {
-  const { hasAnyPermission } = usePermissions();
+  const { hasAnyPermission, isLoading: permissionsLoading } = usePermissions();
+  const canAccessPickPack = hasAnyPermission([
+    "orders:read",
+    "pick-pack:manage",
+    "orders:fulfill",
+    "orders:update",
+  ]);
   const canManagePickPack = hasAnyPermission([
     "pick-pack:manage",
-    "orders:manage",
     "orders:fulfill",
     "orders:update",
   ]);
@@ -820,6 +825,27 @@ export function PickPackWorkSurface() {
     },
   });
 
+  const shipOrderMutation = trpc.orders.shipOrder.useMutation({
+    onMutate: () => setSaving(),
+    onSuccess: () => {
+      const orderNum = orderDetails?.order.orderNumber;
+      setSelectedOrderId(null);
+      setInspectorMode(null);
+      setInspectedItemId(null);
+      void refetchPickList();
+      void refetchStats();
+      setSaved();
+      toast.success("Order marked shipped");
+      notifyStatusFilterExit(orderNum, "SHIPPED");
+    },
+    onError: (error: { message: string }) => {
+      if (!handleConflictError(error)) {
+        setError(error.message || "Failed to mark shipped");
+        toast.error(`Failed to mark shipped: ${error.message}`);
+      }
+    },
+  });
+
   // Handlers
   const handleSelectOrder = useCallback(
     (orderId: number) => {
@@ -926,6 +952,14 @@ export function PickPackWorkSurface() {
       markReadyMutation.mutate({ orderId: selectedOrderId });
     }
   }, [canManagePickPack, selectedOrderId, markReadyMutation]);
+
+  const handleMarkShipped = useCallback(() => {
+    if (!canManagePickPack || !selectedOrderId) {
+      return;
+    }
+
+    shipOrderMutation.mutate({ id: selectedOrderId });
+  }, [canManagePickPack, selectedOrderId, shipOrderMutation]);
 
   const handleExportManifest = useCallback(() => {
     if (!orderDetails || pickPackManifestRows.length === 0) {
@@ -1130,6 +1164,13 @@ export function PickPackWorkSurface() {
     return null;
   }, [inspectorMode, inspectedItemId, orderDetails]);
 
+  const canShipSelectedOrder =
+    !!orderDetails &&
+    orderDetails.order.pickPackStatus === "READY" &&
+    !["SHIPPED", "DELIVERED", "RETURNED"].includes(
+      orderDetails.order.fulfillmentStatus ?? ""
+    );
+
   // Status counts
   const statusCounts = useMemo(
     () => ({
@@ -1140,6 +1181,18 @@ export function PickPackWorkSurface() {
     }),
     [stats]
   );
+
+  if (!permissionsLoading && !canAccessPickPack) {
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <Card className="max-w-md">
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            Shipping access requires order read or fulfillment permissions.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -1443,30 +1496,52 @@ export function PickPackWorkSurface() {
                 Pack All to One Bag
               </Button>
               <div className="flex-1" />
-              <Button
-                variant="default"
-                size="sm"
-                onClick={handleMarkReady}
-                disabled={
-                  orderDetails.summary.packedItems <
-                    orderDetails.summary.totalItems ||
-                  markReadyMutation.isPending ||
-                  !canManagePickPack
-                }
-                className="bg-green-600 hover:bg-green-700"
-                title={
-                  canManagePickPack
-                    ? undefined
-                    : "Shipping manage permissions required"
-                }
-              >
-                {markReadyMutation.isPending ? (
-                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                ) : (
-                  <Truck className="w-4 h-4 mr-2" />
-                )}
-                {readyCtaLabel}
-              </Button>
+              {canShipSelectedOrder ? (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={handleMarkShipped}
+                  disabled={shipOrderMutation.isPending || !canManagePickPack}
+                  className="bg-green-600 hover:bg-green-700"
+                  title={
+                    canManagePickPack
+                      ? undefined
+                      : "Shipping manage permissions required"
+                  }
+                >
+                  {shipOrderMutation.isPending ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Truck className="w-4 h-4 mr-2" />
+                  )}
+                  Mark Shipped
+                </Button>
+              ) : (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={handleMarkReady}
+                  disabled={
+                    orderDetails.summary.packedItems <
+                      orderDetails.summary.totalItems ||
+                    markReadyMutation.isPending ||
+                    !canManagePickPack
+                  }
+                  className="bg-green-600 hover:bg-green-700"
+                  title={
+                    canManagePickPack
+                      ? undefined
+                      : "Shipping manage permissions required"
+                  }
+                >
+                  {markReadyMutation.isPending ? (
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  ) : (
+                    <Truck className="w-4 h-4 mr-2" />
+                  )}
+                  {readyCtaLabel}
+                </Button>
+              )}
             </div>
 
             {/* Items List */}

--- a/client/src/components/work-surface/QuotesWorkSurface.tsx
+++ b/client/src/components/work-surface/QuotesWorkSurface.tsx
@@ -94,7 +94,7 @@ interface Quote {
   id: number;
   orderNumber: string;
   clientId: number;
-  quoteStatus:
+  quoteStatus?:
     | "UNSENT"
     | "SENT"
     | "VIEWED"
@@ -178,16 +178,20 @@ const formatDate = (dateString: string | undefined): string => {
   }
 };
 
+const getEffectiveQuoteStatus = (quote: Pick<Quote, "quoteStatus">) =>
+  quote.quoteStatus ?? "UNSENT";
+
 // ============================================================================
 // STATUS BADGE
 // ============================================================================
 
-function QuoteStatusBadge({ status }: { status: string }) {
-  const config = STATUS_CONFIG[status] || STATUS_CONFIG.UNSENT;
+function QuoteStatusBadge({ status }: { status?: string }) {
+  const effectiveStatus = status ?? "UNSENT";
+  const config = STATUS_CONFIG[effectiveStatus] || STATUS_CONFIG.UNSENT;
   return (
     <Badge variant="outline" className={cn("gap-1", config.color)}>
       {config.icon}
-      {status}
+      {effectiveStatus}
     </Badge>
   );
 }
@@ -225,6 +229,7 @@ function QuoteInspectorContent({
   }
 
   const items = quote.items || [];
+  const effectiveStatus = getEffectiveQuoteStatus(quote);
 
   return (
     <div className="space-y-6">
@@ -234,7 +239,7 @@ function QuoteInspectorContent({
             <p className="font-semibold text-lg">{quote.orderNumber}</p>
           </InspectorField>
           <InspectorField label="Status">
-            <QuoteStatusBadge status={quote.quoteStatus} />
+            <QuoteStatusBadge status={effectiveStatus} />
           </InspectorField>
         </div>
 
@@ -322,7 +327,7 @@ function QuoteInspectorContent({
 
       <InspectorSection title="Actions" defaultOpen>
         <div className="space-y-2">
-          {quote.quoteStatus === "UNSENT" && (
+          {effectiveStatus === "UNSENT" && (
             <>
               <Button
                 variant="outline"
@@ -342,9 +347,9 @@ function QuoteInspectorContent({
               </Button>
             </>
           )}
-          {(quote.quoteStatus === "UNSENT" ||
-            quote.quoteStatus === "SENT" ||
-            quote.quoteStatus === "VIEWED") && (
+          {(effectiveStatus === "UNSENT" ||
+            effectiveStatus === "SENT" ||
+            effectiveStatus === "VIEWED") && (
             <Button
               variant="default"
               className="w-full justify-start"
@@ -362,7 +367,7 @@ function QuoteInspectorContent({
             <Copy className="h-4 w-4 mr-2" />
             Duplicate Quote
           </Button>
-          {quote.quoteStatus === "UNSENT" && (
+          {effectiveStatus === "UNSENT" && (
             <Button
               variant="outline"
               className="w-full justify-start text-red-600 hover:text-red-700"
@@ -453,9 +458,10 @@ export function QuotesWorkSurface() {
   // Statistics
   const stats = useMemo(
     () => ({
-      draft: quotes.filter(q => q.quoteStatus === "UNSENT").length,
-      sent: quotes.filter(q => q.quoteStatus === "SENT").length,
-      converted: quotes.filter(q => q.quoteStatus === "CONVERTED").length,
+      draft: quotes.filter(q => getEffectiveQuoteStatus(q) === "UNSENT").length,
+      sent: quotes.filter(q => getEffectiveQuoteStatus(q) === "SENT").length,
+      converted: quotes.filter(q => getEffectiveQuoteStatus(q) === "CONVERTED")
+        .length,
       total: quotes.length,
     }),
     [quotes]

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -352,10 +352,23 @@ export default function OrderCreatorPageV2() {
     null
   );
   const { hasAnyPermission } = usePermissions();
-  const canEditPricing = hasAnyPermission([
+  const canViewPricingContext = hasAnyPermission([
+    "orders:view_pricing",
+    "pricing:read",
+    "pricing:access",
+    "pricing:rules:read",
+    "pricing:profiles:read",
+    "pricing:defaults:view",
+  ]);
+  const canManagePricing = hasAnyPermission([
     "pricing:manage",
     "pricing:update",
     "pricing:create",
+    "pricing:profiles:update",
+    "pricing:profiles:create",
+    "pricing:rules:update",
+    "pricing:rules:create",
+    "pricing:defaults:edit",
   ]);
 
   const { saveState, setSaving, setSaved, setError, SaveStateIndicator } =
@@ -810,7 +823,7 @@ export default function OrderCreatorPageV2() {
           (!item.effectiveCogsBasis ||
             item.effectiveCogsBasis === profilePricing.effectiveCogsBasis);
         const cogsPerUnit = shouldRefreshCogsState
-          ? profilePricing.effectiveCogs ?? item.cogsPerUnit
+          ? (profilePricing.effectiveCogs ?? item.cogsPerUnit)
           : item.cogsPerUnit;
         const retailPrice =
           profilePricing.retailPrice ?? profilePricing.basePrice ?? cogsPerUnit;
@@ -833,23 +846,23 @@ export default function OrderCreatorPageV2() {
             ? cogsPerUnit
             : item.originalCogsPerUnit,
           cogsMode: shouldRefreshCogsState
-            ? profilePricing.cogsMode ?? item.cogsMode
+            ? (profilePricing.cogsMode ?? item.cogsMode)
             : item.cogsMode,
           unitCogsMin: shouldRefreshCogsState
-            ? profilePricing.unitCogsMin ?? item.unitCogsMin ?? null
-            : item.unitCogsMin ?? null,
+            ? (profilePricing.unitCogsMin ?? item.unitCogsMin ?? null)
+            : (item.unitCogsMin ?? null),
           unitCogsMax: shouldRefreshCogsState
-            ? profilePricing.unitCogsMax ?? item.unitCogsMax ?? null
-            : item.unitCogsMax ?? null,
+            ? (profilePricing.unitCogsMax ?? item.unitCogsMax ?? null)
+            : (item.unitCogsMax ?? null),
           effectiveCogsBasis: shouldRefreshCogsState
-            ? profilePricing.effectiveCogsBasis ?? item.effectiveCogsBasis
+            ? (profilePricing.effectiveCogsBasis ?? item.effectiveCogsBasis)
             : item.effectiveCogsBasis,
           originalRangeMin: shouldRefreshCogsState
-            ? profilePricing.unitCogsMin ?? item.originalRangeMin ?? null
-            : item.originalRangeMin ?? null,
+            ? (profilePricing.unitCogsMin ?? item.originalRangeMin ?? null)
+            : (item.originalRangeMin ?? null),
           originalRangeMax: shouldRefreshCogsState
-            ? profilePricing.unitCogsMax ?? item.originalRangeMax ?? null
-            : item.originalRangeMax ?? null,
+            ? (profilePricing.unitCogsMax ?? item.originalRangeMax ?? null)
+            : (item.originalRangeMax ?? null),
           isBelowVendorRange:
             typeof item.originalRangeMin === "number"
               ? cogsPerUnit < item.originalRangeMin
@@ -1216,7 +1229,9 @@ export default function OrderCreatorPageV2() {
         originalRangeMin: item.unitCogsMin ?? null,
         originalRangeMax: item.unitCogsMax ?? null,
         isBelowVendorRange:
-          typeof item.unitCogsMin === "number" ? cogsPerUnit < item.unitCogsMin : false,
+          typeof item.unitCogsMin === "number"
+            ? cogsPerUnit < item.unitCogsMin
+            : false,
         marginPercent: marginPercent || 0, // Ensure marginPercent is always a number
         marginDollar: calculated.marginDollar || 0, // Ensure marginDollar is always a number
         unitPrice: calculated.unitPrice || 0, // Ensure unitPrice is always a number
@@ -1629,14 +1644,14 @@ export default function OrderCreatorPageV2() {
                               event.currentTarget
                             )
                           }
-                          disabled={!canEditPricing}
+                          disabled={!canViewPricingContext}
                         >
                           Pricing Profile
                         </Button>
                       </div>
-                      {!canEditPricing ? (
+                      {!canViewPricingContext ? (
                         <p className="text-[11px] text-muted-foreground">
-                          Pricing edits require pricing permissions.
+                          Pricing context requires pricing access.
                         </p>
                       ) : null}
                     </CardContent>
@@ -1904,10 +1919,20 @@ export default function OrderCreatorPageV2() {
                     />
                   ) : null}
                   {customerDrawerSection === "sales-pricing" ? (
-                    <PricingConfigTab
-                      clientId={clientId}
-                      onProfileApplied={handlePricingProfileApplied}
-                    />
+                    canManagePricing ? (
+                      <PricingConfigTab
+                        clientId={clientId}
+                        onProfileApplied={handlePricingProfileApplied}
+                      />
+                    ) : (
+                      <Card>
+                        <CardContent className="py-4 text-sm text-muted-foreground">
+                          Pricing rules can be reviewed here, but changing the
+                          relationship pricing profile requires pricing edit
+                          permissions.
+                        </CardContent>
+                      </Card>
+                    )
                   ) : null}
                 </div>
               ) : (

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -3,7 +3,7 @@
  * Handles all database operations for the unified Quote/Sales system
  */
 
-import { eq, and, desc, sql, isNull, type SQL } from "drizzle-orm";
+import { eq, and, desc, sql, isNull, or, type SQL } from "drizzle-orm";
 import { safeInArray } from "./lib/sqlSafety";
 import { getDb } from "./db";
 import {
@@ -131,7 +131,12 @@ async function syncOrderLineItemsForOrder(
   if (existingLineItemIds.length > 0) {
     await tx
       .delete(orderLineItemAllocations)
-      .where(safeInArray(orderLineItemAllocations.orderLineItemId, existingLineItemIds));
+      .where(
+        safeInArray(
+          orderLineItemAllocations.orderLineItemId,
+          existingLineItemIds
+        )
+      );
 
     await tx.delete(orderLineItems).where(eq(orderLineItems.orderId, orderId));
   }
@@ -147,7 +152,9 @@ async function syncOrderLineItemsForOrder(
       productDisplayName: item.displayName,
       quantity: item.quantity.toString(),
       cogsPerUnit: item.unitCogs.toFixed(4),
-      originalCogsPerUnit: (item.originalCogsPerUnit ?? item.unitCogs).toFixed(4),
+      originalCogsPerUnit: (item.originalCogsPerUnit ?? item.unitCogs).toFixed(
+        4
+      ),
       effectiveCogsBasis: item.effectiveCogsBasis ?? "MANUAL",
       originalRangeMin:
         item.originalRangeMin !== null && item.originalRangeMin !== undefined
@@ -160,7 +167,8 @@ async function syncOrderLineItemsForOrder(
       isBelowVendorRange: item.isBelowVendorRange ?? false,
       belowRangeReason: item.isBelowVendorRange ? item.belowRangeReason : null,
       isCogsOverridden: item.overrideCogs !== undefined,
-      cogsOverrideReason: item.overrideCogs !== undefined ? "Legacy order path override" : null,
+      cogsOverrideReason:
+        item.overrideCogs !== undefined ? "Legacy order path override" : null,
       marginPercent: item.marginPercent.toFixed(2),
       marginDollar: item.unitMargin.toFixed(2),
       isMarginOverridden: item.overridePrice !== undefined,
@@ -188,12 +196,20 @@ export interface ConvertQuoteToSaleInput {
   notes?: string;
 }
 
-function normalizeOrderRecord<T extends { fulfillmentStatus?: string | null }>(
-  order: T
-): T {
+function normalizeOrderRecord<
+  T extends {
+    fulfillmentStatus?: string | null;
+    orderType?: string | null;
+    quoteStatus?: string | null;
+  },
+>(order: T): T {
   return {
     ...order,
     fulfillmentStatus: normalizeFulfillmentStatus(order.fulfillmentStatus),
+    quoteStatus:
+      order.orderType === "QUOTE" && !order.quoteStatus
+        ? "UNSENT"
+        : order.quoteStatus,
   };
 }
 
@@ -336,19 +352,19 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
         const marginPercent =
           finalPrice > 0 ? (unitMargin / finalPrice) * 100 : 0;
 
-          cogsResult = {
-            unitCogs: item.overrideCogs,
-            cogsSource: "MANUAL" as const,
-            unitMargin,
-            marginPercent,
-            effectiveCogsBasis: "MANUAL" as const,
-            originalRangeMin: defaultCogsResult.originalRangeMin,
-            originalRangeMax: defaultCogsResult.originalRangeMax,
-            isBelowVendorRange:
-              defaultCogsResult.originalRangeMin !== null
-                ? item.overrideCogs < defaultCogsResult.originalRangeMin
-                : false,
-          };
+        cogsResult = {
+          unitCogs: item.overrideCogs,
+          cogsSource: "MANUAL" as const,
+          unitMargin,
+          marginPercent,
+          effectiveCogsBasis: "MANUAL" as const,
+          originalRangeMin: defaultCogsResult.originalRangeMin,
+          originalRangeMax: defaultCogsResult.originalRangeMax,
+          isBelowVendorRange:
+            defaultCogsResult.originalRangeMin !== null
+              ? item.overrideCogs < defaultCogsResult.originalRangeMin
+              : false,
+        };
       } else {
         // Calculate using COGS calculator
         cogsResult = defaultCogsResult;
@@ -710,12 +726,22 @@ export async function getAllOrders(filters?: {
         normalizedQuoteStatus as (typeof validQuoteStatuses)[number]
       )
     ) {
-      conditions.push(
-        eq(
-          orders.quoteStatus,
-          normalizedQuoteStatus as (typeof validQuoteStatuses)[number]
-        )
-      );
+      if (normalizedQuoteStatus === "UNSENT") {
+        const unsentOrLegacyFilter = or(
+          eq(orders.quoteStatus, "UNSENT"),
+          isNull(orders.quoteStatus)
+        );
+        if (unsentOrLegacyFilter) {
+          conditions.push(unsentOrLegacyFilter);
+        }
+      } else {
+        conditions.push(
+          eq(
+            orders.quoteStatus,
+            normalizedQuoteStatus as (typeof validQuoteStatuses)[number]
+          )
+        );
+      }
     }
   }
 
@@ -1093,12 +1119,7 @@ export async function convertQuoteToSale(
     }
 
     // SM-001: Validate quote status allows conversion
-    if (!quote.quoteStatus) {
-      throw new Error(
-        `Quote ${input.quoteId} has no status set. Cannot convert.`
-      );
-    }
-    const currentStatus = quote.quoteStatus;
+    const currentStatus = quote.quoteStatus ?? "UNSENT";
     if (!isValidStatusTransition("quote", currentStatus, "CONVERTED")) {
       throw new Error(
         `Cannot convert quote: invalid transition from ${currentStatus} to CONVERTED. ` +

--- a/server/routers/pickPack.ts
+++ b/server/routers/pickPack.ts
@@ -9,9 +9,14 @@
  */
 
 import { z } from "zod";
-import { router, adminProcedure, getAuthenticatedUserId } from "../_core/trpc";
+import {
+  router,
+  protectedProcedure,
+  getAuthenticatedUserId,
+} from "../_core/trpc";
 import { TRPCError } from "@trpc/server";
 import { logger } from "../_core/logger";
+import { requireAnyPermission } from "../_core/permissionMiddleware";
 
 const pickPackDisplayStatusSchema = z.enum([
   "PENDING",
@@ -114,7 +119,15 @@ export const pickPackRouter = router({
   /**
    * Get the real-time pick list (orders ready for picking)
    */
-  getPickList: adminProcedure
+  getPickList: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "orders:read",
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(
       z.object({
         filters: z
@@ -286,7 +299,15 @@ export const pickPackRouter = router({
   /**
    * Get order details for picking/packing
    */
-  getOrderDetails: adminProcedure
+  getOrderDetails: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "orders:read",
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(z.object({ orderId: z.number() }))
     .query(async ({ input, ctx: _ctx }) => {
       const db = await import("../db").then(m => m.getDb());
@@ -433,7 +454,14 @@ export const pickPackRouter = router({
   /**
    * Pack selected items into a bag
    */
-  packItems: adminProcedure
+  packItems: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(
       z.object({
         orderId: z.number(),
@@ -567,7 +595,14 @@ export const pickPackRouter = router({
   /**
    * Unpack items from a bag (requires confirmation)
    */
-  unpackItems: adminProcedure
+  unpackItems: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(
       z.object({
         orderId: z.number(),
@@ -658,7 +693,14 @@ export const pickPackRouter = router({
   /**
    * Mark all items in order as packed
    */
-  markAllPacked: adminProcedure
+  markAllPacked: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(
       z.object({
         orderId: z.number(),
@@ -778,7 +820,14 @@ export const pickPackRouter = router({
   /**
    * Mark order as ready for shipping
    */
-  markOrderReady: adminProcedure
+  markOrderReady: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(z.object({ orderId: z.number() }))
     .mutation(async ({ input, ctx }) => {
       const db = await import("../db").then(m => m.getDb());
@@ -846,7 +895,14 @@ export const pickPackRouter = router({
   /**
    * Update order pick/pack status
    */
-  updateStatus: adminProcedure
+  updateStatus: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
     .input(
       z.object({
         orderId: z.number(),
@@ -875,54 +931,63 @@ export const pickPackRouter = router({
   /**
    * Get stats for the pick/pack dashboard
    */
-  getStats: adminProcedure.query(async ({ ctx: _ctx }) => {
-    const db = await import("../db").then(m => m.getDb());
-    if (!db)
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Database not available",
-      });
+  getStats: protectedProcedure
+    .use(
+      requireAnyPermission([
+        "orders:read",
+        "pick-pack:manage",
+        "orders:fulfill",
+        "orders:update",
+      ])
+    )
+    .query(async ({ ctx: _ctx }) => {
+      const db = await import("../db").then(m => m.getDb());
+      if (!db)
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Database not available",
+        });
 
-    const { orders } = await import("../../drizzle/schema");
-    const { eq, and, isNull } = await import("drizzle-orm");
+      const { orders } = await import("../../drizzle/schema");
+      const { eq, and, isNull } = await import("drizzle-orm");
 
-    const conditions = [
-      eq(orders.orderType, "SALE"),
-      eq(orders.isDraft, false),
-      isNull(orders.deletedAt),
-    ];
+      const conditions = [
+        eq(orders.orderType, "SALE"),
+        eq(orders.isDraft, false),
+        isNull(orders.deletedAt),
+      ];
 
-    const orderStatuses = await db
-      .select({
-        pickPackStatus: orders.pickPackStatus,
-        fulfillmentStatus: orders.fulfillmentStatus,
-      })
-      .from(orders)
-      .where(and(...conditions));
+      const orderStatuses = await db
+        .select({
+          pickPackStatus: orders.pickPackStatus,
+          fulfillmentStatus: orders.fulfillmentStatus,
+        })
+        .from(orders)
+        .where(and(...conditions));
 
-    const statusCounts = {
-      PENDING: 0,
-      PARTIAL: 0,
-      READY: 0,
-      SHIPPED: 0,
-    };
+      const statusCounts = {
+        PENDING: 0,
+        PARTIAL: 0,
+        READY: 0,
+        SHIPPED: 0,
+      };
 
-    for (const order of orderStatuses) {
-      const displayStatus = mapPickPackDisplayStatus(
-        order.pickPackStatus,
-        order.fulfillmentStatus
-      );
-      statusCounts[displayStatus] += 1;
-    }
+      for (const order of orderStatuses) {
+        const displayStatus = mapPickPackDisplayStatus(
+          order.pickPackStatus,
+          order.fulfillmentStatus
+        );
+        statusCounts[displayStatus] += 1;
+      }
 
-    return {
-      pending: statusCounts.PENDING,
-      partial: statusCounts.PARTIAL,
-      ready: statusCounts.READY,
-      shipped: statusCounts.SHIPPED,
-      total: Object.values(statusCounts).reduce((a, b) => a + b, 0),
-    };
-  }),
+      return {
+        pending: statusCounts.PENDING,
+        partial: statusCounts.PARTIAL,
+        ready: statusCounts.READY,
+        shipped: statusCounts.SHIPPED,
+        total: Object.values(statusCounts).reduce((a, b) => a + b, 0),
+      };
+    }),
 });
 
 export type PickPackRouter = typeof pickPackRouter;

--- a/server/routers/quotes.test.ts
+++ b/server/routers/quotes.test.ts
@@ -111,16 +111,9 @@ describe("Quotes Router", () => {
     });
   });
 
-  describe("Null quoteStatus handling (W6 fix)", () => {
-    it("should reject send when quoteStatus is null", async () => {
-      // The quotes router does a DB query; since we mock the DB,
-      // we need to test the isValidStatusTransition logic directly
-
-      // Null/undefined status should not be silently defaulted
-      // The router now throws before calling isValidStatusTransition
-      // Verify the old DRAFT fallback no longer exists by checking
-      // that DRAFT is not a valid status in the quote machine
-      expect(isValidStatusTransition("quote", "DRAFT", "SENT")).toBe(false);
+  describe("Null quoteStatus handling (legacy quote compatibility)", () => {
+    it("treats legacy null quote status like UNSENT for transitions", async () => {
+      expect(isValidStatusTransition("quote", "UNSENT", "SENT")).toBe(true);
     });
 
     it("should reject transition from non-existent status", async () => {

--- a/server/routers/quotes.ts
+++ b/server/routers/quotes.ts
@@ -90,6 +90,10 @@ function addDays(date: Date, days: number): Date {
   return result;
 }
 
+function getLegacyCompatibleQuoteStatus(value: string | null | undefined) {
+  return value ?? "UNSENT";
+}
+
 // ============================================================================
 // QUOTES ROUTER
 // ============================================================================
@@ -111,7 +115,13 @@ export const quotesRouter = router({
       ];
 
       if (input.status) {
-        conditions.push(eq(orders.quoteStatus, input.status));
+        if (input.status === "UNSENT") {
+          conditions.push(
+            sql`(${orders.quoteStatus} = 'UNSENT' OR ${orders.quoteStatus} IS NULL)`
+          );
+        } else {
+          conditions.push(eq(orders.quoteStatus, input.status));
+        }
       }
 
       if (input.clientId) {
@@ -288,13 +298,7 @@ export const quotesRouter = router({
       const client = result.clients;
 
       // SM-001: Validate quote status transition using state machine
-      if (!quote.quoteStatus) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Quote has no status set. Cannot transition to SENT.",
-        });
-      }
-      const currentStatus = quote.quoteStatus;
+      const currentStatus = getLegacyCompatibleQuoteStatus(quote.quoteStatus);
       if (!isValidStatusTransition("quote", currentStatus, "SENT")) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -473,13 +477,7 @@ export const quotesRouter = router({
       }
 
       // SM-001: Validate quote status transition using state machine
-      if (!quote.quoteStatus) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Quote has no status set. Cannot transition to CONVERTED.",
-        });
-      }
-      const currentStatus = quote.quoteStatus;
+      const currentStatus = getLegacyCompatibleQuoteStatus(quote.quoteStatus);
       if (!isValidStatusTransition("quote", currentStatus, "CONVERTED")) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -537,13 +535,7 @@ export const quotesRouter = router({
       }
 
       // SM-001: Validate quote status transition using state machine
-      if (!quote.quoteStatus) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Quote has no status set. Cannot transition to REJECTED.",
-        });
-      }
-      const currentStatus = quote.quoteStatus;
+      const currentStatus = getLegacyCompatibleQuoteStatus(quote.quoteStatus);
       if (!isValidStatusTransition("quote", currentStatus, "REJECTED")) {
         throw new TRPCError({
           code: "BAD_REQUEST",


### PR DESCRIPTION
## Description
- restore legacy quote actions by treating null `quoteStatus` rows as `UNSENT` in list, transition, and conversion paths
- let read-capable sales roles open pricing context without granting pricing-edit powers
- open pick/pack to fulfillment-capable operators and add an explicit `Mark Shipped` action once an order is ready

## Related Issues
- Follow-up to March 10 recording backlog closure staging replay
- Addresses residual gaps behind TER-695, TER-698, TER-699, TER-701

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that breaks existing functionality)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes)
- [ ] ⚡️ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔒 Security fix

## Testing Performed
### Manual Testing
- local review of quote inspector action availability for legacy/null-status quotes
- local review of pricing drawer gating split between read-capable and edit-capable roles
- local review of pick/pack CTA path for ready-to-ship orders

### Automated Testing
```bash
pnpm exec vitest run server/routers/quotes.test.ts server/routers/pickPack.test.ts
pnpm check
pnpm lint
pnpm test
pnpm build
```

## Staging Verification
- [ ] Pending post-merge staging replay on https://terp-staging-yicld.ondigitalocean.app

## Deployment Notes
- No migrations required
- No environment variable changes
- `vet` remains blocked by Codex harness event parsing (`collab_tool_call`) even after upgrading `verify-everything` from `0.2.5` to `0.2.7`
