### PR TITLE
fix(credits): make finance workspace dashboard-first

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -580,7 +580,7 @@ function Router() {
                   component={RedirectWithTab(
                     "/credit-settings",
                     "/credits",
-                    "settings"
+                    "capacity"
                   )}
                 />
                 {/* NAV-017: Credits management page */}
@@ -589,7 +589,7 @@ function Router() {
                   component={RedirectWithTab(
                     "/credits/manage",
                     "/credits",
-                    "credits"
+                    "adjustments"
                   )}
                 />
                 <Route

--- a/client/src/config/workspaces.ts
+++ b/client/src/config/workspaces.ts
@@ -74,10 +74,13 @@ export const CREDITS_WORKSPACE = {
   description:
     "Separate issued credit adjustments from client credit capacity settings in one finance workspace.",
   tabs: [
-    { value: "credits", label: "Issued Credits" },
-    { value: "settings", label: "Capacity Settings" },
+    { value: "dashboard", label: "Dashboard" },
+    { value: "adjustments", label: "Issued Adjustments" },
+    { value: "capacity", label: "Capacity Settings" },
   ],
-} as const satisfies WorkspaceConfig<"credits" | "settings">;
+} as const satisfies WorkspaceConfig<
+  "dashboard" | "adjustments" | "capacity"
+>;
 
 export const ACCOUNTING_WORKSPACE = {
   title: "Accounting",

--- a/client/src/pages/ConsolidatedWorkspaces.test.tsx
+++ b/client/src/pages/ConsolidatedWorkspaces.test.tsx
@@ -15,6 +15,15 @@ import CreditsWorkspacePage from "./CreditsWorkspacePage";
 let mockActiveTab = "matchmaking";
 const mockSetActiveTab = vi.fn();
 const mockSetLocation = vi.fn();
+const mockCreditsSummary = {
+  totalCreditsRemaining: 1250,
+  totalCreditsUsed: 800,
+  creditCount: 3,
+  expiringWithin30Days: {
+    count: 1,
+    totalAmount: 250,
+  },
+};
 
 vi.mock("@/hooks/useQueryTabState", () => ({
   useQueryTabState: () => ({
@@ -25,6 +34,19 @@ vi.mock("@/hooks/useQueryTabState", () => ({
 
 vi.mock("wouter", () => ({
   useLocation: () => ["/inventory", mockSetLocation],
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    credits: {
+      getSummary: {
+        useQuery: () => ({
+          data: mockCreditsSummary,
+          isLoading: false,
+        }),
+      },
+    },
+  },
 }));
 
 vi.mock("@/pages/NeedsManagementPage", () => ({
@@ -132,8 +154,25 @@ describe("Consolidated workspace pages", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders Client Credit workspace with dashboard-first content", () => {
+    mockActiveTab = "dashboard";
+    render(<CreditsWorkspacePage />);
+    expect(
+      screen.getByRole("heading", { name: "Client Credit" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Client Credit Dashboard" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Review Issued Adjustments" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "Open Capacity Settings" }).length
+    ).toBeGreaterThan(0);
+  });
+
   it("renders Client Credit workspace with settings content", () => {
-    mockActiveTab = "settings";
+    mockActiveTab = "capacity";
     render(<CreditsWorkspacePage />);
     expect(
       screen.getByRole("heading", { name: "Client Credit" })

--- a/client/src/pages/CreditSettingsPage.tsx
+++ b/client/src/pages/CreditSettingsPage.tsx
@@ -323,12 +323,12 @@ export default function CreditSettingsPage({
             <Info className="h-5 w-5 text-blue-600 flex-shrink-0 mt-0.5" />
             <div className="text-sm">
               <p className="font-medium text-blue-900 dark:text-blue-100">
-                Capacity settings are not issued credits
+                Capacity settings are not issued adjustments
               </p>
               <p className="text-blue-800 dark:text-blue-200 mt-1">
                 Use this page to change client limits, score weights, and order
-                guardrails. Use the Issued Credits tab when you need to create
-                or apply a post-sale adjustment balance.
+                guardrails. Use the Issued Adjustments tab when you need to
+                create or apply a post-sale adjustment balance.
               </p>
             </div>
           </div>

--- a/client/src/pages/CreditsPage.tsx
+++ b/client/src/pages/CreditsPage.tsx
@@ -184,7 +184,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
 
   const applyCreditMutation = trpc.credits.applyCredit.useMutation({
     onSuccess: () => {
-      toast({ title: "Issued credit applied successfully" });
+      toast({ title: "Credit adjustment applied successfully" });
       setApplyCreditOpen(false);
       setApplyForm({ invoiceId: "", amount: "", notes: "" });
       setSelectedCredit(null);
@@ -192,7 +192,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
     },
     onError: error => {
       toast({
-        title: "Error applying issued credit",
+        title: "Error applying credit adjustment",
         description: error.message,
         variant: "destructive",
       });
@@ -201,12 +201,12 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
 
   const voidCreditMutation = trpc.credits.void.useMutation({
     onSuccess: () => {
-      toast({ title: "Issued credit voided successfully" });
+      toast({ title: "Credit adjustment voided successfully" });
       refetch();
     },
     onError: error => {
       toast({
-        title: "Error voiding issued credit",
+        title: "Error voiding credit adjustment",
         description: error.message,
         variant: "destructive",
       });
@@ -278,7 +278,9 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
 
       <div>
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Issued Credits</h1>
+          <h1 className="text-3xl font-bold tracking-tight">
+            Issued Credit Adjustments
+          </h1>
           <p className="text-muted-foreground mt-1">
             Issue, track, and apply credit adjustments after returns, pricing
             corrections, refunds, or goodwill decisions.
@@ -303,12 +305,12 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
           <CardContent className="space-y-3">
             <div className="rounded-lg border border-blue-200 bg-background/90 p-3 text-sm text-muted-foreground">
               Capacity answers &quot;How much can this client carry?&quot;
-              Issued credits answer &quot;What adjustment balance can the client
-              spend back down?&quot;
+              Issued adjustments answer &quot;What adjustment balance can the
+              client spend back down?&quot;
             </div>
             <Button
               variant="outline"
-              onClick={() => (window.location.href = "/credits?tab=settings")}
+              onClick={() => (window.location.href = "/credits?tab=capacity")}
             >
               Open Capacity Settings
               <ArrowRight className="ml-2 h-4 w-4" />
@@ -322,7 +324,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
               <div>
                 <CardTitle>Issue or apply an adjustment</CardTitle>
                 <CardDescription className="mt-1">
-                  Keep post-sale credits visible here until they are fully
+                  Keep post-sale adjustments visible here until they are fully
                   applied back to invoices.
                 </CardDescription>
               </div>
@@ -333,7 +335,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
             <div className="grid gap-3 sm:grid-cols-2">
               <div>
                 <p className="text-sm text-muted-foreground">
-                  Open credit balance
+                  Open adjustment balance
                 </p>
                 <p className="text-2xl font-semibold text-emerald-700">
                   {formatCurrency(summary?.totalCreditsRemaining)}
@@ -370,7 +372,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">
-                Issued Credit Value
+                Issued Adjustment Value
               </CardTitle>
               <CreditCard className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
@@ -379,7 +381,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
                 {formatCurrency(summary.totalCreditsIssued)}
               </div>
               <p className="text-xs text-muted-foreground">
-                {summary.creditCount} credits
+                {summary.creditCount} adjustments
               </p>
             </CardContent>
           </Card>
@@ -404,7 +406,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">
-                Credits Used
+                Adjustments Used
               </CardTitle>
               <TrendingUp className="h-4 w-4 text-blue-600" />
             </CardHeader>
@@ -430,8 +432,8 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
                 {formatCurrency(summary.expiringWithin30Days.totalAmount)}
               </div>
               <p className="text-xs text-muted-foreground">
-                {summary.expiringWithin30Days.count} open credits in the next 30
-                days
+                {summary.expiringWithin30Days.count} open adjustments in the
+                next 30 days
               </p>
             </CardContent>
           </Card>
@@ -443,7 +445,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle>Issued credits and balances</CardTitle>
+              <CardTitle>Issued adjustments and balances</CardTitle>
               <CardDescription className="mt-1">
                 Search, filter, and apply issued credit adjustments without
                 mixing them up with client capacity settings.
@@ -453,7 +455,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
               <div className="relative">
                 <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
                 <Input
-                  placeholder="Search issued credits..."
+                  placeholder="Search issued adjustments..."
                   value={searchTerm}
                   onChange={e => setSearchTerm(e.target.value)}
                   className="pl-8 w-[200px]"
@@ -480,7 +482,9 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
         </CardHeader>
         <CardContent>
           {isLoading ? (
-            <p className="text-muted-foreground">Loading credits...</p>
+            <p className="text-muted-foreground">
+              Loading issued adjustments...
+            </p>
           ) : credits?.items && credits.items.length > 0 ? (
             <Table>
               <TableHeader>
@@ -559,7 +563,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
             </Table>
           ) : (
             <p className="text-muted-foreground text-center py-4">
-              No issued credits match the current filters
+              No issued adjustments match the current filters
             </p>
           )}
         </CardContent>
@@ -571,7 +575,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
           <DialogHeader>
             <DialogTitle>Issue Credit Adjustment</DialogTitle>
             <DialogDescription>
-              Create an issued credit balance that can be applied back to a
+              Create an issued adjustment balance that can be applied back to a
               customer invoice.
             </DialogDescription>
           </DialogHeader>
@@ -664,7 +668,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
       <Dialog open={applyCreditOpen} onOpenChange={setApplyCreditOpen}>
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
-            <DialogTitle>Apply Issued Credit</DialogTitle>
+            <DialogTitle>Apply Credit Adjustment</DialogTitle>
             <DialogDescription>
               Apply credit {selectedCredit?.creditNumber} to an invoice balance
             </DialogDescription>
@@ -735,10 +739,10 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
       <AlertDialog open={voidDialogOpen} onOpenChange={setVoidDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Void Issued Credit?</AlertDialogTitle>
+            <AlertDialogTitle>Void Issued Adjustment?</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to void this issued credit balance? This
-              action cannot be undone.
+              Are you sure you want to void this issued adjustment balance?
+              This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -755,7 +759,7 @@ export default function CreditsPage({ embedded = false }: CreditsPageProps) {
               }}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Void Issued Credit
+              Void Issued Adjustment
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/client/src/pages/CreditsWorkspacePage.tsx
+++ b/client/src/pages/CreditsWorkspacePage.tsx
@@ -1,22 +1,199 @@
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import CreditsPage from "@/pages/CreditsPage";
 import CreditSettingsPage from "@/pages/CreditSettingsPage";
 import { useQueryTabState } from "@/hooks/useQueryTabState";
 import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
 import { CREDITS_WORKSPACE } from "@/config/workspaces";
+import { trpc } from "@/lib/trpc";
 import {
   LinearWorkspacePanel,
   LinearWorkspaceShell,
 } from "@/components/layout/LinearWorkspaceShell";
+import {
+  ArrowRight,
+  CreditCard,
+  Shield,
+  SlidersHorizontal,
+} from "lucide-react";
 
 type CreditsTab = (typeof CREDITS_WORKSPACE.tabs)[number]["value"];
 const CREDITS_TABS = CREDITS_WORKSPACE.tabs.map(
   tab => tab.value
 ) as readonly CreditsTab[];
 
+function formatCurrency(amount: number | undefined) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount ?? 0);
+}
+
+function CreditsWorkspaceDashboard({
+  onOpenAdjustments,
+  onOpenCapacity,
+}: {
+  onOpenAdjustments: () => void;
+  onOpenCapacity: () => void;
+}) {
+  const { data: summary, isLoading } = trpc.credits.getSummary.useQuery();
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Client Credit Dashboard
+        </h2>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Start with the two decisions operators actually need to make:
+          adjust a client&apos;s carrying capacity, or issue and apply a
+          post-sale credit adjustment back to invoices.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="border-sky-200 bg-sky-50/70">
+          <CardHeader className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <CardTitle>Client credit capacity</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Adjust exposure guardrails, visibility, and override policy
+                  when a client&apos;s carrying capacity changes.
+                </p>
+              </div>
+              <Shield className="h-5 w-5 text-sky-700" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-lg border border-sky-200 bg-background/90 p-3 text-sm text-muted-foreground">
+              Capacity answers “How much can this client carry?” and should
+              stay separate from one-off financial adjustments.
+            </div>
+            <Button onClick={onOpenCapacity}>
+              Open Capacity Settings
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="border-emerald-200 bg-emerald-50/70">
+          <CardHeader className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <CardTitle>Issued credit adjustments</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Issue, review, and apply return, refund, pricing, or
+                  goodwill adjustments without mixing them up with capacity
+                  policy.
+                </p>
+              </div>
+              <CreditCard className="h-5 w-5 text-emerald-700" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Open adjustment balance
+                </p>
+                <p className="text-2xl font-semibold text-emerald-700">
+                  {isLoading
+                    ? "Loading..."
+                    : formatCurrency(summary?.totalCreditsRemaining)}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Issued adjustments
+                </p>
+                <p className="text-2xl font-semibold">
+                  {isLoading ? "Loading..." : summary?.creditCount ?? 0}
+                </p>
+              </div>
+            </div>
+            <Button onClick={onOpenAdjustments}>
+              Review Issued Adjustments
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Adjustment balance</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {isLoading
+                ? "Loading..."
+                : formatCurrency(summary?.totalCreditsRemaining)}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Still available to apply back to invoices.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Adjustments used</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {isLoading
+                ? "Loading..."
+                : formatCurrency(summary?.totalCreditsUsed)}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Already consumed against invoice balances.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Expiring soon</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {isLoading
+                ? "Loading..."
+                : formatCurrency(summary?.expiringWithin30Days.totalAmount)}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {isLoading
+                ? "Review upcoming expirations."
+                : `${summary?.expiringWithin30Days.count ?? 0} open adjustments in the next 30 days.`}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-dashed">
+        <CardHeader className="space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle>Keep the concepts separate</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Client credit capacity is a policy surface. Issued adjustments
+                are operational balances created after returns, refunds,
+                goodwill, or billing corrections.
+              </p>
+            </div>
+            <SlidersHorizontal className="h-5 w-5 text-muted-foreground" />
+          </div>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}
+
 export default function CreditsWorkspacePage() {
   const { activeTab, setActiveTab } = useQueryTabState<CreditsTab>({
-    defaultTab: "credits",
+    defaultTab: "dashboard",
     validTabs: CREDITS_TABS,
   });
   useWorkspaceHomeTelemetry("credits", activeTab);
@@ -36,32 +213,45 @@ export default function CreditsWorkspacePage() {
         },
         {
           label: "Adjustments",
-          value: "Issued credits that can be applied back to invoices",
+          value: "Issued adjustments that can be applied back to invoices",
         },
       ]}
       commandStrip={
         <>
           <Button
             size="sm"
-            variant="outline"
-            onClick={() => setActiveTab("credits")}
+            variant={activeTab === "dashboard" ? "outline" : "ghost"}
+            onClick={() => setActiveTab("dashboard")}
           >
-            Manage Issued Credits
+            Open Dashboard
           </Button>
           <Button
             size="sm"
-            variant="ghost"
-            onClick={() => setActiveTab("settings")}
+            variant={activeTab === "adjustments" ? "outline" : "ghost"}
+            onClick={() => setActiveTab("adjustments")}
+          >
+            Open Issued Adjustments
+          </Button>
+          <Button
+            size="sm"
+            variant={activeTab === "capacity" ? "outline" : "ghost"}
+            onClick={() => setActiveTab("capacity")}
           >
             Open Capacity Settings
           </Button>
         </>
       }
     >
-      <LinearWorkspacePanel value="credits">
+      <LinearWorkspacePanel value="dashboard">
+        <CreditsWorkspaceDashboard
+          onOpenAdjustments={() => setActiveTab("adjustments")}
+          onOpenCapacity={() => setActiveTab("capacity")}
+        />
+      </LinearWorkspacePanel>
+      <LinearWorkspacePanel value="adjustments">
         <CreditsPage embedded />
       </LinearWorkspacePanel>
-      <LinearWorkspacePanel value="settings">
+      <LinearWorkspacePanel value="capacity">
         <CreditSettingsPage embedded />
       </LinearWorkspacePanel>
     </LinearWorkspaceShell>


### PR DESCRIPTION
## Summary
- make the credits workspace default to a dashboard-first IA with explicit dashboard, issued adjustments, and capacity tabs
- align credits and capacity copy so users do not see stale issued-credits terminology
- preserve legacy deep links by redirecting /credit-settings to capacity and /credits/manage to adjustments

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build