### PR TITLE
fix(orders): keep confirmed list sale-only

### DIFF
--- a/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
+++ b/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildConfirmedQueryInput } from "./OrdersWorkSurface";
+
+describe("buildConfirmedQueryInput", () => {
+  it("always constrains confirmed orders to sales", () => {
+    expect(buildConfirmedQueryInput()).toEqual({
+      orderType: "SALE",
+      isDraft: false,
+    });
+  });
+
+  it("preserves the selected fulfillment filter for sales only", () => {
+    expect(buildConfirmedQueryInput("SHIPPED")).toEqual({
+      orderType: "SALE",
+      isDraft: false,
+      fulfillmentStatus: "SHIPPED",
+    });
+  });
+});

--- a/client/src/components/work-surface/OrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/OrdersWorkSurface.tsx
@@ -244,15 +244,16 @@ const extractItems = <T,>(data: unknown): T[] => {
   return [];
 };
 
-const buildConfirmedQueryInput = (
+export const buildConfirmedQueryInput = (
   fulfillmentStatus?: string
 ): {
+  orderType: "SALE";
   isDraft: boolean;
   fulfillmentStatus?: string;
 } =>
   fulfillmentStatus && fulfillmentStatus !== "ALL"
-    ? { isDraft: false, fulfillmentStatus }
-    : { isDraft: false };
+    ? { orderType: "SALE", isDraft: false, fulfillmentStatus }
+    : { orderType: "SALE", isDraft: false };
 
 const normalizeStatus = (status?: string | null): string =>
   String(status ?? "").toUpperCase();


### PR DESCRIPTION
## Summary
- constrain confirmed orders queries to sales so converted quotes stop leaking into the Orders list
- add a focused unit test for the confirmed query contract

## Testing
- pnpm exec vitest run client/src/components/work-surface/OrdersWorkSurface.query.test.ts
- pnpm exec eslint client/src/components/work-surface/OrdersWorkSurface.tsx client/src/components/work-surface/OrdersWorkSurface.query.test.ts
- pre-push checks