### PR TITLE
fix: support legacy photography completion schema

### DIFF
--- a/server/routers/photography.media-behavior.test.ts
+++ b/server/routers/photography.media-behavior.test.ts
@@ -18,10 +18,18 @@ const permissionMocks = vi.hoisted(() => ({
     .mockResolvedValue([{ id: 1, name: "Inventory Manager" }]),
   clearPermissionCache: vi.fn(),
 }));
+const compatibilityMocks = vi.hoisted(() => ({
+  hasPhotographyCompleteFlagColumn: vi.fn().mockResolvedValue(true),
+}));
 
 vi.mock("../services/permissionService", () => ({
   ...permissionMocks,
   default: permissionMocks,
+}));
+
+vi.mock("../lib/photographyCompleteCompatibility", () => ({
+  hasPhotographyCompleteFlagColumn:
+    compatibilityMocks.hasPhotographyCompleteFlagColumn,
 }));
 
 import { photographyRouter, isVisibleImageStatus } from "./photography";
@@ -108,6 +116,7 @@ describe("photographyRouter media behavior", () => {
     permissionMocks.hasAllPermissions.mockResolvedValue(true);
     permissionMocks.hasAnyPermission.mockResolvedValue(true);
     permissionMocks.isSuperAdmin.mockResolvedValue(false);
+    compatibilityMocks.hasPhotographyCompleteFlagColumn.mockResolvedValue(true);
   });
 
   it("treats only pending/approved/null statuses as visible", () => {
@@ -262,6 +271,56 @@ describe("photographyRouter media behavior", () => {
     expect(result).toEqual({ success: true });
     expect(updateSet).toHaveBeenCalledWith({
       isPhotographyComplete: true,
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("falls back to LIVE status when the photography flag column is unavailable", async () => {
+    compatibilityMocks.hasPhotographyCompleteFlagColumn.mockResolvedValue(
+      false
+    );
+    mockSelectSequence([
+      [{ id: 300, productId: 12 }],
+      [],
+      [{ id: 9001, isPrimary: true, status: "APPROVED", sortOrder: 0 }],
+    ]);
+
+    const updateWhere = vi.fn().mockResolvedValue({ changes: 1 });
+    const updateSet = vi.fn(() => ({ where: updateWhere }));
+    vi.mocked(db.update).mockReturnValue({ set: updateSet } as never);
+
+    const result = await createUserCaller().markComplete({ batchId: 300 });
+
+    expect(result).toEqual({ success: true });
+    expect(updateSet).toHaveBeenCalledWith({
+      batchStatus: "LIVE",
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("falls back to LIVE status when completing a session on the legacy schema", async () => {
+    compatibilityMocks.hasPhotographyCompleteFlagColumn.mockResolvedValue(
+      false
+    );
+    mockSelectSequence([
+      [{ id: 300, metadata: null }],
+      [{ id: 9001, isPrimary: true, status: "APPROVED", sortOrder: 0 }],
+    ]);
+
+    const updateWhere = vi.fn().mockResolvedValue({ changes: 1 });
+    const updateSet = vi.fn(() => ({ where: updateWhere }));
+    vi.mocked(db.update).mockReturnValue({ set: updateSet } as never);
+
+    const result = await createUserCaller().completeSession({ batchId: 300 });
+
+    expect(result).toEqual({
+      success: true,
+      batchId: 300,
+      photoCount: 1,
+    });
+    expect(updateSet).toHaveBeenCalledWith({
+      batchStatus: "LIVE",
+      metadata: expect.any(String),
       updatedAt: expect.any(Date),
     });
   });

--- a/server/routers/photography.ts
+++ b/server/routers/photography.ts
@@ -20,6 +20,7 @@ import { logger } from "../_core/logger";
 import { TRPCError } from "@trpc/server";
 import { isSchemaDriftError } from "../_core/dbErrors";
 import { requirePermission } from "../_core/permissionMiddleware";
+import { hasPhotographyCompleteFlagColumn } from "../lib/photographyCompleteCompatibility";
 
 // Image status enum
 const imageStatusEnum = z.enum(["PENDING", "APPROVED", "REJECTED", "ARCHIVED"]);
@@ -1084,14 +1085,24 @@ export const photographyRouter = router({
           .where(eq(productImages.id, desiredPrimaryId));
       }
 
-      // TER-574: Set isPhotographyComplete flag instead of changing status
-      await db
-        .update(batches)
-        .set({
-          isPhotographyComplete: true,
-          updatedAt: new Date(),
-        })
-        .where(eq(batches.id, input.batchId));
+      const completionTimestamp = new Date();
+      if (await hasPhotographyCompleteFlagColumn()) {
+        await db
+          .update(batches)
+          .set({
+            isPhotographyComplete: true,
+            updatedAt: completionTimestamp,
+          })
+          .where(eq(batches.id, input.batchId));
+      } else {
+        await db
+          .update(batches)
+          .set({
+            batchStatus: "LIVE",
+            updatedAt: completionTimestamp,
+          })
+          .where(eq(batches.id, input.batchId));
+      }
 
       return { success: true };
     }),
@@ -1316,15 +1327,26 @@ export const photographyRouter = router({
       metadata.photographyCompletedBy = ctx.user?.id;
       metadata.photoCount = visiblePhotos.length;
 
-      // TER-574: Set isPhotographyComplete flag instead of changing status
-      await database
-        .update(batches)
-        .set({
-          isPhotographyComplete: true,
-          metadata: JSON.stringify(metadata),
-          updatedAt: new Date(),
-        })
-        .where(eq(batches.id, input.batchId));
+      const completionTimestamp = new Date();
+      if (await hasPhotographyCompleteFlagColumn()) {
+        await database
+          .update(batches)
+          .set({
+            isPhotographyComplete: true,
+            metadata: JSON.stringify(metadata),
+            updatedAt: completionTimestamp,
+          })
+          .where(eq(batches.id, input.batchId));
+      } else {
+        await database
+          .update(batches)
+          .set({
+            batchStatus: "LIVE",
+            metadata: JSON.stringify(metadata),
+            updatedAt: completionTimestamp,
+          })
+          .where(eq(batches.id, input.batchId));
+      }
 
       logger.info(
         { batchId: input.batchId, photoCount: visiblePhotos.length },


### PR DESCRIPTION
## Summary
- make photography completion use the schema compatibility path instead of always writing `batches.isPhotographyComplete`
- fall back to the legacy completion representation (`batchStatus: LIVE`) when the photography flag column is missing
- cover both modern and legacy completion paths in photography router tests

## Verification
- pnpm exec vitest run server/routers/photography.media-behavior.test.ts server/lib/photographyCompleteCompatibility.test.ts
- pnpm check
- pnpm lint
- pnpm test
- pnpm build

## Staging evidence
- current staging build `build-mmmp6e56` removed the old `10002` access failure on `/photography`
- the `Mark Shot` row action still returns `500` because `photography.markComplete` tries to update a missing `isPhotographyComplete` column on the live DB schema
- this PR patches that legacy-schema runtime path