### PR TITLE
fix: surface canonical supplier names in accounting

### DIFF
--- a/server/routers/accounting.ts
+++ b/server/routers/accounting.ts
@@ -22,7 +22,6 @@ import {
   bills,
   payments,
   clients,
-  supplierProfiles,
 } from "../../drizzle/schema";
 import { eq, and, sql, desc, asc, inArray } from "drizzle-orm";
 import { logger } from "../_core/logger";
@@ -31,6 +30,7 @@ import {
   onPaymentReceived,
 } from "../services/notificationTriggers";
 import { postInvoiceGLEntries, postPaymentGLEntries } from "../accountingHooks";
+import { getVendorDisplayName, getVendorNameMap } from "../vendorDisplay";
 
 export const accountingRouter = router({
   // ============================================================================
@@ -144,21 +144,13 @@ export const accountingRouter = router({
         // Get outstanding payables
         const outstanding = await arApDb.getOutstandingPayables();
 
-        // Group bills by vendor
-        // Join through supplier_profiles→clients to resolve vendor names
         const byVendorResult = await db
           .select({
             vendorId: bills.vendorId,
-            vendorName: sql<string>`COALESCE(${clients.name}, CONCAT('Vendor #', ${bills.vendorId}))`,
             totalOwed: sql<number>`SUM(CAST(${bills.amountDue} AS DECIMAL(15,2)))`,
             billCount: sql<number>`COUNT(*)`,
           })
           .from(bills)
-          .leftJoin(
-            supplierProfiles,
-            eq(bills.vendorId, supplierProfiles.legacyVendorId)
-          )
-          .leftJoin(clients, eq(supplierProfiles.clientId, clients.id))
           .where(
             and(
               inArray(bills.status, ["PENDING", "PARTIAL", "OVERDUE"]),
@@ -166,8 +158,12 @@ export const accountingRouter = router({
               sql`${bills.deletedAt} IS NULL`
             )
           )
-          .groupBy(bills.vendorId, clients.name)
+          .groupBy(bills.vendorId)
           .orderBy(desc(sql`SUM(CAST(${bills.amountDue} AS DECIMAL(15,2)))`));
+
+        const vendorNameMap = await getVendorNameMap(
+          byVendorResult.map(vendor => vendor.vendorId)
+        );
 
         // Count bills by status
         const statusCounts = await db
@@ -190,7 +186,10 @@ export const accountingRouter = router({
           },
           byVendor: byVendorResult.map(v => ({
             vendorId: v.vendorId,
-            vendorName: v.vendorName || "Unknown Vendor",
+            vendorName: getVendorDisplayName(
+              v.vendorId,
+              vendorNameMap.get(v.vendorId)
+            ),
             totalOwed: Number(v.totalOwed || 0),
             billCount: Number(v.billCount || 0),
           })),
@@ -422,7 +421,6 @@ export const accountingRouter = router({
             id: bills.id,
             billNumber: bills.billNumber,
             vendorId: bills.vendorId,
-            vendorName: clients.name,
             billDate: bills.billDate,
             dueDate: bills.dueDate,
             totalAmount: bills.totalAmount,
@@ -430,7 +428,6 @@ export const accountingRouter = router({
             status: bills.status,
           })
           .from(bills)
-          .leftJoin(clients, eq(bills.vendorId, clients.id))
           .where(
             and(
               sql`CAST(${bills.amountDue} AS DECIMAL(15,2)) > 0`,
@@ -441,6 +438,10 @@ export const accountingRouter = router({
           .orderBy(asc(bills.dueDate))
           .limit(input.limit)
           .offset(input.offset);
+
+        const overdueVendorNameMap = await getVendorNameMap(
+          overdueBills.map(bill => bill.vendorId)
+        );
 
         // Get total count
         const countResult = await db
@@ -462,6 +463,10 @@ export const accountingRouter = router({
           );
           return {
             ...bill,
+            vendorName: getVendorDisplayName(
+              bill.vendorId,
+              overdueVendorNameMap.get(bill.vendorId)
+            ),
             totalAmount: Number(bill.totalAmount),
             amountDue: Number(bill.amountDue),
             daysOverdue,
@@ -1002,10 +1007,20 @@ export const accountingRouter = router({
       )
       .query(async ({ input }) => {
         const result = await arApDb.getBills(input);
+        const billItems = result.bills || result;
+        const vendorNameMap = await getVendorNameMap(
+          billItems.map(bill => bill.vendorId)
+        );
+        const billsWithVendorNames = billItems.map(bill => ({
+          ...bill,
+          vendorName: getVendorDisplayName(
+            bill.vendorId,
+            vendorNameMap.get(bill.vendorId)
+          ),
+        }));
         // BUG-034: Standardized pagination response
-        const bills = result.bills || result;
         return createSafeUnifiedResponse(
-          bills,
+          billsWithVendorNames,
           result.total || -1,
           input.limit || 50,
           input.offset || 0

--- a/server/vendorDisplay.test.ts
+++ b/server/vendorDisplay.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getVendorDisplayName } from "./vendorDisplay";
+
+describe("getVendorDisplayName", () => {
+  it("prefers the direct canonical client name", () => {
+    expect(
+      getVendorDisplayName(42, "North Coast Supply", "Legacy Mapping Name")
+    ).toBe("North Coast Supply");
+  });
+
+  it("falls back to the mapped supplier name when direct lookup is missing", () => {
+    expect(getVendorDisplayName(42, null, "Legacy Mapping Name")).toBe(
+      "Legacy Mapping Name"
+    );
+  });
+
+  it("uses a user-facing supplier fallback only when no real name is available", () => {
+    expect(getVendorDisplayName(42, null, null)).toBe("Supplier #42");
+  });
+});

--- a/server/vendorDisplay.ts
+++ b/server/vendorDisplay.ts
@@ -1,0 +1,71 @@
+import { eq, sql } from "drizzle-orm";
+
+import { clients, supplierProfiles } from "../drizzle/schema";
+import * as clientsDb from "./clientsDb";
+import { getDb } from "./db";
+
+export function getVendorDisplayName(
+  vendorId: number,
+  directClientName?: string | null,
+  mappedSupplierName?: string | null
+): string {
+  const normalizedDirectClientName = directClientName?.trim();
+  if (normalizedDirectClientName) {
+    return normalizedDirectClientName;
+  }
+
+  const normalizedMappedSupplierName = mappedSupplierName?.trim();
+  if (normalizedMappedSupplierName) {
+    return normalizedMappedSupplierName;
+  }
+
+  return `Supplier #${vendorId}`;
+}
+
+export async function getVendorNameMap(
+  vendorIds: number[]
+): Promise<Map<number, string>> {
+  const uniqueVendorIds = [...new Set(vendorIds.filter(id => id > 0))];
+  const vendorNameMap = new Map<number, string>();
+
+  await Promise.all(
+    uniqueVendorIds.map(async vendorId => {
+      const client = await clientsDb.getClientById(vendorId);
+      if (client?.name?.trim()) {
+        vendorNameMap.set(vendorId, client.name.trim());
+      }
+    })
+  );
+
+  const unresolvedVendorIds = uniqueVendorIds.filter(id => !vendorNameMap.has(id));
+  if (!unresolvedVendorIds.length) {
+    return vendorNameMap;
+  }
+
+  const db = await getDb();
+  if (!db) {
+    return vendorNameMap;
+  }
+
+  const mappedSupplierRows = await db
+    .select({
+      legacyVendorId: supplierProfiles.legacyVendorId,
+      supplierName: clients.name,
+    })
+    .from(supplierProfiles)
+    .innerJoin(clients, eq(supplierProfiles.clientId, clients.id))
+    .where(
+      sql`${supplierProfiles.legacyVendorId} IS NOT NULL AND ${supplierProfiles.legacyVendorId} IN (${sql.join(
+        unresolvedVendorIds.map(id => sql`${id}`),
+        sql`, `
+      )})`
+    );
+
+  mappedSupplierRows.forEach(row => {
+    if (row.legacyVendorId && row.supplierName?.trim()) {
+      vendorNameMap.set(row.legacyVendorId, row.supplierName.trim());
+    }
+  });
+
+  return vendorNameMap;
+}


### PR DESCRIPTION
## Summary
- add a shared vendor display resolver that prefers canonical supplier client names and falls back through legacy supplier-profile mappings
- apply the resolver to the AP summary, overdue bills, and bills list so accounting surfaces stop leaking Vendor # placeholders
- add focused regression coverage for vendor display fallback behavior

## Validation
- pnpm exec vitest run server/vendorDisplay.test.ts
- pnpm exec eslint server/vendorDisplay.ts server/vendorDisplay.test.ts server/routers/accounting.ts
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- pnpm test
- pnpm build