### PR TITLE
fix(intake): support legacy batch insert schemas

### DIFF
--- a/server/inventoryIntakeService.mediaUrls.test.ts
+++ b/server/inventoryIntakeService.mediaUrls.test.ts
@@ -18,6 +18,44 @@ vi.mock("./sequenceDb", () => ({
   }),
 }));
 
+vi.mock("./lib/batchInsertCompatibility", async () => {
+  const { batches } = await import("../drizzle/schema");
+
+  return {
+    insertBatchWithCompatibility: vi.fn(async (tx, payload) => {
+      const [created] = await tx
+        .insert(batches)
+        .values({
+          code: payload.code,
+          sku: payload.sku,
+          productId: payload.productId,
+          lotId: payload.lotId,
+          batchStatus: payload.batchStatus,
+          grade: payload.grade ?? null,
+          cogsMode: payload.cogsMode,
+          unitCogs: payload.unitCogs,
+          unitCogsMin: payload.unitCogsMin,
+          unitCogsMax: payload.unitCogsMax,
+          paymentTerms: payload.paymentTerms,
+          ownershipType: payload.ownershipType ?? "CONSIGNED",
+          metadata: payload.metadata,
+          onHandQty: payload.onHandQty,
+          sampleQty: payload.sampleQty,
+          reservedQty: payload.reservedQty,
+          quarantineQty: payload.quarantineQty,
+          holdQty: payload.holdQty,
+          defectiveQty: payload.defectiveQty,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        })
+        .$returningId();
+
+      return created.id;
+    }),
+  };
+});
+
 import { processIntake } from "./inventoryIntakeService";
 import { productImages } from "../drizzle/schema";
 

--- a/server/inventoryIntakeService.ts
+++ b/server/inventoryIntakeService.ts
@@ -32,6 +32,7 @@ import * as inventoryUtils from "./inventoryUtils";
 import { findOrCreate } from "./_core/dbUtils";
 import { logger } from "./_core/logger";
 import { withRetryableTransaction } from "./dbTransaction";
+import { insertBatchWithCompatibility } from "./lib/batchInsertCompatibility";
 // MEET-005, MEET-006: Import payables service for consigned inventory tracking
 import * as payablesService from "./services/payablesService";
 
@@ -260,24 +261,23 @@ export async function processIntake(input: IntakeInput): Promise<IntakeResult> {
         let batch: Batch | undefined;
         while (!batch) {
           try {
-            const [batchCreated] = await tx
-              .insert(batches)
-              .values({
+            const batchId = await insertBatchWithCompatibility(tx, {
                 code: batchCode,
-                sku: sku,
+                sku,
                 productId: product.id,
                 lotId: lot.id,
                 batchStatus: "AWAITING_INTAKE",
-                grade: input.grade,
+                grade: input.grade ?? null,
                 isSample: 0,
                 sampleOnly: 0,
                 sampleAvailable: 0,
                 cogsMode: input.cogsMode,
-                unitCogs: input.unitCogs,
-                unitCogsMin: input.unitCogsMin,
-                unitCogsMax: input.unitCogsMax,
+                unitCogs: input.unitCogs ?? null,
+                unitCogsMin: input.unitCogsMin ?? null,
+                unitCogsMax: input.unitCogsMax ?? null,
                 paymentTerms: input.paymentTerms,
-                ownershipType: ownershipType, // MEET-006
+                ownershipType, // MEET-006
+                amountPaid: "0",
                 metadata: (() => {
                   const metadata = input.metadata || {};
                   if (input.mediaUrls && input.mediaUrls.length > 0) {
@@ -293,15 +293,12 @@ export async function processIntake(input: IntakeInput): Promise<IntakeResult> {
                 quarantineQty: "0",
                 holdQty: "0",
                 defectiveQty: "0",
-                publishEcom: 0,
-                publishB2b: 0,
-              })
-              .$returningId();
+              });
 
             const [createdBatch] = await tx
               .select()
               .from(batches)
-              .where(eq(batches.id, batchCreated.id));
+              .where(eq(batches.id, batchId));
 
             if (!createdBatch) {
               throw new Error("Failed to create batch");

--- a/server/lib/batchInsertCompatibility.test.ts
+++ b/server/lib/batchInsertCompatibility.test.ts
@@ -22,11 +22,17 @@ const buildPayload = () => ({
   productId: 1,
   lotId: 2,
   batchStatus: "AWAITING_INTAKE",
+  grade: "A",
+  isSample: 0,
+  sampleOnly: 0,
+  sampleAvailable: 0,
   cogsMode: "FIXED",
   unitCogs: "25.0000",
   unitCogsMin: null,
   unitCogsMax: null,
   paymentTerms: "CONSIGNMENT",
+  ownershipType: "CONSIGNED",
+  amountPaid: "0",
   metadata: "{\"poNumber\":\"PO-1\"}",
   onHandQty: "10",
   sampleQty: "0",
@@ -56,9 +62,11 @@ describe("batchInsertCompatibility", () => {
         "productId",
         "lotId",
         "batchStatus",
+        "grade",
         "cogsMode",
         "unitCogs",
         "paymentTerms",
+        "ownership_type",
         "metadata",
         "onHandQty",
         "sampleQty",
@@ -77,6 +85,7 @@ describe("batchInsertCompatibility", () => {
     expect(columns).not.toContain("isPhotographyComplete");
     expect(columns).toContain("code");
     expect(columns).toContain("onHandQty");
+    expect(columns).toContain("ownership_type");
   });
 
   it("logs once when the staging schema is missing modern batch columns", async () => {
@@ -111,9 +120,11 @@ describe("batchInsertCompatibility", () => {
           { columnName: "productId" },
           { columnName: "lotId" },
           { columnName: "batchStatus" },
+          { columnName: "grade" },
           { columnName: "cogsMode" },
           { columnName: "unitCogs" },
           { columnName: "paymentTerms" },
+          { columnName: "ownership_type" },
           { columnName: "metadata" },
           { columnName: "onHandQty" },
           { columnName: "sampleQty" },
@@ -151,9 +162,11 @@ describe("batchInsertCompatibility", () => {
           { columnName: "productId" },
           { columnName: "lotId" },
           { columnName: "batchStatus" },
+          { columnName: "grade" },
           { columnName: "cogsMode" },
           { columnName: "unitCogs" },
           { columnName: "paymentTerms" },
+          { columnName: "ownership_type" },
           { columnName: "metadata" },
           { columnName: "onHandQty" },
           { columnName: "sampleQty" },
@@ -179,5 +192,27 @@ describe("batchInsertCompatibility", () => {
       77
     );
     expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves intake-specific ownership and grade values when the schema supports them", async () => {
+    const { buildCompatibleBatchInsertEntries } = await import(
+      "./batchInsertCompatibility"
+    );
+
+    const entries = buildCompatibleBatchInsertEntries(
+      new Set(["grade", "ownership_type", "amountPaid"]),
+      {
+        ...buildPayload(),
+        grade: "Premium",
+        ownershipType: "OFFICE_OWNED",
+        amountPaid: "125.00",
+      }
+    );
+
+    expect(entries).toEqual([
+      ["grade", "Premium"],
+      ["ownership_type", "OFFICE_OWNED"],
+      ["amountPaid", "125.00"],
+    ]);
   });
 });

--- a/server/lib/batchInsertCompatibility.ts
+++ b/server/lib/batchInsertCompatibility.ts
@@ -8,11 +8,17 @@ export interface BatchInsertPayload {
   productId: number;
   lotId: number;
   batchStatus: string;
+  grade?: string | null;
+  isSample?: number;
+  sampleOnly?: number;
+  sampleAvailable?: number;
   cogsMode: string;
   unitCogs: string | null;
   unitCogsMin: string | null;
   unitCogsMax: string | null;
   paymentTerms: string;
+  ownershipType?: string;
+  amountPaid?: string;
   metadata: string | null;
   onHandQty: string;
   sampleQty: string;
@@ -38,17 +44,17 @@ function buildBatchInsertRecord(payload: BatchInsertPayload): Record<string, unk
     batchStatus: payload.batchStatus,
     isPhotographyComplete: false,
     statusId: null,
-    grade: null,
-    isSample: 0,
-    sampleOnly: 0,
-    sampleAvailable: 0,
+    grade: payload.grade ?? null,
+    isSample: payload.isSample ?? 0,
+    sampleOnly: payload.sampleOnly ?? 0,
+    sampleAvailable: payload.sampleAvailable ?? 0,
     cogsMode: payload.cogsMode,
     unitCogs: payload.unitCogs,
     unitCogsMin: payload.unitCogsMin,
     unitCogsMax: payload.unitCogsMax,
     paymentTerms: payload.paymentTerms,
-    ownership_type: "CONSIGNED",
-    amountPaid: "0",
+    ownership_type: payload.ownershipType ?? "CONSIGNED",
+    amountPaid: payload.amountPaid ?? "0",
     metadata: payload.metadata,
     photo_session_event_id: null,
     onHandQty: payload.onHandQty,
@@ -83,11 +89,14 @@ async function detectBatchColumns(): Promise<Set<string>> {
       productId: 0,
       lotId: 0,
       batchStatus: "AWAITING_INTAKE",
+      grade: null,
       cogsMode: "FIXED",
       unitCogs: "0",
       unitCogsMin: null,
       unitCogsMax: null,
       paymentTerms: "CONSIGNMENT",
+      ownershipType: "CONSIGNED",
+      amountPaid: "0",
       metadata: null,
       onHandQty: "0",
       sampleQty: "0",
@@ -140,11 +149,14 @@ async function detectBatchColumns(): Promise<Set<string>> {
       productId: 0,
       lotId: 0,
       batchStatus: "AWAITING_INTAKE",
+      grade: null,
       cogsMode: "FIXED",
       unitCogs: "0",
       unitCogsMin: null,
       unitCogsMax: null,
       paymentTerms: "CONSIGNMENT",
+      ownershipType: "CONSIGNED",
+      amountPaid: "0",
       metadata: null,
       onHandQty: "0",
       sampleQty: "0",


### PR DESCRIPTION
## Summary
- route direct intake batch creation through the legacy-compatible batch insert helper
- preserve intake-specific fields like grade and ownership on compatible schemas
- add regression coverage for the compatibility helper and intake media flow

## Verification
- pnpm exec vitest run server/lib/batchInsertCompatibility.test.ts server/inventoryIntakeService.mediaUrls.test.ts
- pnpm check
- pnpm lint
- pnpm build
- pnpm test

## Notes
- vet remains blocked in this environment because the current Codex event stream includes `collab_tool_call`, which the installed vet parser rejects.