### PR TITLE
fix: allow inventory managers to access photography queue

### DIFF
--- a/server/routers/photography.media-behavior.test.ts
+++ b/server/routers/photography.media-behavior.test.ts
@@ -7,6 +7,22 @@ import { setupDbMock } from "../test-utils/testDb";
 import type { TrpcContext } from "../_core/context";
 
 vi.mock("../db", () => setupDbMock());
+const permissionMocks = vi.hoisted(() => ({
+  hasPermission: vi.fn().mockResolvedValue(true),
+  hasAllPermissions: vi.fn().mockResolvedValue(true),
+  hasAnyPermission: vi.fn().mockResolvedValue(true),
+  isSuperAdmin: vi.fn().mockResolvedValue(false),
+  getUserPermissions: vi.fn().mockResolvedValue(new Set(["*"])),
+  getUserRoles: vi
+    .fn()
+    .mockResolvedValue([{ id: 1, name: "Inventory Manager" }]),
+  clearPermissionCache: vi.fn(),
+}));
+
+vi.mock("../services/permissionService", () => ({
+  ...permissionMocks,
+  default: permissionMocks,
+}));
 
 import { photographyRouter, isVisibleImageStatus } from "./photography";
 import { db } from "../db";
@@ -88,6 +104,10 @@ function createUserCaller() {
 describe("photographyRouter media behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    permissionMocks.hasPermission.mockResolvedValue(true);
+    permissionMocks.hasAllPermissions.mockResolvedValue(true);
+    permissionMocks.hasAnyPermission.mockResolvedValue(true);
+    permissionMocks.isSuperAdmin.mockResolvedValue(false);
   });
 
   it("treats only pending/approved/null statuses as visible", () => {
@@ -172,6 +192,89 @@ describe("photographyRouter media behavior", () => {
       batchesWithPhotos: 12,
       batchesWithoutPhotos: 3,
       coveragePercent: 80,
+    });
+  });
+
+  it("allows a non-admin inventory user to read the photography queue", async () => {
+    mockSelectSequence([
+      [
+        {
+          batchId: 42,
+          batchCode: "BATCH-42",
+          batchStatus: "LIVE",
+          productName: "Blue Dream",
+          strainName: "Blue Dream",
+          createdAt: now,
+          hasImages: 0,
+        },
+      ],
+      [
+        {
+          batchId: 42,
+          batchStatus: "LIVE",
+          createdAt: now,
+          hasImages: 0,
+        },
+      ],
+    ]);
+
+    const queue = await createUserCaller().getQueue({});
+
+    expect(permissionMocks.hasPermission).toHaveBeenCalledWith(
+      "user-2",
+      "inventory:read"
+    );
+    expect(queue.items).toHaveLength(1);
+    expect(queue.items[0]).toMatchObject({
+      batchId: 42,
+      productName: "Blue Dream",
+      status: "PENDING",
+    });
+  });
+
+  it("blocks queue access when the user lacks inventory read permission", async () => {
+    permissionMocks.hasPermission.mockResolvedValue(false);
+
+    await expect(createUserCaller().getQueue({})).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message:
+        "You do not have permission to perform this action. Required permission: inventory:read",
+    });
+  });
+
+  it("allows a non-admin inventory user to complete photography when update permission is granted", async () => {
+    mockSelectSequence([
+      [{ id: 300, productId: 12 }],
+      [],
+      [{ id: 9001, isPrimary: true, status: "APPROVED", sortOrder: 0 }],
+    ]);
+
+    const updateWhere = vi.fn().mockResolvedValue({ changes: 1 });
+    const updateSet = vi.fn(() => ({ where: updateWhere }));
+    vi.mocked(db.update).mockReturnValue({ set: updateSet } as never);
+
+    const result = await createUserCaller().markComplete({ batchId: 300 });
+
+    expect(permissionMocks.hasPermission).toHaveBeenCalledWith(
+      "user-2",
+      "inventory:update"
+    );
+    expect(result).toEqual({ success: true });
+    expect(updateSet).toHaveBeenCalledWith({
+      isPhotographyComplete: true,
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("blocks completion when the user lacks inventory update permission", async () => {
+    permissionMocks.hasPermission.mockResolvedValue(false);
+
+    await expect(
+      createUserCaller().markComplete({ batchId: 300 })
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message:
+        "You do not have permission to perform this action. Required permission: inventory:update",
     });
   });
 });

--- a/server/routers/photography.ts
+++ b/server/routers/photography.ts
@@ -19,6 +19,7 @@ import { storagePut, isStorageConfigured } from "../storage";
 import { logger } from "../_core/logger";
 import { TRPCError } from "@trpc/server";
 import { isSchemaDriftError } from "../_core/dbErrors";
+import { requirePermission } from "../_core/permissionMiddleware";
 
 // Image status enum
 const imageStatusEnum = z.enum(["PENDING", "APPROVED", "REJECTED", "ARCHIVED"]);
@@ -717,7 +718,8 @@ export const photographyRouter = router({
    * Get photography queue for the UI
    * Returns batches that need photos, are being photographed, or have been completed
    */
-  getQueue: adminProcedure
+  getQueue: protectedProcedure
+    .use(requirePermission("inventory:read"))
     .input(
       z.object({
         status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETED"]).optional(),
@@ -941,7 +943,8 @@ export const photographyRouter = router({
   /**
    * Mark a batch as photography complete
    */
-  markComplete: adminProcedure
+  markComplete: protectedProcedure
+    .use(requirePermission("inventory:update"))
     .input(
       z.object({
         batchId: z.number(),


### PR DESCRIPTION
## Summary
- replace legacy admin-only gates on photography queue reads and completion with inventory RBAC permissions
- keep the user-visible photography workspace aligned with the permissions of Inventory Manager accounts
- add router tests covering allowed and denied queue access/completion paths for non-admin users

## Verification
- pnpm exec vitest run server/routers/photography.media-behavior.test.ts
- pnpm check
- pnpm lint
- pnpm test
- pnpm build

## Notes
- `vet` agentic mode was attempted and hung in this environment, so it was treated as a tooling blocker rather than a completion gate.