### PR TITLE
fix(batches): tolerate staging schema drift

### DIFF
--- a/server/inventoryDb.ts
+++ b/server/inventoryDb.ts
@@ -5,7 +5,7 @@
 
 import { eq, and, or, like, desc, asc, sql, isNull } from "drizzle-orm";
 import { safeInArray } from "./lib/sqlSafety";
-import { hasPhotographyCompleteFlagColumn } from "./lib/photographyCompleteCompatibility";
+import { getCompatibleBatchSelect } from "./lib/batchColumnCompatibility";
 import { getDb } from "./db";
 import { AppError } from "./_core/errors";
 import cache, { CacheKeys, CacheTTL } from "./_core/cache";
@@ -49,52 +49,6 @@ const safeProductSelect = {
   createdAt: products.createdAt,
   updatedAt: products.updatedAt,
 };
-
-async function getCompatibleBatchSelect() {
-  const hasPhotographyFlag = await hasPhotographyCompleteFlagColumn();
-  const isPhotographyCompleteSelect = hasPhotographyFlag
-    ? batches.isPhotographyComplete
-    : sql<boolean>`CASE
-        WHEN ${batches.batchStatus} = 'PHOTOGRAPHY_COMPLETE' THEN true
-        ELSE false
-      END`.as("isPhotographyComplete");
-
-  return {
-    id: batches.id,
-    code: batches.code,
-    deletedAt: batches.deletedAt,
-    version: batches.version,
-    sku: batches.sku,
-    productId: batches.productId,
-    lotId: batches.lotId,
-    batchStatus: batches.batchStatus,
-    isPhotographyComplete: isPhotographyCompleteSelect,
-    statusId: batches.statusId,
-    grade: batches.grade,
-    isSample: batches.isSample,
-    sampleOnly: batches.sampleOnly,
-    sampleAvailable: batches.sampleAvailable,
-    cogsMode: batches.cogsMode,
-    unitCogs: batches.unitCogs,
-    unitCogsMin: batches.unitCogsMin,
-    unitCogsMax: batches.unitCogsMax,
-    paymentTerms: batches.paymentTerms,
-    ownershipType: batches.ownershipType,
-    amountPaid: batches.amountPaid,
-    metadata: batches.metadata,
-    photoSessionEventId: batches.photoSessionEventId,
-    onHandQty: batches.onHandQty,
-    sampleQty: batches.sampleQty,
-    reservedQty: batches.reservedQty,
-    quarantineQty: batches.quarantineQty,
-    holdQty: batches.holdQty,
-    defectiveQty: batches.defectiveQty,
-    publishEcom: batches.publishEcom,
-    publishB2b: batches.publishB2b,
-    createdAt: batches.createdAt,
-    updatedAt: batches.updatedAt,
-  };
-}
 
 // ============================================================================
 // VENDOR QUERIES (DEPRECATED - Use Supplier functions below)
@@ -724,9 +678,10 @@ export async function createBatch(batch: InsertBatch) {
 export async function getBatchById(id: number) {
   const db = await getDb();
   if (!db) return null;
+  const batchSelect = await getCompatibleBatchSelect();
 
   const result = await db
-    .select()
+    .select(batchSelect)
     .from(batches)
     .where(eq(batches.id, id))
     .limit(1);
@@ -736,9 +691,10 @@ export async function getBatchById(id: number) {
 export async function getBatchByCode(code: string) {
   const db = await getDb();
   if (!db) return null;
+  const batchSelect = await getCompatibleBatchSelect();
 
   const result = await db
-    .select()
+    .select(batchSelect)
     .from(batches)
     .where(eq(batches.code, code))
     .limit(1);
@@ -907,10 +863,11 @@ export async function getBatchesByIds(
 ): Promise<Map<number, typeof batches.$inferSelect>> {
   const db = await getDb();
   if (!db || batchIds.length === 0) return new Map();
+  const batchSelect = await getCompatibleBatchSelect();
 
   // Use IN clause for bulk fetch
   const result = await db
-    .select()
+    .select(batchSelect)
     .from(batches)
     .where(
       sql`${batches.id} IN (${sql.join(

--- a/server/lib/batchColumnCompatibility.test.ts
+++ b/server/lib/batchColumnCompatibility.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { batches } from "../../drizzle/schema";
+import {
+  getCompatibleBatchSelect,
+  resetBatchColumnCompatibilityCacheForTests,
+} from "./batchColumnCompatibility";
+import { getDb } from "../db";
+
+vi.mock("../db", () => ({
+  getDb: vi.fn(),
+}));
+
+describe("batchColumnCompatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBatchColumnCompatibilityCacheForTests();
+  });
+
+  it("returns native batch columns when the full schema is available", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValue([
+        [
+          { COLUMN_NAME: "deleted_at" },
+          { COLUMN_NAME: "version" },
+          { COLUMN_NAME: "isPhotographyComplete" },
+          { COLUMN_NAME: "paymentTerms" },
+          { COLUMN_NAME: "ownership_type" },
+          { COLUMN_NAME: "amountPaid" },
+          { COLUMN_NAME: "photo_session_event_id" },
+          { COLUMN_NAME: "quarantineQty" },
+          { COLUMN_NAME: "holdQty" },
+          { COLUMN_NAME: "defectiveQty" },
+          { COLUMN_NAME: "publishEcom" },
+          { COLUMN_NAME: "publishB2b" },
+        ],
+      ]);
+
+    vi.mocked(getDb).mockResolvedValue({
+      execute,
+    } as Awaited<ReturnType<typeof getDb>>);
+
+    const select = await getCompatibleBatchSelect();
+
+    expect(select.deletedAt).toBe(batches.deletedAt);
+    expect(select.isPhotographyComplete).toBe(batches.isPhotographyComplete);
+    expect(select.paymentTerms).toBe(batches.paymentTerms);
+    expect(select.ownershipType).toBe(batches.ownershipType);
+    expect(select.amountPaid).toBe(batches.amountPaid);
+  });
+
+  it("synthesizes safe defaults for missing optional batch columns", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValue([
+        [
+          { COLUMN_NAME: "id" },
+          { COLUMN_NAME: "code" },
+          { COLUMN_NAME: "sku" },
+          { COLUMN_NAME: "productId" },
+          { COLUMN_NAME: "lotId" },
+          { COLUMN_NAME: "batchStatus" },
+          { COLUMN_NAME: "onHandQty" },
+          { COLUMN_NAME: "sampleQty" },
+          { COLUMN_NAME: "reservedQty" },
+          { COLUMN_NAME: "createdAt" },
+          { COLUMN_NAME: "updatedAt" },
+        ],
+      ]);
+
+    vi.mocked(getDb).mockResolvedValue({
+      execute,
+    } as Awaited<ReturnType<typeof getDb>>);
+
+    const select = await getCompatibleBatchSelect();
+
+    expect(select.isPhotographyComplete).not.toBe(
+      batches.isPhotographyComplete
+    );
+    expect(select.paymentTerms).not.toBe(batches.paymentTerms);
+    expect(select.ownershipType).not.toBe(batches.ownershipType);
+    expect(select.amountPaid).not.toBe(batches.amountPaid);
+    expect(select.photoSessionEventId).not.toBe(batches.photoSessionEventId);
+  });
+});

--- a/server/lib/batchColumnCompatibility.ts
+++ b/server/lib/batchColumnCompatibility.ts
@@ -1,0 +1,170 @@
+import { sql } from "drizzle-orm";
+
+import { logger } from "../_core/logger";
+import { getDb } from "../db";
+import { batches } from "../../drizzle/schema";
+
+let batchColumnsCache: Set<string> | null | undefined;
+let batchColumnsPromise: Promise<Set<string> | null> | undefined;
+
+function hasColumn(columns: Set<string> | null, columnName: string): boolean {
+  return columns === null || columns.has(columnName);
+}
+
+async function detectBatchColumns(): Promise<Set<string> | null> {
+  const db = await getDb();
+  if (!db) {
+    return null;
+  }
+
+  try {
+    const [rows] = await db.execute(
+      `SELECT COLUMN_NAME
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = 'batches'`
+    );
+
+    if (!Array.isArray(rows)) {
+      return null;
+    }
+
+    return new Set(
+      rows
+        .map(row =>
+          typeof row === "object" && row !== null && "COLUMN_NAME" in row
+            ? String(row.COLUMN_NAME)
+            : ""
+        )
+        .filter(Boolean)
+    );
+  } catch (error) {
+    logger.warn(
+      { error },
+      "Failed to inspect batches schema; assuming modern batch columns"
+    );
+    return null;
+  }
+}
+
+export async function getBatchColumnNames(): Promise<Set<string> | null> {
+  if (batchColumnsCache !== undefined) {
+    return batchColumnsCache;
+  }
+
+  if (batchColumnsPromise) {
+    return batchColumnsPromise;
+  }
+
+  batchColumnsPromise = detectBatchColumns()
+    .then(columns => {
+      batchColumnsCache = columns;
+      batchColumnsPromise = undefined;
+      return columns;
+    })
+    .catch(error => {
+      batchColumnsPromise = undefined;
+      throw error;
+    });
+
+  return batchColumnsPromise;
+}
+
+export async function getCompatibleBatchSelect() {
+  const columns = await getBatchColumnNames();
+
+  const isPhotographyCompleteSelect = hasColumn(
+    columns,
+    "isPhotographyComplete"
+  )
+    ? batches.isPhotographyComplete
+    : sql<boolean>`CASE
+        WHEN ${batches.batchStatus} = 'PHOTOGRAPHY_COMPLETE' THEN true
+        ELSE false
+      END`.as("isPhotographyComplete");
+
+  return {
+    id: batches.id,
+    code: batches.code,
+    deletedAt: hasColumn(columns, "deleted_at")
+      ? batches.deletedAt
+      : sql<Date | null>`NULL`.as("deletedAt"),
+    version: hasColumn(columns, "version")
+      ? batches.version
+      : sql<number>`1`.as("version"),
+    sku: batches.sku,
+    productId: batches.productId,
+    lotId: batches.lotId,
+    batchStatus: batches.batchStatus,
+    isPhotographyComplete: isPhotographyCompleteSelect,
+    statusId: hasColumn(columns, "statusId")
+      ? batches.statusId
+      : sql<number | null>`NULL`.as("statusId"),
+    grade: batches.grade,
+    isSample: hasColumn(columns, "isSample")
+      ? batches.isSample
+      : sql<number>`0`.as("isSample"),
+    sampleOnly: hasColumn(columns, "sampleOnly")
+      ? batches.sampleOnly
+      : sql<number>`0`.as("sampleOnly"),
+    sampleAvailable: hasColumn(columns, "sampleAvailable")
+      ? batches.sampleAvailable
+      : sql<number>`0`.as("sampleAvailable"),
+    cogsMode: hasColumn(columns, "cogsMode")
+      ? batches.cogsMode
+      : sql<"FIXED" | "RANGE">`'FIXED'`.as("cogsMode"),
+    unitCogs: hasColumn(columns, "unitCogs")
+      ? batches.unitCogs
+      : sql<string | null>`NULL`.as("unitCogs"),
+    unitCogsMin: hasColumn(columns, "unitCogsMin")
+      ? batches.unitCogsMin
+      : sql<string | null>`NULL`.as("unitCogsMin"),
+    unitCogsMax: hasColumn(columns, "unitCogsMax")
+      ? batches.unitCogsMax
+      : sql<string | null>`NULL`.as("unitCogsMax"),
+    paymentTerms: hasColumn(columns, "paymentTerms")
+      ? batches.paymentTerms
+      : sql<(typeof batches.$inferSelect)["paymentTerms"]>`'NET_30'`.as(
+          "paymentTerms"
+        ),
+    ownershipType: hasColumn(columns, "ownership_type")
+      ? batches.ownershipType
+      : sql<(typeof batches.$inferSelect)["ownershipType"]>`'CONSIGNED'`.as(
+          "ownershipType"
+        ),
+    amountPaid: hasColumn(columns, "amountPaid")
+      ? batches.amountPaid
+      : sql<string>`'0'`.as("amountPaid"),
+    metadata: hasColumn(columns, "metadata")
+      ? batches.metadata
+      : sql<string | null>`NULL`.as("metadata"),
+    photoSessionEventId: hasColumn(columns, "photo_session_event_id")
+      ? batches.photoSessionEventId
+      : sql<number | null>`NULL`.as("photoSessionEventId"),
+    onHandQty: batches.onHandQty,
+    sampleQty: batches.sampleQty,
+    reservedQty: batches.reservedQty,
+    quarantineQty: hasColumn(columns, "quarantineQty")
+      ? batches.quarantineQty
+      : sql<string>`'0'`.as("quarantineQty"),
+    holdQty: hasColumn(columns, "holdQty")
+      ? batches.holdQty
+      : sql<string>`'0'`.as("holdQty"),
+    defectiveQty: hasColumn(columns, "defectiveQty")
+      ? batches.defectiveQty
+      : sql<string>`'0'`.as("defectiveQty"),
+    publishEcom: hasColumn(columns, "publishEcom")
+      ? batches.publishEcom
+      : sql<number>`0`.as("publishEcom"),
+    publishB2b: hasColumn(columns, "publishB2b")
+      ? batches.publishB2b
+      : sql<number>`0`.as("publishB2b"),
+    createdAt: batches.createdAt,
+    updatedAt: batches.updatedAt,
+  };
+}
+
+export function resetBatchColumnCompatibilityCacheForTests(): void {
+  batchColumnsCache = undefined;
+  batchColumnsPromise = undefined;
+}

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -5,6 +5,7 @@
 
 import { eq, and, desc, sql, isNull, or, type SQL } from "drizzle-orm";
 import { safeInArray } from "./lib/sqlSafety";
+import { getCompatibleBatchSelect } from "./lib/batchColumnCompatibility";
 import { getDb } from "./db";
 import {
   orders,
@@ -388,11 +389,12 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
     // 2. Process each item and calculate COGS
     // IMPORTANT: Lock batches with FOR UPDATE to prevent race conditions
     const processedItems: OrderItem[] = [];
+    const batchSelect = await getCompatibleBatchSelect();
 
     for (const item of input.items) {
       // Get batch details with row-level lock to prevent concurrent modifications
       const batch = await tx
-        .select()
+        .select(batchSelect)
         .from(batches)
         .where(eq(batches.id, item.batchId))
         .limit(1)
@@ -586,7 +588,7 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
         // Re-fetch with lock to ensure we have latest quantity
         // (though we already locked earlier, this ensures consistency)
         const lockedBatch = await tx
-          .select()
+          .select(batchSelect)
           .from(batches)
           .where(eq(batches.id, item.batchId))
           .limit(1)
@@ -1242,6 +1244,7 @@ export async function convertQuoteToSale(
 
     // 2. Parse quote items
     const quoteItems = parseStoredOrderItems(quote.items);
+    const batchSelect = await getCompatibleBatchSelect();
     const subtotal = quoteItems.reduce((sum, item) => sum + item.lineTotal, 0);
     const totalCogs = quoteItems.reduce((sum, item) => sum + item.lineCogs, 0);
     const totalMargin = subtotal - totalCogs;
@@ -1298,7 +1301,7 @@ export async function convertQuoteToSale(
     for (const item of quoteItems) {
       // Lock batch row to prevent concurrent modifications
       const batch = await tx
-        .select()
+        .select(batchSelect)
         .from(batches)
         .where(eq(batches.id, item.batchId))
         .limit(1)
@@ -1518,8 +1521,9 @@ export async function confirmDraftOrder(input: {
     // INV-002: Lock all batch rows with FOR UPDATE to prevent concurrent modifications
     // This ensures that if two confirmations happen simultaneously, one will wait for the other
     // BUG-115: Use safeInArray to prevent crash if batchIds is somehow empty
+    const batchSelect = await getCompatibleBatchSelect();
     const lockedBatches = await tx
-      .select()
+      .select(batchSelect)
       .from(batches)
       .where(safeInArray(batches.id, batchIds))
       .for("update");
@@ -1723,10 +1727,11 @@ export async function updateDraftOrder(input: {
       // Process each item and calculate COGS
       const processedItems: OrderItem[] = [];
 
+      const batchSelect = await getCompatibleBatchSelect();
       for (const item of input.items) {
         // Get batch details
         const batch = await tx
-          .select()
+          .select(batchSelect)
           .from(batches)
           .where(eq(batches.id, item.batchId))
           .limit(1)
@@ -2108,8 +2113,9 @@ export async function updateOrderStatus(input: {
           );
         }
 
+        const batchSelect = await getCompatibleBatchSelect();
         const [batch] = await tx
-          .select()
+          .select(batchSelect)
           .from(batches)
           .where(eq(batches.id, item.batchId));
         if (!batch) {
@@ -2523,10 +2529,11 @@ export async function processReturn(input: {
 
     // Restock inventory for each returned item
     const { inventoryMovements } = await import("../drizzle/schema");
+    const batchSelect = await getCompatibleBatchSelect();
     for (const item of items) {
       // Get current batch quantity
       const [batch] = await tx
-        .select()
+        .select(batchSelect)
         .from(batches)
         .where(eq(batches.id, item.batchId));
       if (!batch) continue;


### PR DESCRIPTION
## Summary
- add batch-column compatibility detection with safe defaults for staging drift
- use compatible batch selects in order conversion and inventory batch detail reads
- add regression coverage for legacy/missing batch-column compatibility

## Verification
- pnpm exec vitest run server/lib/batchColumnCompatibility.test.ts server/ordersDb.legacyQuoteCompatibility.test.ts server/routers/quotes.test.ts
- pnpm check
- pnpm lint
- pnpm build
- pnpm test
- vet . *(blocked: ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN not set)*