### PR TITLE
fix(samples): hide unauthorized workflow actions

### DIFF
--- a/client/src/pages/SampleManagement.test.tsx
+++ b/client/src/pages/SampleManagement.test.tsx
@@ -53,8 +53,21 @@ const sampleItems: SampleRequestMock[] = [
 
 let capturedStatus: string | undefined;
 let capturedSearch: string | undefined;
+let capturedActionAvailability:
+  | {
+      onDelete: boolean;
+      onRequestReturn: boolean;
+      onApproveReturn: boolean;
+      onCompleteReturn: boolean;
+      onRequestVendorReturn: boolean;
+      onShipToVendor: boolean;
+      onConfirmVendorReturn: boolean;
+      onUpdateLocation: boolean;
+    }
+  | undefined;
 let getAllMock = vi.fn();
 let refetchMock = vi.fn();
+let hasPermissionMock = vi.fn();
 
 vi.mock("@/components/samples/SampleList", () => ({
   getSampleOperatorLane: (status: string) => {
@@ -78,9 +91,27 @@ vi.mock("@/components/samples/SampleList", () => ({
     searchQuery: string;
     samples: unknown[];
     isLoading: boolean;
+    onDelete?: unknown;
+    onRequestReturn?: unknown;
+    onApproveReturn?: unknown;
+    onCompleteReturn?: unknown;
+    onRequestVendorReturn?: unknown;
+    onShipToVendor?: unknown;
+    onConfirmVendorReturn?: unknown;
+    onUpdateLocation?: unknown;
   }) => {
     capturedStatus = props.statusFilter;
     capturedSearch = props.searchQuery;
+    capturedActionAvailability = {
+      onDelete: Boolean(props.onDelete),
+      onRequestReturn: Boolean(props.onRequestReturn),
+      onApproveReturn: Boolean(props.onApproveReturn),
+      onCompleteReturn: Boolean(props.onCompleteReturn),
+      onRequestVendorReturn: Boolean(props.onRequestVendorReturn),
+      onShipToVendor: Boolean(props.onShipToVendor),
+      onConfirmVendorReturn: Boolean(props.onConfirmVendorReturn),
+      onUpdateLocation: Boolean(props.onUpdateLocation),
+    };
     return (
       <div data-testid="sample-list-mock">
         <span data-testid="sample-count">
@@ -125,6 +156,18 @@ vi.mock("@/hooks/useAuth", () => ({
     isAuthenticated: true,
     refresh: vi.fn(),
     logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/usePermissions", () => ({
+  usePermissions: () => ({
+    hasPermission: hasPermissionMock,
+    hasAnyPermission: vi.fn(),
+    hasAllPermissions: vi.fn(),
+    isSuperAdmin: false,
+    permissions: [],
+    isLoading: false,
+    error: null,
   }),
 }));
 
@@ -229,7 +272,18 @@ describe("SampleManagement", () => {
   beforeEach(() => {
     capturedStatus = undefined;
     capturedSearch = undefined;
+    capturedActionAvailability = undefined;
     refetchMock = vi.fn();
+    hasPermissionMock = vi.fn((permission: string) =>
+      [
+        "samples:create",
+        "samples:delete",
+        "samples:return",
+        "samples:approve",
+        "samples:vendorReturn",
+        "samples:track",
+      ].includes(permission)
+    );
 
     // Default mock - samples with data
     getAllMock = vi.fn().mockReturnValue({
@@ -296,6 +350,16 @@ describe("SampleManagement", () => {
 
       fireEvent.click(screen.getByRole("button", { name: /new sample/i }));
       expect(screen.getByTestId("sample-form")).toBeInTheDocument();
+    });
+
+    it("hides creation button when user lacks samples:create", () => {
+      hasPermissionMock = vi.fn(() => false);
+
+      render(<SampleManagement />);
+
+      expect(
+        screen.queryByRole("button", { name: /new sample/i })
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -403,6 +467,27 @@ describe("SampleManagement", () => {
         }),
         expect.anything()
       );
+    });
+  });
+
+  describe("Permission Surfacing", () => {
+    it("does not expose dead-end sample actions when permissions are missing", () => {
+      hasPermissionMock = vi.fn(permission =>
+        permission === "samples:track"
+      );
+
+      render(<SampleManagement />);
+
+      expect(capturedActionAvailability).toEqual({
+        onDelete: false,
+        onRequestReturn: false,
+        onApproveReturn: false,
+        onCompleteReturn: false,
+        onRequestVendorReturn: false,
+        onShipToVendor: false,
+        onConfirmVendorReturn: false,
+        onUpdateLocation: true,
+      });
     });
   });
 

--- a/client/src/pages/SampleManagement.tsx
+++ b/client/src/pages/SampleManagement.tsx
@@ -43,6 +43,7 @@ import {
 import { LoadingState } from "@/components/ui/loading-state";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/hooks/useAuth";
+import { usePermissions } from "@/hooks/usePermissions";
 import { useDebounce } from "@/hooks/useDebounce";
 import type { SampleRequest } from "../../../drizzle/schema";
 import { toast } from "sonner";
@@ -120,6 +121,13 @@ export default function SampleManagement() {
   const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [selectedSampleLocation, setSelectedSampleLocation] =
     useState<SampleLocation | null>(null);
+  const { hasPermission } = usePermissions();
+  const canCreateSamples = hasPermission("samples:create");
+  const canDeleteSamples = hasPermission("samples:delete");
+  const canRequestSampleReturn = hasPermission("samples:return");
+  const canApproveSampleReturn = hasPermission("samples:approve");
+  const canManageVendorReturn = hasPermission("samples:vendorReturn");
+  const canTrackSamples = hasPermission("samples:track");
 
   const debouncedProductSearch = useDebounce(productSearch, 300);
 
@@ -710,7 +718,9 @@ export default function SampleManagement() {
             Track samples out and sample returns without the old status maze.
           </p>
         </div>
-        <Button onClick={() => setIsFormOpen(true)}>New Sample</Button>
+        {canCreateSamples && (
+          <Button onClick={() => setIsFormOpen(true)}>New Sample</Button>
+        )}
       </div>
 
       {/* Expiring Samples Widget */}
@@ -777,14 +787,24 @@ export default function SampleManagement() {
         statusFilter={statusFilter}
         searchQuery={searchQuery}
         isLoading={samplesLoading}
-        onDelete={handleDelete}
-        onRequestReturn={handleRequestReturn}
-        onApproveReturn={handleApproveReturn}
-        onCompleteReturn={handleCompleteReturn}
-        onRequestVendorReturn={handleRequestVendorReturn}
-        onShipToVendor={handleShipToVendor}
-        onConfirmVendorReturn={handleConfirmVendorReturn}
-        onUpdateLocation={handleUpdateLocation}
+        onDelete={canDeleteSamples ? handleDelete : undefined}
+        onRequestReturn={
+          canRequestSampleReturn ? handleRequestReturn : undefined
+        }
+        onApproveReturn={
+          canApproveSampleReturn ? handleApproveReturn : undefined
+        }
+        onCompleteReturn={
+          canRequestSampleReturn ? handleCompleteReturn : undefined
+        }
+        onRequestVendorReturn={
+          canManageVendorReturn ? handleRequestVendorReturn : undefined
+        }
+        onShipToVendor={canManageVendorReturn ? handleShipToVendor : undefined}
+        onConfirmVendorReturn={
+          canManageVendorReturn ? handleConfirmVendorReturn : undefined
+        }
+        onUpdateLocation={canTrackSamples ? handleUpdateLocation : undefined}
         pageSize={10}
       />
 


### PR DESCRIPTION
## Summary
- gate sample actions in  by the same permissions the backend enforces
- hide creation when the current user lacks 
- add regression coverage so we do not surface dead-end sample actions again

## Verification
- pnpm exec vitest run client/src/pages/SampleManagement.test.tsx
- pnpm check
- pnpm lint
- pnpm build

## Staging finding addressed
-  surfaced  to , but  returned  for missing 
