### PR TITLE
fix: remove primary density control chrome from header

### DIFF
--- a/client/src/components/layout/AppHeader.test.tsx
+++ b/client/src/components/layout/AppHeader.test.tsx
@@ -110,9 +110,7 @@ describe("AppHeader - Notification Bell", () => {
     // Check for unread badge - should show the mocked unread count
     const badge = screen.getByText("2");
     expect(badge).toBeInTheDocument();
-
-    const densityToggle = screen.getByTestId("density-toggle-button");
-    expect(densityToggle).toBeInTheDocument();
+    expect(screen.queryByTestId("density-toggle-button")).not.toBeInTheDocument();
   });
 
   it("routes notifications to the notifications hub", () => {
@@ -126,5 +124,19 @@ describe("AppHeader - Notification Bell", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: /notifications/i }));
 
     expect(mockSetLocation).toHaveBeenCalledWith("/notifications");
+  });
+
+  it("keeps density control inside the account menu instead of primary header chrome", () => {
+    render(
+      <ThemeProvider>
+        <AppHeader />
+      </ThemeProvider>
+    );
+
+    openAccountMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: /switch to comfortable spacing/i })
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -119,20 +119,6 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
             <Command className="h-3.5 w-3.5 mr-1.5" />K
           </Button>
 
-          <Button
-            variant={isCompact ? "secondary" : "ghost"}
-            className="hidden md:flex h-8 rounded-full border border-border/70 bg-background px-2.5 text-[11px] font-medium text-muted-foreground"
-            onClick={toggleDensity}
-            title={
-              isCompact
-                ? "Switch to comfortable row spacing"
-                : "Switch to compact row spacing"
-            }
-            data-testid="density-toggle-button"
-          >
-            {isCompact ? "Comfortable" : "Compact"}
-          </Button>
-
           <NotificationBell className="hidden sm:flex relative" />
 
           {/* Theme Toggle */}


### PR DESCRIPTION
## Summary
- remove the always-visible Comfortable/Compact pill from the primary app header chrome
- keep density switching available in the account menu so the setting stays reachable without cluttering workflow pages
- update the header test contract to verify the control is moved out of primary chrome

## Verification
- pnpm exec vitest run client/src/components/layout/AppHeader.test.tsx
- pnpm check
- pnpm lint
- pnpm build

## Notes
- This addresses the live stale chrome still visible on sales and demand/supply surfaces during staging audit.