### PR TITLE
fix(rbac): resolve my permissions via open id

### DIFF
--- a/server/routers/rbac-users.test.ts
+++ b/server/routers/rbac-users.test.ts
@@ -40,6 +40,17 @@ const createCaller = async () => {
   });
 };
 
+const createCallerWithUser = async (user: typeof mockUser) => {
+  const ctx = await createContext({
+    req: { headers: {} as Record<string, string> },
+    res: {} as Record<string, unknown>,
+  });
+  return appRouter.createCaller({
+    ...ctx,
+    user,
+  });
+};
+
 describe("RBAC Users Router", () => {
   let caller: Awaited<ReturnType<typeof createCaller>>;
 
@@ -115,6 +126,73 @@ describe("RBAC Users Router", () => {
       // Assert
       expect(mockLimit).toHaveBeenCalledWith(25);
       expect(mockOffset).toHaveBeenCalledWith(50);
+    });
+  });
+
+  describe("getMyPermissions", () => {
+    it("should resolve superadmin permissions using the authenticated openId", async () => {
+      vi.mocked(permissionService.isSuperAdmin).mockResolvedValue(true);
+      vi.mocked(permissionService.getUserPermissions).mockResolvedValue(
+        new Set(["orders:read", "pick-pack:manage"])
+      );
+      vi.mocked(permissionService.getUserRoles).mockResolvedValue([
+        {
+          id: 1,
+          name: "Super Admin",
+          description: "Full system access",
+        },
+      ]);
+
+      const result = await caller.rbacUsers.getMyPermissions();
+
+      expect(permissionService.isSuperAdmin).toHaveBeenCalledWith(
+        mockUser.openId
+      );
+      expect(permissionService.getUserPermissions).toHaveBeenCalledWith(
+        mockUser.openId
+      );
+      expect(permissionService.getUserRoles).toHaveBeenCalledWith(
+        mockUser.openId
+      );
+      expect(result).toEqual({
+        userId: mockUser.openId,
+        isSuperAdmin: true,
+        permissions: ["orders:read", "pick-pack:manage"],
+        roles: ["Super Admin"],
+      });
+    });
+
+    it("should fall back to the numeric user id when openId is absent", async () => {
+      const numericOnlyUser = {
+        ...mockUser,
+        id: 42,
+        openId: undefined as unknown as string,
+      };
+      const numericCaller = await createCallerWithUser(numericOnlyUser);
+
+      vi.mocked(permissionService.isSuperAdmin).mockResolvedValue(false);
+      vi.mocked(permissionService.getUserPermissions).mockResolvedValue(
+        new Set(["inventory:read"])
+      );
+      vi.mocked(permissionService.getUserRoles).mockResolvedValue([
+        {
+          id: 2,
+          name: "Inventory Manager",
+          description: "Inventory access",
+        },
+      ]);
+
+      const result = await numericCaller.rbacUsers.getMyPermissions();
+
+      expect(permissionService.isSuperAdmin).toHaveBeenCalledWith("42");
+      expect(permissionService.getUserPermissions).toHaveBeenCalledWith("42");
+      expect(permissionService.getUserRoles).toHaveBeenCalledWith("42");
+      expect(result).toEqual({
+        userId: "42",
+        isSuperAdmin: false,
+        permissions: ["inventory:read"],
+        roles: ["Inventory Manager"],
+      });
     });
   });
 

--- a/server/routers/rbac-users.ts
+++ b/server/routers/rbac-users.ts
@@ -11,11 +11,15 @@ import {
   roles,
   userPermissionOverrides,
   permissions,
-  rolePermissions,
 } from "../../drizzle/schema";
 import { eq, inArray, and } from "drizzle-orm";
 import { logger } from "../_core/logger";
-import { clearPermissionCache } from "../services/permissionService";
+import {
+  clearPermissionCache,
+  getUserPermissions,
+  getUserRoles,
+  isSuperAdmin,
+} from "../services/permissionService";
 
 /**
  * RBAC Users Router
@@ -656,87 +660,19 @@ export const rbacUsersRouter = router({
    */
   getMyPermissions: protectedProcedure.query(async ({ ctx }) => {
     try {
-      const db = await getDb();
-      if (!db) throw new Error("Database not available");
-
       // Authentication is enforced by protectedProcedure
-      const userId = String(ctx.user.id);
-
-      // Check if user is Super Admin (check by role name since isSuperAdmin column doesn't exist)
-      const userRoleRecords = await db
-        .select({
-          roleId: userRoles.roleId,
-          roleName: roles.name,
-        })
-        .from(userRoles)
-        .innerJoin(roles, eq(userRoles.roleId, roles.id))
-        .where(eq(userRoles.userId, userId));
-
-      const isSuperAdmin = userRoleRecords.some(
-        r => r.roleName === "Super Admin"
-      );
-
-      // If Super Admin, return all permissions
-      if (isSuperAdmin) {
-        const allPermissions = await db
-          .select({ name: permissions.name })
-          .from(permissions);
-
-        return {
-          userId,
-          isSuperAdmin: true,
-          permissions: allPermissions.map(p => p.name),
-          roles: userRoleRecords.map(r => r.roleName),
-        };
-      }
-
-      // Get permissions from roles
-      const roleIds = userRoleRecords.map(r => r.roleId);
-      const rolePerms =
-        roleIds.length > 0
-          ? await db
-              .select({ permissionName: permissions.name })
-              .from(rolePermissions)
-              .innerJoin(
-                permissions,
-                eq(rolePermissions.permissionId, permissions.id)
-              )
-              .where(inArray(rolePermissions.roleId, roleIds))
-          : [];
-
-      // Get permission overrides
-      const overrides = await db
-        .select({
-          permissionName: permissions.name,
-          granted: userPermissionOverrides.granted,
-        })
-        .from(userPermissionOverrides)
-        .innerJoin(
-          permissions,
-          eq(userPermissionOverrides.permissionId, permissions.id)
-        )
-        .where(eq(userPermissionOverrides.userId, userId));
-
-      // Combine permissions
-      const permissionSet = new Set<string>();
-
-      // Add role permissions
-      rolePerms.forEach(p => permissionSet.add(p.permissionName));
-
-      // Apply overrides
-      overrides.forEach(override => {
-        if (override.granted) {
-          permissionSet.add(override.permissionName);
-        } else {
-          permissionSet.delete(override.permissionName);
-        }
-      });
+      const userId = ctx.user.openId || String(ctx.user.id);
+      const [superAdmin, permissionSet, assignedRoles] = await Promise.all([
+        isSuperAdmin(userId),
+        getUserPermissions(userId),
+        getUserRoles(userId),
+      ]);
 
       return {
         userId,
-        isSuperAdmin: false,
+        isSuperAdmin: superAdmin,
         permissions: Array.from(permissionSet),
-        roles: userRoleRecords.map(r => r.roleName),
+        roles: assignedRoles.map(role => role.name),
       };
     } catch (error) {
       logger.error({


### PR DESCRIPTION
## Summary\n- resolve `rbacUsers.getMyPermissions` against the authenticated `openId` when present\n- reuse the permission service helpers so superadmin/frontend permission payloads stay aligned\n- add regression coverage for openId and numeric-id fallback behavior\n\n## Verification\n- pnpm exec vitest run server/routers/rbac-users.test.ts server/routers/auth-integration.test.ts server/routers/permission-checks.test.ts\n- pnpm check\n- pnpm lint\n- pnpm build\n- pnpm test (running in worktree during PR creation)\n