### PR TITLE
fix(quotes): normalize legacy quote items

### DIFF
--- a/client/src/components/work-surface/QuotesWorkSurface.tsx
+++ b/client/src/components/work-surface/QuotesWorkSurface.tsx
@@ -110,9 +110,13 @@ interface Quote {
   notes?: string;
   items?: Array<{
     batchId?: number;
-    displayName: string;
+    displayName?: string;
+    originalName?: string;
+    productName?: string;
     quantity: number;
-    price: string;
+    price?: string | number;
+    unitPrice?: string | number;
+    lineTotal?: string | number;
   }>;
 }
 
@@ -163,6 +167,7 @@ const STATUS_CONFIG: Record<string, { icon: ReactNode; color: string }> = {
 
 const formatCurrency = (value: string | number): string => {
   const num = typeof value === "string" ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return "—";
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
@@ -180,6 +185,36 @@ const formatDate = (dateString: string | undefined): string => {
 
 const getEffectiveQuoteStatus = (quote: Pick<Quote, "quoteStatus">) =>
   quote.quoteStatus ?? "UNSENT";
+
+const getQuoteItemDisplayName = (item: NonNullable<Quote["items"]>[number]) =>
+  item.displayName || item.productName || item.originalName || "Product";
+
+const getQuoteItemUnitPrice = (item: NonNullable<Quote["items"]>[number]) => {
+  const value =
+    item.unitPrice !== undefined && item.unitPrice !== null
+      ? item.unitPrice
+      : item.price;
+  const numeric = typeof value === "string" ? parseFloat(value) : value;
+  return typeof numeric === "number" && Number.isFinite(numeric)
+    ? numeric
+    : null;
+};
+
+const getQuoteItemLineTotal = (item: NonNullable<Quote["items"]>[number]) => {
+  const lineTotal =
+    item.lineTotal !== undefined && item.lineTotal !== null
+      ? typeof item.lineTotal === "string"
+        ? parseFloat(item.lineTotal)
+        : item.lineTotal
+      : null;
+
+  if (typeof lineTotal === "number" && Number.isFinite(lineTotal)) {
+    return lineTotal;
+  }
+
+  const unitPrice = getQuoteItemUnitPrice(item);
+  return unitPrice !== null ? item.quantity * unitPrice : null;
+};
 
 // ============================================================================
 // STATUS BADGE
@@ -264,27 +299,36 @@ function QuoteInspectorContent({
           <p className="text-sm text-muted-foreground">No items</p>
         ) : (
           <div className="space-y-2">
-            {items.map(item => (
-              <div
-                key={`quote-item-${item.batchId ?? item.displayName}-${item.quantity}-${item.price}`}
-                className="p-3 border rounded-lg bg-muted/30"
-              >
-                <div className="flex justify-between items-start">
-                  <div>
-                    <p className="font-medium">{item.displayName}</p>
-                    <p className="text-sm text-muted-foreground">
-                      Qty: {item.quantity}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-mono">{formatCurrency(item.price)}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formatCurrency(item.quantity * parseFloat(item.price))}
-                    </p>
+            {items.map(item => {
+              const unitPrice = getQuoteItemUnitPrice(item);
+              const lineTotal = getQuoteItemLineTotal(item);
+
+              return (
+                <div
+                  key={`quote-item-${item.batchId ?? getQuoteItemDisplayName(item)}-${item.quantity}-${unitPrice ?? "legacy"}`}
+                  className="p-3 border rounded-lg bg-muted/30"
+                >
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <p className="font-medium">
+                        {getQuoteItemDisplayName(item)}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Qty: {item.quantity}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-mono">
+                        {unitPrice !== null ? formatCurrency(unitPrice) : "—"}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {lineTotal !== null ? formatCurrency(lineTotal) : "—"}
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </InspectorSection>

--- a/server/ordersDb.legacyQuoteCompatibility.test.ts
+++ b/server/ordersDb.legacyQuoteCompatibility.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { convertQuoteToSale, getOrderById } from "./ordersDb";
+import { getDb } from "./db";
+
+vi.mock("./db", () => ({
+  getDb: vi.fn(),
+}));
+
+function createSelectChain(result: unknown) {
+  const chain: Record<string, unknown> = {};
+  const methods = ["from", "where", "limit", "for", "orderBy"];
+
+  for (const method of methods) {
+    chain[method] = vi.fn(() => chain);
+  }
+
+  chain.then = (resolve: (value: unknown) => unknown) =>
+    Promise.resolve(resolve(result));
+
+  return chain;
+}
+
+function createTransactionMock(selectResults: unknown[]) {
+  let selectIndex = 0;
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+
+  const tx = {
+    select: vi.fn(() => createSelectChain(selectResults[selectIndex++] ?? [])),
+    insert: vi.fn(() => ({
+      values: insertValues,
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: updateWhere,
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+
+  return { tx, insertValues, updateWhere };
+}
+
+describe("ordersDb legacy quote compatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("converts a legacy quote with price-only items into a normalized sale", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-11T19:00:00.000Z"));
+
+    const legacyQuote = {
+      id: 77,
+      orderNumber: "Q-LEGACY-001",
+      orderType: "QUOTE",
+      quoteStatus: null,
+      clientId: 12,
+      items: JSON.stringify([
+        {
+          batchId: 42,
+          displayName: "Legacy Flower",
+          quantity: 2,
+          price: "12.50",
+        },
+      ]),
+      subtotal: "25.00",
+      tax: "0",
+      discount: "0",
+      total: "25.00",
+      totalCogs: null,
+      totalMargin: null,
+      avgMarginPercent: null,
+      validUntil: null,
+      notes: "legacy quote",
+      createdBy: 5,
+    };
+
+    const createdSale = {
+      id: 88,
+      orderNumber: "S-1741729200000",
+      orderType: "SALE",
+      clientId: 12,
+      items: "[]",
+      tax: "0",
+      subtotal: "25.00",
+      total: "25.00",
+    };
+
+    const batch = {
+      id: 42,
+      sku: "LEG-42",
+      sampleQty: "0",
+      reservedQty: "0",
+      onHandQty: "100",
+      quarantineQty: "0",
+      holdQty: "0",
+    };
+
+    const { tx, insertValues, updateWhere } = createTransactionMock([
+      [legacyQuote],
+      [createdSale],
+      [],
+      [batch],
+    ]);
+
+    vi.mocked(getDb).mockResolvedValue({
+      transaction: async (callback: (txArg: typeof tx) => Promise<unknown>) =>
+        callback(tx),
+    } as Awaited<ReturnType<typeof getDb>>);
+
+    const result = await convertQuoteToSale({
+      quoteId: 77,
+      paymentTerms: "NET_30",
+    });
+
+    expect(result).toBe(createdSale);
+
+    const [saleInsert, lineItemInsert] = insertValues.mock.calls.map(
+      call => call[0]
+    );
+
+    expect(saleInsert).toEqual(
+      expect.objectContaining({
+        orderType: "SALE",
+        subtotal: "25",
+        total: "25",
+      })
+    );
+
+    const normalizedItems = JSON.parse(saleInsert.items as string) as Array<{
+      unitPrice: number;
+      lineTotal: number;
+      unitCogs: number;
+    }>;
+    expect(normalizedItems).toEqual([
+      expect.objectContaining({
+        unitPrice: 12.5,
+        lineTotal: 25,
+        unitCogs: 0,
+      }),
+    ]);
+
+    expect(lineItemInsert).toEqual([
+      expect.objectContaining({
+        productDisplayName: "Legacy Flower",
+        unitPrice: "12.50",
+        lineTotal: "25.00",
+        cogsPerUnit: "0.0000",
+      }),
+    ]);
+
+    expect(updateWhere).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("normalizes legacy price-only items when reading an order", async () => {
+    const legacyOrder = {
+      id: 91,
+      orderNumber: "Q-LEGACY-READ",
+      orderType: "QUOTE",
+      quoteStatus: null,
+      fulfillmentStatus: null,
+      items: JSON.stringify([
+        {
+          batchId: 7,
+          productName: "Legacy Extract",
+          quantity: 3,
+          price: "9.25",
+        },
+      ]),
+    };
+
+    const db = {
+      select: vi.fn(() => createSelectChain([legacyOrder])),
+    };
+
+    vi.mocked(getDb).mockResolvedValue(db as Awaited<ReturnType<typeof getDb>>);
+
+    const order = await getOrderById(91);
+
+    expect(order?.quoteStatus).toBe("UNSENT");
+    expect(order?.items).toEqual([
+      expect.objectContaining({
+        displayName: "Legacy Extract",
+        unitPrice: 9.25,
+        lineTotal: 27.75,
+      }),
+    ]);
+  });
+});

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -36,6 +36,7 @@ import {
   isReadyForPackingLikeStatus,
   normalizeFulfillmentStatus,
 } from "./lib/fulfillmentStatusCompatibility";
+import { parseMoneyOrNull, parseMoneyOrZero } from "./utils/money";
 // MEET-005: Import payables service for tracking vendor payables when inventory is sold
 import * as payablesService from "./services/payablesService";
 // ST-053: Import DbTransaction type for proper typing
@@ -194,6 +195,113 @@ export interface ConvertQuoteToSaleInput {
     | "CONSIGNMENT";
   cashPayment?: number;
   notes?: string;
+}
+
+type OrderItemLike = Partial<OrderItem> & {
+  batchId?: number | string | null;
+  displayName?: string | null;
+  originalName?: string | null;
+  productName?: string | null;
+  quantity?: number | string | null;
+  unitPrice?: number | string | null;
+  price?: number | string | null;
+  lineTotal?: number | string | null;
+  unitCogs?: number | string | null;
+  cogsPerUnit?: number | string | null;
+  lineCogs?: number | string | null;
+  unitMargin?: number | string | null;
+  lineMargin?: number | string | null;
+  marginPercent?: number | string | null;
+  overridePrice?: number | string | null;
+  overrideCogs?: number | string | null;
+};
+
+function normalizeStoredOrderItem(rawItem: unknown): OrderItem {
+  if (!rawItem || typeof rawItem !== "object") {
+    throw new Error("Order contains an invalid line item payload");
+  }
+
+  const item = rawItem as OrderItemLike;
+  const batchId = Number(item.batchId);
+  if (!Number.isFinite(batchId) || batchId <= 0) {
+    throw new Error("Order contains an item with a missing batchId");
+  }
+
+  const quantity = parseMoneyOrZero(item.quantity);
+  const unitPrice = parseMoneyOrZero(item.unitPrice ?? item.price);
+  const lineTotal = parseMoneyOrNull(item.lineTotal) ?? unitPrice * quantity;
+  const unitCogs = parseMoneyOrZero(item.unitCogs ?? item.cogsPerUnit);
+  const lineCogs = parseMoneyOrNull(item.lineCogs) ?? unitCogs * quantity;
+  const unitMargin = parseMoneyOrNull(item.unitMargin) ?? unitPrice - unitCogs;
+  const lineMargin = parseMoneyOrNull(item.lineMargin) ?? lineTotal - lineCogs;
+  const marginPercent =
+    parseMoneyOrNull(item.marginPercent) ??
+    (unitPrice > 0 ? (unitMargin / unitPrice) * 100 : 0);
+
+  const cogsMode = item.cogsMode === "RANGE" ? "RANGE" : "FIXED";
+  const cogsSource =
+    item.cogsSource &&
+    [
+      "FIXED",
+      "LOW",
+      "MIDPOINT",
+      "HIGH",
+      "CLIENT_ADJUSTMENT",
+      "RULE",
+      "MANUAL",
+    ].includes(item.cogsSource)
+      ? item.cogsSource
+      : "MANUAL";
+  const effectiveCogsBasis =
+    item.effectiveCogsBasis &&
+    ["LOW", "MID", "HIGH", "MANUAL"].includes(item.effectiveCogsBasis)
+      ? item.effectiveCogsBasis
+      : "MANUAL";
+  const displayName =
+    item.displayName ||
+    item.productName ||
+    item.originalName ||
+    `Batch ${batchId}`;
+
+  return {
+    batchId,
+    displayName,
+    originalName: item.originalName || displayName,
+    quantity,
+    unitPrice,
+    isSample: Boolean(item.isSample),
+    unitCogs,
+    originalCogsPerUnit: parseMoneyOrNull(item.originalCogsPerUnit) ?? unitCogs,
+    cogsMode,
+    cogsSource,
+    appliedRule: item.appliedRule,
+    effectiveCogsBasis,
+    originalRangeMin: parseMoneyOrNull(item.originalRangeMin),
+    originalRangeMax: parseMoneyOrNull(item.originalRangeMax),
+    isBelowVendorRange: Boolean(item.isBelowVendorRange),
+    belowRangeReason:
+      typeof item.belowRangeReason === "string"
+        ? item.belowRangeReason
+        : undefined,
+    unitMargin,
+    marginPercent,
+    lineTotal,
+    lineCogs,
+    lineMargin,
+    overridePrice: parseMoneyOrNull(item.overridePrice) ?? undefined,
+    overrideCogs: parseMoneyOrNull(item.overrideCogs) ?? undefined,
+  };
+}
+
+function parseStoredOrderItems(items: unknown): OrderItem[] {
+  const parsedItems =
+    typeof items === "string" ? JSON.parse(items) : (items as unknown);
+
+  if (!Array.isArray(parsedItems)) {
+    return [];
+  }
+
+  return parsedItems.map(normalizeStoredOrderItem);
 }
 
 function normalizeOrderRecord<
@@ -578,8 +686,7 @@ export async function getOrderById(id: number): Promise<Order | null> {
   let parsedItems: OrderItem[] = [];
   if (order.items) {
     try {
-      parsedItems =
-        typeof order.items === "string" ? JSON.parse(order.items) : order.items;
+      parsedItems = parseStoredOrderItems(order.items);
     } catch (e) {
       console.error(`Failed to parse items for order ${order.id}:`, e);
       throw new Error(
@@ -631,10 +738,7 @@ export async function getOrdersByClient(
     let parsedItems: OrderItem[] = [];
     if (order.items) {
       try {
-        parsedItems =
-          typeof order.items === "string"
-            ? JSON.parse(order.items)
-            : order.items;
+        parsedItems = parseStoredOrderItems(order.items);
       } catch (e) {
         console.error(`Failed to parse items for order ${order.id}:`, e);
         throw new Error(
@@ -845,10 +949,7 @@ export async function getAllOrders(filters?: {
     let parsedItems: OrderItem[] = [];
     if (row.orders.items) {
       try {
-        parsedItems =
-          typeof row.orders.items === "string"
-            ? JSON.parse(row.orders.items)
-            : row.orders.items;
+        parsedItems = parseStoredOrderItems(row.orders.items);
       } catch (e) {
         console.error(`Failed to parse items for order ${row.orders.id}:`, e);
         throw new Error(
@@ -1140,7 +1241,14 @@ export async function convertQuoteToSale(
     }
 
     // 2. Parse quote items
-    const quoteItems = JSON.parse(quote.items as string) as OrderItem[];
+    const quoteItems = parseStoredOrderItems(quote.items);
+    const subtotal = quoteItems.reduce((sum, item) => sum + item.lineTotal, 0);
+    const totalCogs = quoteItems.reduce((sum, item) => sum + item.lineCogs, 0);
+    const totalMargin = subtotal - totalCogs;
+    const avgMarginPercent = subtotal > 0 ? (totalMargin / subtotal) * 100 : 0;
+    const tax = parseMoneyOrZero(quote.tax);
+    const discount = parseMoneyOrZero(quote.discount);
+    const total = parseMoneyOrNull(quote.total) ?? subtotal + tax - discount;
 
     // 3. Calculate due date
     const dueDate = calculateDueDate(input.paymentTerms);
@@ -1153,14 +1261,14 @@ export async function convertQuoteToSale(
       orderNumber: saleNumber,
       orderType: "SALE",
       clientId: quote.clientId,
-      items: quote.items,
-      subtotal: quote.subtotal,
-      tax: quote.tax,
-      discount: quote.discount,
-      total: quote.total,
-      totalCogs: quote.totalCogs,
-      totalMargin: quote.totalMargin,
-      avgMarginPercent: quote.avgMarginPercent,
+      items: JSON.stringify(quoteItems),
+      subtotal: subtotal.toString(),
+      tax: tax.toString(),
+      discount: discount.toString(),
+      total: total.toString(),
+      totalCogs: totalCogs.toString(),
+      totalMargin: totalMargin.toString(),
+      avgMarginPercent: avgMarginPercent.toString(),
       paymentTerms: input.paymentTerms,
       cashPayment: input.cashPayment?.toString() || "0",
       dueDate: dueDate,
@@ -1279,8 +1387,7 @@ export async function exportOrder(
   }
 
   // Parse items
-  const items =
-    typeof order.items === "string" ? JSON.parse(order.items) : order.items;
+  const items = parseStoredOrderItems(order.items);
 
   // Build export data
   const exportData = {

--- a/server/routers/quotes.ts
+++ b/server/routers/quotes.ts
@@ -332,12 +332,17 @@ export const quotesRouter = router({
                 displayName?: string;
                 productName?: string;
                 quantity: number;
-                unitPrice: number;
+                unitPrice?: number | string | null;
+                price?: number | string | null;
+                lineTotal?: number | string | null;
               }) => ({
                 name: item.displayName || item.productName || "Product",
                 quantity: Number(item.quantity),
-                unitPrice: Number(item.unitPrice),
-                total: Number(item.quantity) * Number(item.unitPrice),
+                unitPrice: Number(item.unitPrice ?? item.price ?? 0),
+                total:
+                  Number(item.lineTotal ?? 0) ||
+                  Number(item.quantity) *
+                    Number(item.unitPrice ?? item.price ?? 0),
               })
             );
           } catch {


### PR DESCRIPTION
## Summary
- normalize legacy quote items before quote-to-sale conversion and order reads
- keep quote send/export and the quotes work surface compatible with price-only legacy items
- add regression coverage for converting and reading legacy quote payloads

## Verification
- pnpm exec vitest run server/ordersDb.legacyQuoteCompatibility.test.ts server/routers/quotes.test.ts
- pnpm check
- pnpm lint
- pnpm build
- pnpm test