### PR TITLE
fix: simplify shipping status labels

### DIFF
--- a/client/src/components/orders/OrderFulfillment.tsx
+++ b/client/src/components/orders/OrderFulfillment.tsx
@@ -39,6 +39,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { trpc } from "@/lib/trpc";
+import {
+  getFulfillmentDisplayLabel,
+  mapToFulfillmentDisplayStatus,
+} from "@/lib/fulfillmentDisplay";
 import { toast } from "sonner";
 import {
   CheckCircle,
@@ -108,16 +112,21 @@ export function OrderFulfillment({ order, onUpdate }: OrderFulfillmentProps) {
   // Status badge helper
   const getStatusBadge = () => {
     const statusConfig: Record<string, { label: string; className: string }> = {
-      READY_FOR_PACKING: {
-        label: "Ready for Packing",
+      PENDING: {
+        label: "Pending",
         className: "bg-yellow-100 text-yellow-800",
       },
-      PACKED: { label: "Packed", className: "bg-blue-100 text-blue-800" },
+      READY: { label: "Ready", className: "bg-blue-100 text-blue-800" },
       SHIPPED: { label: "Shipped", className: "bg-green-100 text-green-800" },
     };
 
+    const displayStatus =
+      mapToFulfillmentDisplayStatus(currentFulfillmentStatus) ?? "PENDING";
     const config =
-      statusConfig[currentFulfillmentStatus || "READY_FOR_PACKING"];
+      statusConfig[displayStatus] ?? {
+        label: getFulfillmentDisplayLabel(currentFulfillmentStatus),
+        className: "bg-gray-100 text-gray-800",
+      };
     return <Badge className={config.className}>{config.label}</Badge>;
   };
 

--- a/client/src/components/orders/OrderStatusActions.test.tsx
+++ b/client/src/components/orders/OrderStatusActions.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { OrderStatusActions } from "./OrderStatusActions";
 
 describe("OrderStatusActions", () => {
-  it("shows ready-for-packing transitions without the legacy pending label", async () => {
+  it("shows simplified shipping labels for ready-for-packing transitions", async () => {
     render(
       <OrderStatusActions
         currentStatus="READY_FOR_PACKING"
@@ -20,10 +20,11 @@ describe("OrderStatusActions", () => {
       screen.getByRole("button", { name: /change status/i })
     );
 
-    expect(await screen.findByText("Packed")).toBeInTheDocument();
+    expect(await screen.findByText("Ready")).toBeInTheDocument();
     expect(await screen.findByText("Shipped")).toBeInTheDocument();
     expect(await screen.findByText("Cancelled")).toBeInTheDocument();
     expect(screen.queryByText("Pending")).not.toBeInTheDocument();
     expect(screen.queryByText("Ready for Packing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Packed")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/orders/OrderStatusActions.tsx
+++ b/client/src/components/orders/OrderStatusActions.tsx
@@ -38,6 +38,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getFulfillmentDisplayLabel } from "@/lib/fulfillmentDisplay";
 import type { FulfillmentStatus } from "./OrderStatusBadge";
 
 type LegacyFulfillmentStatus = FulfillmentStatus | "PENDING";
@@ -63,8 +64,8 @@ const ORDER_STATUS_TRANSITIONS: Record<FulfillmentStatus, FulfillmentStatus[]> =
 const STATUS_LABELS: Record<FulfillmentStatus, string> = {
   DRAFT: "Draft",
   CONFIRMED: "Confirmed",
-  READY_FOR_PACKING: "Ready for Packing",
-  PACKED: "Packed",
+  READY_FOR_PACKING: "Pending",
+  PACKED: "Ready",
   SHIPPED: "Shipped",
   DELIVERED: "Delivered",
   RETURNED: "Returned",
@@ -281,7 +282,9 @@ export function OrderStatusActions({
                   )}
                 >
                   {STATUS_ICONS[status]}
-                  <span>{STATUS_LABELS[status]}</span>
+                  <span>
+                    {STATUS_LABELS[status] ?? getFulfillmentDisplayLabel(status)}
+                  </span>
                 </DropdownMenuItem>
               </React.Fragment>
             );

--- a/client/src/components/orders/OrderStatusBadge.tsx
+++ b/client/src/components/orders/OrderStatusBadge.tsx
@@ -1,5 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import {
+  getFulfillmentDisplayLabel,
+  mapToFulfillmentDisplayStatus,
+  type FulfillmentDisplayStatus,
+} from "@/lib/fulfillmentDisplay";
 
 /**
  * ARCH-003: All fulfillment statuses from the order state machine
@@ -27,7 +32,7 @@ interface OrderStatusBadgeProps {
  * backgrounds fails contrast for yellow, amber, blue, and cyan variants.
  */
 const STATUS_CONFIG: Record<
-  FulfillmentStatus,
+  FulfillmentDisplayStatus,
   { label: string; className: string }
 > = {
   DRAFT: {
@@ -38,12 +43,12 @@ const STATUS_CONFIG: Record<
     label: "Confirmed",
     className: "bg-blue-100 text-blue-900 border-blue-400",
   },
-  READY_FOR_PACKING: {
-    label: "Ready for Packing",
+  PENDING: {
+    label: "Pending",
     className: "bg-yellow-100 text-yellow-900 border-yellow-500",
   },
-  PACKED: {
-    label: "Packed",
+  READY: {
+    label: "Ready",
     className: "bg-purple-100 text-purple-900 border-purple-400",
   },
   SHIPPED: {
@@ -73,9 +78,11 @@ const STATUS_CONFIG: Record<
 };
 
 export function OrderStatusBadge({ status, className }: OrderStatusBadgeProps) {
-  const normalizedStatus = status === "PENDING" ? "READY_FOR_PACKING" : status;
-  const config = STATUS_CONFIG[normalizedStatus as FulfillmentStatus] || {
-    label: normalizedStatus,
+  const displayStatus =
+    mapToFulfillmentDisplayStatus(status) ??
+    mapToFulfillmentDisplayStatus(status === "PENDING" ? "READY_FOR_PACKING" : status);
+  const config = (displayStatus && STATUS_CONFIG[displayStatus]) || {
+    label: getFulfillmentDisplayLabel(status),
     className: "bg-gray-100 text-gray-800 border-gray-300",
   };
 

--- a/client/src/components/orders/OrderStatusTimeline.tsx
+++ b/client/src/components/orders/OrderStatusTimeline.tsx
@@ -1,15 +1,14 @@
 import { trpc } from "@/lib/trpc";
 import { format } from "date-fns";
 import { CheckCircle2, Circle } from "lucide-react";
+import { getFulfillmentDisplayLabel } from "@/lib/fulfillmentDisplay";
 
 interface OrderStatusTimelineProps {
   orderId: number;
 }
 
 const formatFulfillmentStatus = (status: string | null | undefined) =>
-  status === "READY_FOR_PACKING" || status === "PENDING"
-    ? "Ready for Packing"
-    : status || "Unknown";
+  getFulfillmentDisplayLabel(status);
 
 export function OrderStatusTimeline({ orderId }: OrderStatusTimelineProps) {
   const { data: history, isLoading } =

--- a/client/src/components/orders/ShipOrderModal.tsx
+++ b/client/src/components/orders/ShipOrderModal.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { trpc } from "@/lib/trpc";
+import { getFulfillmentDisplayLabel } from "@/lib/fulfillmentDisplay";
 import { toast } from "sonner";
 import { AlertCircle } from "lucide-react";
 
@@ -45,7 +46,9 @@ export function ShipOrderModal({
         newStatus,
         notes: notes || undefined,
       });
-      toast.success(`Order marked as ${newStatus.toLowerCase()}`);
+      toast.success(
+        `Order marked as ${getFulfillmentDisplayLabel(newStatus).toLowerCase()}`
+      );
       setNotes(""); // Reset notes
       onSuccess();
       onClose();
@@ -63,7 +66,7 @@ export function ShipOrderModal({
 
   const actionLabel =
     normalizedCurrentStatus === "READY_FOR_PACKING"
-      ? "Mark as Packed"
+      ? "Mark as Ready"
       : "Mark as Shipped";
   const warningText =
     normalizedCurrentStatus === "PACKED"

--- a/client/src/components/orders/WorkflowStatusTracker.tsx
+++ b/client/src/components/orders/WorkflowStatusTracker.tsx
@@ -3,7 +3,7 @@
  * TER-212: Canonical state machine visualization for Quote and Sale workflows
  *
  * Quote lifecycle:  Unsent → Sent → Viewed → Converted (to Sale)
- * Sale lifecycle:   Pending → Partial/Paid (payment) + Pending → Packed → Shipped (fulfillment)
+ * Sale lifecycle:   Pending → Partial/Paid (payment) + Pending → Ready → Shipped (fulfillment)
  */
 
 import type { ReactNode } from "react";
@@ -109,10 +109,10 @@ const QUOTE_TERMINAL_STEPS: Record<string, StepConfig> = {
 const FULFILLMENT_STEPS: StepConfig[] = [
   {
     key: "READY_FOR_PACKING",
-    label: "Ready for Packing",
+    label: "Pending",
     icon: <Clock className="h-4 w-4" />,
   },
-  { key: "PACKED", label: "Packed", icon: <Package className="h-4 w-4" /> },
+  { key: "PACKED", label: "Ready", icon: <Package className="h-4 w-4" /> },
   { key: "SHIPPED", label: "Shipped", icon: <Truck className="h-4 w-4" /> },
 ];
 

--- a/client/src/components/work-surface/OrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/OrdersWorkSurface.tsx
@@ -23,6 +23,11 @@ import { useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
 import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
+import {
+  getFulfillmentDisplayLabel,
+  mapToFulfillmentDisplayStatus,
+  type FulfillmentDisplayStatus,
+} from "@/lib/fulfillmentDisplay";
 import { toast } from "sonner";
 import { format } from "date-fns";
 import { usePermissions } from "@/hooks/usePermissions";
@@ -160,8 +165,8 @@ type FulfillmentStatusValue = Exclude<
 // WSQA-003: Added RETURNED, RESTOCKED, RETURNED_TO_VENDOR statuses
 const FULFILLMENT_STATUSES = [
   { value: "ALL", label: "All" },
-  { value: "READY_FOR_PACKING", label: "Ready for Packing" },
-  { value: "PACKED", label: "Packed" },
+  { value: "READY_FOR_PACKING", label: "Pending" },
+  { value: "PACKED", label: "Ready" },
   { value: "SHIPPED", label: "Shipped" },
   { value: "DELIVERED", label: "Delivered" },
   { value: "RETURNED", label: "Returned" },
@@ -190,9 +195,11 @@ const ORDER_SORT_OPTIONS: Array<{ value: OrdersSortKey; label: string }> = [
 ];
 
 // WSQA-003: Added return status icons
-const STATUS_ICONS: Record<string, ReactNode> = {
-  READY_FOR_PACKING: <Clock className="h-4 w-4" />,
-  PACKED: <CheckCircle2 className="h-4 w-4" />,
+const STATUS_ICONS: Record<FulfillmentDisplayStatus, ReactNode> = {
+  DRAFT: <FileText className="h-4 w-4" />,
+  CONFIRMED: <CheckCircle2 className="h-4 w-4" />,
+  PENDING: <Clock className="h-4 w-4" />,
+  READY: <CheckCircle2 className="h-4 w-4" />,
   SHIPPED: <Truck className="h-4 w-4" />,
   DELIVERED: <CheckCircle2 className="h-4 w-4" />,
   RETURNED: <RefreshCw className="h-4 w-4" />,
@@ -202,16 +209,17 @@ const STATUS_ICONS: Record<string, ReactNode> = {
 };
 
 // WSQA-003: Added return status colors
-const STATUS_COLORS: Record<string, string> = {
-  READY_FOR_PACKING: "bg-yellow-100 text-yellow-800",
-  PACKED: "bg-purple-100 text-purple-800",
+const STATUS_COLORS: Record<FulfillmentDisplayStatus, string> = {
+  DRAFT: "bg-gray-100 text-gray-800",
+  CONFIRMED: "bg-blue-100 text-blue-800",
+  PENDING: "bg-yellow-100 text-yellow-800",
+  READY: "bg-purple-100 text-purple-800",
   SHIPPED: "bg-indigo-100 text-indigo-800",
   DELIVERED: "bg-green-100 text-green-800",
   RETURNED: "bg-orange-100 text-orange-800",
   RESTOCKED: "bg-emerald-100 text-emerald-800",
   RETURNED_TO_VENDOR: "bg-amber-100 text-amber-800",
   CANCELLED: "bg-red-100 text-red-800",
-  DRAFT: "bg-gray-100 text-gray-800",
 };
 
 // ============================================================================
@@ -287,7 +295,11 @@ export function getStatusFilterExitMessage(params: {
     return null;
   }
 
-  return `${params.orderNumber} moved to ${normalizedTarget} and is now hidden by the ${normalizedFilter.toLowerCase()} filter. Switch to All to keep tracking it.`;
+  return `${params.orderNumber} moved to ${getFulfillmentDisplayLabel(
+    normalizedTarget
+  )} and is now hidden by the ${getFulfillmentDisplayLabel(
+    normalizedFilter
+  ).toLowerCase()} filter. Switch to All to keep tracking it.`;
 }
 
 // ============================================================================
@@ -301,16 +313,19 @@ function OrderStatusBadge({
   status?: string | null;
   isDraft?: boolean;
 }) {
-  const displayStatus = isDraft
-    ? "DRAFT"
-    : normalizeFulfillmentStatus(status) || "READY_FOR_PACKING";
+  const displayStatus = (
+    isDraft
+      ? "DRAFT"
+      : mapToFulfillmentDisplayStatus(normalizeFulfillmentStatus(status)) ||
+        "PENDING"
+  ) as FulfillmentDisplayStatus;
   return (
     <Badge
       variant="outline"
       className={cn("gap-1", STATUS_COLORS[displayStatus])}
     >
       {STATUS_ICONS[displayStatus]}
-      {displayStatus}
+      {getFulfillmentDisplayLabel(displayStatus)}
     </Badge>
   );
 }
@@ -1030,6 +1045,9 @@ export function OrdersWorkSurface() {
           normalizeFulfillmentStatus(o.fulfillmentStatus) ===
           "READY_FOR_PACKING"
       ).length,
+      ready: confirmedOrders.filter(
+        (o: Order) => normalizeFulfillmentStatus(o.fulfillmentStatus) === "PACKED"
+      ).length,
       shipped: confirmedOrders.filter(
         (o: Order) => o.fulfillmentStatus === "SHIPPED"
       ).length,
@@ -1321,9 +1339,15 @@ export function OrdersWorkSurface() {
                 </span>
               </span>
               <span>
-                Ready for Packing:{" "}
+                Pending:{" "}
                 <span className="font-semibold text-foreground">
                   {stats.pending}
+                </span>
+              </span>
+              <span>
+                Ready:{" "}
+                <span className="font-semibold text-foreground">
+                  {stats.ready}
                 </span>
               </span>
               <span>

--- a/client/src/lib/fulfillmentDisplay.test.ts
+++ b/client/src/lib/fulfillmentDisplay.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFulfillmentDisplayLabel,
+  mapToFulfillmentDisplayStatus,
+} from "./fulfillmentDisplay";
+
+describe("fulfillmentDisplay", () => {
+  it("maps legacy shipping statuses into the simplified operator vocabulary", () => {
+    expect(mapToFulfillmentDisplayStatus("READY_FOR_PACKING")).toBe("PENDING");
+    expect(mapToFulfillmentDisplayStatus("PENDING")).toBe("PENDING");
+    expect(mapToFulfillmentDisplayStatus("PACKED")).toBe("READY");
+    expect(mapToFulfillmentDisplayStatus("SHIPPED")).toBe("SHIPPED");
+  });
+
+  it("returns user-facing labels for simplified shipping states", () => {
+    expect(getFulfillmentDisplayLabel("READY_FOR_PACKING")).toBe("Pending");
+    expect(getFulfillmentDisplayLabel("PACKED")).toBe("Ready");
+    expect(getFulfillmentDisplayLabel("SHIPPED")).toBe("Shipped");
+  });
+});

--- a/client/src/lib/fulfillmentDisplay.ts
+++ b/client/src/lib/fulfillmentDisplay.ts
@@ -1,0 +1,67 @@
+export type FulfillmentDisplayStatus =
+  | "DRAFT"
+  | "CONFIRMED"
+  | "PENDING"
+  | "READY"
+  | "SHIPPED"
+  | "DELIVERED"
+  | "RETURNED"
+  | "RESTOCKED"
+  | "RETURNED_TO_VENDOR"
+  | "CANCELLED";
+
+const DISPLAY_LABELS: Record<FulfillmentDisplayStatus, string> = {
+  DRAFT: "Draft",
+  CONFIRMED: "Confirmed",
+  PENDING: "Pending",
+  READY: "Ready",
+  SHIPPED: "Shipped",
+  DELIVERED: "Delivered",
+  RETURNED: "Returned",
+  RESTOCKED: "Restocked",
+  RETURNED_TO_VENDOR: "Returned to Supplier",
+  CANCELLED: "Cancelled",
+};
+
+const normalizeStatus = (status?: string | null): string =>
+  String(status ?? "").trim().toUpperCase();
+
+export function mapToFulfillmentDisplayStatus(
+  status?: string | null
+): FulfillmentDisplayStatus | null {
+  const normalized = normalizeStatus(status);
+
+  switch (normalized) {
+    case "DRAFT":
+      return "DRAFT";
+    case "CONFIRMED":
+      return "CONFIRMED";
+    case "PENDING":
+    case "READY_FOR_PACKING":
+      return "PENDING";
+    case "PACKED":
+      return "READY";
+    case "SHIPPED":
+      return "SHIPPED";
+    case "DELIVERED":
+      return "DELIVERED";
+    case "RETURNED":
+      return "RETURNED";
+    case "RESTOCKED":
+      return "RESTOCKED";
+    case "RETURNED_TO_VENDOR":
+      return "RETURNED_TO_VENDOR";
+    case "CANCELLED":
+      return "CANCELLED";
+    default:
+      return normalized ? null : null;
+  }
+}
+
+export function getFulfillmentDisplayLabel(status?: string | null): string {
+  const displayStatus = mapToFulfillmentDisplayStatus(status);
+  if (!displayStatus) {
+    return normalizeStatus(status) || "-";
+  }
+  return DISPLAY_LABELS[displayStatus];
+}


### PR DESCRIPTION
## Summary
- collapse READY_FOR_PACKING and PACKED to user-facing Pending and Ready labels across order surfaces
- add a shared fulfillment display helper so badges, filters, timeline, and ship actions stay aligned
- add focused regression coverage for the label mapping and order status actions

## Validation
- pnpm exec vitest run client/src/lib/fulfillmentDisplay.test.ts client/src/components/orders/OrderStatusActions.test.tsx client/src/components/work-surface/OrdersWorkSurface.query.test.ts
- pnpm exec eslint client/src/lib/fulfillmentDisplay.ts client/src/lib/fulfillmentDisplay.test.ts client/src/components/orders/OrderStatusBadge.tsx client/src/components/orders/OrderStatusActions.tsx client/src/components/orders/OrderStatusActions.test.tsx client/src/components/orders/OrderFulfillment.tsx client/src/components/orders/OrderStatusTimeline.tsx client/src/components/orders/ShipOrderModal.tsx client/src/components/orders/WorkflowStatusTracker.tsx client/src/components/work-surface/OrdersWorkSurface.tsx
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build