### PR TITLE
fix(quotes): surface converted sales in orders

### DIFF
--- a/server/ordersDb.legacyQuoteCompatibility.test.ts
+++ b/server/ordersDb.legacyQuoteCompatibility.test.ts
@@ -126,8 +126,12 @@ describe("ordersDb legacy quote compatibility", () => {
     expect(saleInsert).toEqual(
       expect.objectContaining({
         orderType: "SALE",
+        isDraft: false,
+        fulfillmentStatus: "READY_FOR_PACKING",
+        saleStatus: "PENDING",
         subtotal: "25",
         total: "25",
+        confirmedAt: expect.any(Date),
       })
     );
 

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -1260,10 +1260,12 @@ export async function convertQuoteToSale(
     const saleNumber = `S-${Date.now()}`;
 
     // 5. Create sale order
+    const confirmedAt = new Date();
     await tx.insert(orders).values({
       orderNumber: saleNumber,
       orderType: "SALE",
       clientId: quote.clientId,
+      isDraft: false,
       items: JSON.stringify(quoteItems),
       subtotal: subtotal.toString(),
       tax: tax.toString(),
@@ -1276,6 +1278,8 @@ export async function convertQuoteToSale(
       cashPayment: input.cashPayment?.toString() || "0",
       dueDate: dueDate,
       saleStatus: "PENDING",
+      fulfillmentStatus: "READY_FOR_PACKING",
+      confirmedAt,
       notes: input.notes || quote.notes,
       createdBy: quote.createdBy,
       convertedFromOrderId: quote.id,


### PR DESCRIPTION
## Summary
- mark quote-to-sale conversions as confirmed non-draft sales
- set explicit ready-for-packing fulfillment metadata during conversion
- extend the legacy quote conversion regression test to cover the surfaced order state

## Verification
- pnpm exec vitest run server/ordersDb.legacyQuoteCompatibility.test.ts server/routers/quotes.test.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint server/ordersDb.ts server/ordersDb.legacyQuoteCompatibility.test.ts
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- vet "Ensure converted quotes surface as confirmed sales in orders and batch-backed quote conversion works end-to-end" --agentic --agent-harness codex *(fails: collab_tool_call event schema not yet supported by vet)*