### PR TITLE
fix(orders): normalize ready shipping label

### DIFF
--- a/client/src/lib/fulfillmentDisplay.test.ts
+++ b/client/src/lib/fulfillmentDisplay.test.ts
@@ -8,12 +8,14 @@ describe("fulfillmentDisplay", () => {
   it("maps legacy shipping statuses into the simplified operator vocabulary", () => {
     expect(mapToFulfillmentDisplayStatus("READY_FOR_PACKING")).toBe("PENDING");
     expect(mapToFulfillmentDisplayStatus("PENDING")).toBe("PENDING");
+    expect(mapToFulfillmentDisplayStatus("READY")).toBe("READY");
     expect(mapToFulfillmentDisplayStatus("PACKED")).toBe("READY");
     expect(mapToFulfillmentDisplayStatus("SHIPPED")).toBe("SHIPPED");
   });
 
   it("returns user-facing labels for simplified shipping states", () => {
     expect(getFulfillmentDisplayLabel("READY_FOR_PACKING")).toBe("Pending");
+    expect(getFulfillmentDisplayLabel("READY")).toBe("Ready");
     expect(getFulfillmentDisplayLabel("PACKED")).toBe("Ready");
     expect(getFulfillmentDisplayLabel("SHIPPED")).toBe("Shipped");
   });

--- a/client/src/lib/fulfillmentDisplay.ts
+++ b/client/src/lib/fulfillmentDisplay.ts
@@ -39,6 +39,7 @@ export function mapToFulfillmentDisplayStatus(
     case "PENDING":
     case "READY_FOR_PACKING":
       return "PENDING";
+    case "READY":
     case "PACKED":
       return "READY";
     case "SHIPPED":


### PR DESCRIPTION
## Summary\n- treat already-normalized READY fulfillment states as the simplified Ready label\n- cover the READY mapping in fulfillment display tests\n- preserve the confirmed-orders query behavior already live on staging\n\n## Verification\n- pnpm check\n- pnpm lint\n- pnpm test\n- pnpm build\n- pnpm exec vitest run client/src/lib/fulfillmentDisplay.test.ts client/src/components/orders/OrderStatusActions.test.tsx client/src/components/work-surface/OrdersWorkSurface.query.test.ts