### PR TITLE
fix(receiving): support legacy batch insert schemas

### DIFF
--- a/server/lib/batchInsertCompatibility.test.ts
+++ b/server/lib/batchInsertCompatibility.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mockGetDb: vi.fn(),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../db", () => ({
+  getDb: mocks.mockGetDb,
+}));
+
+vi.mock("../_core/logger", () => ({
+  logger: mocks.logger,
+}));
+
+const buildPayload = () => ({
+  code: "BATCH-001",
+  sku: "SKU-001",
+  productId: 1,
+  lotId: 2,
+  batchStatus: "AWAITING_INTAKE",
+  cogsMode: "FIXED",
+  unitCogs: "25.0000",
+  unitCogsMin: null,
+  unitCogsMax: null,
+  paymentTerms: "CONSIGNMENT",
+  metadata: "{\"poNumber\":\"PO-1\"}",
+  onHandQty: "10",
+  sampleQty: "0",
+  reservedQty: "0",
+  quarantineQty: "0",
+  holdQty: "0",
+  defectiveQty: "0",
+});
+
+describe("batchInsertCompatibility", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.mockGetDb.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.logger.warn.mockReset();
+  });
+
+  it("omits unavailable modern-only columns for legacy staging schemas", async () => {
+    const { buildCompatibleBatchInsertEntries } = await import(
+      "./batchInsertCompatibility"
+    );
+
+    const entries = buildCompatibleBatchInsertEntries(
+      new Set([
+        "code",
+        "sku",
+        "productId",
+        "lotId",
+        "batchStatus",
+        "cogsMode",
+        "unitCogs",
+        "paymentTerms",
+        "metadata",
+        "onHandQty",
+        "sampleQty",
+        "reservedQty",
+        "quarantineQty",
+        "holdQty",
+        "defectiveQty",
+        "createdAt",
+        "updatedAt",
+      ]),
+      buildPayload()
+    );
+
+    const columns = entries.map(([column]) => column);
+    expect(columns).not.toContain("deleted_at");
+    expect(columns).not.toContain("isPhotographyComplete");
+    expect(columns).toContain("code");
+    expect(columns).toContain("onHandQty");
+  });
+
+  it("logs once when the staging schema is missing modern batch columns", async () => {
+    mocks.mockGetDb.mockResolvedValue({
+      execute: vi.fn().mockResolvedValue([
+        [
+          { columnName: "code" },
+          { columnName: "sku" },
+          { columnName: "productId" },
+          { columnName: "lotId" },
+          { columnName: "batchStatus" },
+        ],
+      ]),
+    });
+
+    const { getBatchColumnSet } = await import("./batchInsertCompatibility");
+
+    const columns = await getBatchColumnSet();
+    expect(columns.has("code")).toBe(true);
+    expect(columns.has("deleted_at")).toBe(false);
+    expect(columns.has("isPhotographyComplete")).toBe(false);
+    expect(mocks.logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("executes a compatible insert and returns insertId from mysql array results", async () => {
+    mocks.mockGetDb.mockResolvedValue({
+      execute: vi.fn().mockResolvedValue([
+        [
+          { columnName: "code" },
+          { columnName: "version" },
+          { columnName: "sku" },
+          { columnName: "productId" },
+          { columnName: "lotId" },
+          { columnName: "batchStatus" },
+          { columnName: "cogsMode" },
+          { columnName: "unitCogs" },
+          { columnName: "paymentTerms" },
+          { columnName: "metadata" },
+          { columnName: "onHandQty" },
+          { columnName: "sampleQty" },
+          { columnName: "reservedQty" },
+          { columnName: "quarantineQty" },
+          { columnName: "holdQty" },
+          { columnName: "defectiveQty" },
+          { columnName: "createdAt" },
+          { columnName: "updatedAt" },
+        ],
+      ]),
+    });
+
+    const tx = {
+      execute: vi.fn().mockResolvedValue([{ insertId: 42 }]),
+    };
+
+    const { insertBatchWithCompatibility } = await import(
+      "./batchInsertCompatibility"
+    );
+
+    await expect(insertBatchWithCompatibility(tx, buildPayload())).resolves.toBe(
+      42
+    );
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns insertId when drizzle exposes a direct result header", async () => {
+    mocks.mockGetDb.mockResolvedValue({
+      execute: vi.fn().mockResolvedValue([
+        [
+          { columnName: "code" },
+          { columnName: "version" },
+          { columnName: "sku" },
+          { columnName: "productId" },
+          { columnName: "lotId" },
+          { columnName: "batchStatus" },
+          { columnName: "cogsMode" },
+          { columnName: "unitCogs" },
+          { columnName: "paymentTerms" },
+          { columnName: "metadata" },
+          { columnName: "onHandQty" },
+          { columnName: "sampleQty" },
+          { columnName: "reservedQty" },
+          { columnName: "quarantineQty" },
+          { columnName: "holdQty" },
+          { columnName: "defectiveQty" },
+          { columnName: "createdAt" },
+          { columnName: "updatedAt" },
+        ],
+      ]),
+    });
+
+    const tx = {
+      execute: vi.fn().mockResolvedValue({ insertId: 77 }),
+    };
+
+    const { insertBatchWithCompatibility } = await import(
+      "./batchInsertCompatibility"
+    );
+
+    await expect(insertBatchWithCompatibility(tx, buildPayload())).resolves.toBe(
+      77
+    );
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/lib/batchInsertCompatibility.ts
+++ b/server/lib/batchInsertCompatibility.ts
@@ -1,0 +1,208 @@
+import { sql, type SQL } from "drizzle-orm";
+import { logger } from "../_core/logger";
+import { getDb } from "../db";
+
+export interface BatchInsertPayload {
+  code: string;
+  sku: string;
+  productId: number;
+  lotId: number;
+  batchStatus: string;
+  cogsMode: string;
+  unitCogs: string | null;
+  unitCogsMin: string | null;
+  unitCogsMax: string | null;
+  paymentTerms: string;
+  metadata: string | null;
+  onHandQty: string;
+  sampleQty: string;
+  reservedQty: string;
+  quarantineQty: string;
+  holdQty: string;
+  defectiveQty: string;
+}
+
+const MODERN_BATCH_COLUMNS = ["deleted_at", "isPhotographyComplete"] as const;
+
+let cachedBatchColumns: Set<string> | undefined;
+let batchColumnsPromise: Promise<Set<string>> | undefined;
+
+function buildBatchInsertRecord(payload: BatchInsertPayload): Record<string, unknown> {
+  return {
+    code: payload.code,
+    deleted_at: null,
+    version: 1,
+    sku: payload.sku,
+    productId: payload.productId,
+    lotId: payload.lotId,
+    batchStatus: payload.batchStatus,
+    isPhotographyComplete: false,
+    statusId: null,
+    grade: null,
+    isSample: 0,
+    sampleOnly: 0,
+    sampleAvailable: 0,
+    cogsMode: payload.cogsMode,
+    unitCogs: payload.unitCogs,
+    unitCogsMin: payload.unitCogsMin,
+    unitCogsMax: payload.unitCogsMax,
+    paymentTerms: payload.paymentTerms,
+    ownership_type: "CONSIGNED",
+    amountPaid: "0",
+    metadata: payload.metadata,
+    photo_session_event_id: null,
+    onHandQty: payload.onHandQty,
+    sampleQty: payload.sampleQty,
+    reservedQty: payload.reservedQty,
+    quarantineQty: payload.quarantineQty,
+    holdQty: payload.holdQty,
+    defectiveQty: payload.defectiveQty,
+    publishEcom: 0,
+    publishB2b: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+export function buildCompatibleBatchInsertEntries(
+  availableColumns: Set<string>,
+  payload: BatchInsertPayload
+): Array<[string, unknown]> {
+  const batchRecord = buildBatchInsertRecord(payload);
+  return Object.entries(batchRecord).filter(([column]) =>
+    availableColumns.has(column)
+  );
+}
+
+async function detectBatchColumns(): Promise<Set<string>> {
+  const db = await getDb();
+  if (!db) {
+    return new Set(Object.keys(buildBatchInsertRecord({
+      code: "",
+      sku: "",
+      productId: 0,
+      lotId: 0,
+      batchStatus: "AWAITING_INTAKE",
+      cogsMode: "FIXED",
+      unitCogs: "0",
+      unitCogsMin: null,
+      unitCogsMax: null,
+      paymentTerms: "CONSIGNMENT",
+      metadata: null,
+      onHandQty: "0",
+      sampleQty: "0",
+      reservedQty: "0",
+      quarantineQty: "0",
+      holdQty: "0",
+      defectiveQty: "0",
+    })));
+  }
+
+  try {
+    const [rows] = await db.execute(
+      `SELECT COLUMN_NAME AS columnName
+       FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_NAME = 'batches'`
+    );
+
+    const columns = new Set(
+      Array.isArray(rows)
+        ? rows
+            .map(row =>
+              typeof row === "object" && row && "columnName" in row
+                ? String((row as { columnName: unknown }).columnName)
+                : null
+            )
+            .filter((column): column is string => Boolean(column))
+        : []
+    );
+
+    const missingModernColumns = MODERN_BATCH_COLUMNS.filter(
+      column => !columns.has(column)
+    );
+    if (missingModernColumns.length > 0) {
+      logger.info(
+        { missingModernColumns },
+        "Legacy batch schema detected; omitting unavailable columns during PO receiving"
+      );
+    }
+
+    return columns;
+  } catch (error) {
+    logger.warn(
+      { error },
+      "Failed to inspect batch columns; assuming modern schema for PO receiving"
+    );
+    return new Set(Object.keys(buildBatchInsertRecord({
+      code: "",
+      sku: "",
+      productId: 0,
+      lotId: 0,
+      batchStatus: "AWAITING_INTAKE",
+      cogsMode: "FIXED",
+      unitCogs: "0",
+      unitCogsMin: null,
+      unitCogsMax: null,
+      paymentTerms: "CONSIGNMENT",
+      metadata: null,
+      onHandQty: "0",
+      sampleQty: "0",
+      reservedQty: "0",
+      quarantineQty: "0",
+      holdQty: "0",
+      defectiveQty: "0",
+    })));
+  }
+}
+
+export async function getBatchColumnSet(): Promise<Set<string>> {
+  if (cachedBatchColumns) {
+    return cachedBatchColumns;
+  }
+
+  if (!batchColumnsPromise) {
+    batchColumnsPromise = detectBatchColumns().then(columns => {
+      cachedBatchColumns = columns;
+      batchColumnsPromise = undefined;
+      return columns;
+    });
+  }
+
+  return batchColumnsPromise;
+}
+
+function extractInsertId(result: unknown): number {
+  if (Array.isArray(result)) {
+    const header = result[0] as { insertId?: number } | undefined;
+    return Number(header?.insertId ?? 0);
+  }
+
+  if (result && typeof result === "object" && "insertId" in result) {
+    return Number((result as { insertId?: number }).insertId ?? 0);
+  }
+
+  return 0;
+}
+
+export async function insertBatchWithCompatibility(
+  tx: { execute: (query: SQL) => Promise<unknown> },
+  payload: BatchInsertPayload
+): Promise<number> {
+  const availableColumns = await getBatchColumnSet();
+  const entries = buildCompatibleBatchInsertEntries(availableColumns, payload);
+
+  const query = sql`
+    INSERT INTO batches (${sql.join(
+      entries.map(([column]) => sql.raw(`\`${column}\``)),
+      sql`, `
+    )})
+    VALUES (${sql.join(
+      entries.map(([, value]) => sql`${value}`),
+      sql`, `
+    )})
+  `;
+
+  const result = await tx.execute(query);
+  return extractInsertId(result);
+}

--- a/server/routers/poReceiving.ts
+++ b/server/routers/poReceiving.ts
@@ -25,6 +25,7 @@ import {
 import { eq, and, desc, sql, or, isNull } from "drizzle-orm";
 import { logger } from "../_core/logger";
 import { TRPCError } from "@trpc/server";
+import { insertBatchWithCompatibility } from "../lib/batchInsertCompatibility";
 
 export const poReceivingRouter = router({
   // Receive a purchase order (create intake session and update inventory)
@@ -141,7 +142,7 @@ export const poReceivingRouter = router({
             const batchSku = `SKU-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
             const receivedQty = parseFloat(item.receivedQuantity);
 
-            const [newBatch] = await tx.insert(batches).values({
+            batchId = await insertBatchWithCompatibility(tx, {
               code: batchCode,
               sku: batchSku,
               productId: item.newBatchData.productId,
@@ -153,11 +154,13 @@ export const poReceivingRouter = router({
               defectiveQty: "0",
               sampleQty: "0",
               unitCogs: item.newBatchData.costPerUnit?.toString() || "0",
+              unitCogsMin: null,
+              unitCogsMax: null,
               cogsMode: "FIXED",
               paymentTerms: "CONSIGNMENT",
               batchStatus: "AWAITING_INTAKE",
+              metadata: null,
             });
-            batchId = newBatch.insertId;
 
             // INV-005: Record inventory movement for new batch creation
             await tx.insert(inventoryMovements).values({
@@ -600,7 +603,7 @@ export const poReceivingRouter = router({
             );
 
           // Create batch
-          const [newBatch] = await tx.insert(batches).values({
+          const batchId = await insertBatchWithCompatibility(tx, {
             code: batchCode,
             sku: batchSku,
             productId: poItem.productId,
@@ -642,8 +645,6 @@ export const poReceivingRouter = router({
               poItemId: item.poItemId,
             }),
           });
-
-          const batchId = newBatch.insertId;
 
           // INV-005: Record inventory movement for new batch creation
           await tx.insert(inventoryMovements).values({


### PR DESCRIPTION
## Summary\n- route PO batch creation through a compatibility insert helper\n- detect available `batches` columns and omit legacy-missing fields during insert\n- cover both mysql result shapes so receiving can still recover the inserted batch id\n\n## Verification\n- pnpm exec vitest run server/lib/batchInsertCompatibility.test.ts\n- pnpm check\n- pnpm lint\n- pnpm build\n- pnpm test (running in worktree during PR creation)\n