### PR TITLE
fix(intake): avoid legacy batch reread after insert

### DIFF
--- a/server/inventoryIntakeService.mediaUrls.test.ts
+++ b/server/inventoryIntakeService.mediaUrls.test.ts
@@ -18,41 +18,14 @@ vi.mock("./sequenceDb", () => ({
   }),
 }));
 
-vi.mock("./lib/batchInsertCompatibility", async () => {
-  const { batches } = await import("../drizzle/schema");
+vi.mock("./lib/batchInsertCompatibility", async importOriginal => {
+  const actual = await importOriginal<
+    typeof import("./lib/batchInsertCompatibility")
+  >();
 
   return {
-    insertBatchWithCompatibility: vi.fn(async (tx, payload) => {
-      const [created] = await tx
-        .insert(batches)
-        .values({
-          code: payload.code,
-          sku: payload.sku,
-          productId: payload.productId,
-          lotId: payload.lotId,
-          batchStatus: payload.batchStatus,
-          grade: payload.grade ?? null,
-          cogsMode: payload.cogsMode,
-          unitCogs: payload.unitCogs,
-          unitCogsMin: payload.unitCogsMin,
-          unitCogsMax: payload.unitCogsMax,
-          paymentTerms: payload.paymentTerms,
-          ownershipType: payload.ownershipType ?? "CONSIGNED",
-          metadata: payload.metadata,
-          onHandQty: payload.onHandQty,
-          sampleQty: payload.sampleQty,
-          reservedQty: payload.reservedQty,
-          quarantineQty: payload.quarantineQty,
-          holdQty: payload.holdQty,
-          defectiveQty: payload.defectiveQty,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          deletedAt: null,
-        })
-        .$returningId();
-
-      return created.id;
-    }),
+    ...actual,
+    insertBatchWithCompatibility: vi.fn(async () => 300),
   };
 });
 

--- a/server/inventoryIntakeService.ts
+++ b/server/inventoryIntakeService.ts
@@ -32,7 +32,10 @@ import * as inventoryUtils from "./inventoryUtils";
 import { findOrCreate } from "./_core/dbUtils";
 import { logger } from "./_core/logger";
 import { withRetryableTransaction } from "./dbTransaction";
-import { insertBatchWithCompatibility } from "./lib/batchInsertCompatibility";
+import {
+  buildInsertedBatchSnapshot,
+  insertBatchWithCompatibility,
+} from "./lib/batchInsertCompatibility";
 // MEET-005, MEET-006: Import payables service for consigned inventory tracking
 import * as payablesService from "./services/payablesService";
 
@@ -261,49 +264,50 @@ export async function processIntake(input: IntakeInput): Promise<IntakeResult> {
         let batch: Batch | undefined;
         while (!batch) {
           try {
-            const batchId = await insertBatchWithCompatibility(tx, {
-                code: batchCode,
-                sku,
-                productId: product.id,
-                lotId: lot.id,
-                batchStatus: "AWAITING_INTAKE",
-                grade: input.grade ?? null,
-                isSample: 0,
-                sampleOnly: 0,
-                sampleAvailable: 0,
-                cogsMode: input.cogsMode,
-                unitCogs: input.unitCogs ?? null,
-                unitCogsMin: input.unitCogsMin ?? null,
-                unitCogsMax: input.unitCogsMax ?? null,
-                paymentTerms: input.paymentTerms,
-                ownershipType, // MEET-006
-                amountPaid: "0",
-                metadata: (() => {
-                  const metadata = input.metadata || {};
-                  if (input.mediaUrls && input.mediaUrls.length > 0) {
-                    metadata.mediaFiles = input.mediaUrls;
-                  }
-                  return Object.keys(metadata).length > 0
-                    ? inventoryUtils.stringifyMetadata(metadata)
-                    : null;
-                })(),
-                onHandQty: inventoryUtils.formatQty(input.quantity),
-                sampleQty: "0",
-                reservedQty: "0",
-                quarantineQty: "0",
-                holdQty: "0",
-                defectiveQty: "0",
-              });
+            const batchPayload = {
+              code: batchCode,
+              sku,
+              productId: product.id,
+              lotId: lot.id,
+              batchStatus: "AWAITING_INTAKE",
+              grade: input.grade ?? null,
+              isSample: 0,
+              sampleOnly: 0,
+              sampleAvailable: 0,
+              cogsMode: input.cogsMode,
+              unitCogs: input.unitCogs ?? null,
+              unitCogsMin: input.unitCogsMin ?? null,
+              unitCogsMax: input.unitCogsMax ?? null,
+              paymentTerms: input.paymentTerms,
+              ownershipType, // MEET-006
+              amountPaid: "0",
+              metadata: (() => {
+                const metadata = input.metadata || {};
+                if (input.mediaUrls && input.mediaUrls.length > 0) {
+                  metadata.mediaFiles = input.mediaUrls;
+                }
+                return Object.keys(metadata).length > 0
+                  ? inventoryUtils.stringifyMetadata(metadata)
+                  : null;
+              })(),
+              onHandQty: inventoryUtils.formatQty(input.quantity),
+              sampleQty: "0",
+              reservedQty: "0",
+              quarantineQty: "0",
+              holdQty: "0",
+              defectiveQty: "0",
+            } as const;
 
-            const [createdBatch] = await tx
-              .select()
-              .from(batches)
-              .where(eq(batches.id, batchId));
+            const batchId = await insertBatchWithCompatibility(tx, batchPayload);
 
-            if (!createdBatch) {
+            if (!batchId) {
               throw new Error("Failed to create batch");
             }
-            batch = createdBatch;
+
+            // Legacy staging does not expose the full modern batches schema.
+            // Build the newly created batch from the insert payload instead of
+            // immediately re-querying incompatible columns.
+            batch = buildInsertedBatchSnapshot(batchId, batchPayload);
           } catch (insertError) {
             if (!isDuplicateEntryError(insertError)) {
               throw insertError;

--- a/server/lib/batchInsertCompatibility.test.ts
+++ b/server/lib/batchInsertCompatibility.test.ts
@@ -215,4 +215,26 @@ describe("batchInsertCompatibility", () => {
       ["amountPaid", "125.00"],
     ]);
   });
+
+  it("builds a usable batch snapshot without re-reading modern-only columns", async () => {
+    const { buildInsertedBatchSnapshot } = await import(
+      "./batchInsertCompatibility"
+    );
+
+    const batch = buildInsertedBatchSnapshot(535, {
+      ...buildPayload(),
+      ownershipType: "OFFICE_OWNED",
+      amountPaid: "125.00",
+    });
+
+    expect(batch).toMatchObject({
+      id: 535,
+      code: "BATCH-001",
+      sku: "SKU-001",
+      ownershipType: "OFFICE_OWNED",
+      amountPaid: "125.00",
+      batchStatus: "AWAITING_INTAKE",
+      onHandQty: "10",
+    });
+  });
 });

--- a/server/lib/batchInsertCompatibility.ts
+++ b/server/lib/batchInsertCompatibility.ts
@@ -1,4 +1,5 @@
 import { sql, type SQL } from "drizzle-orm";
+import type { Batch } from "../../drizzle/schema";
 import { logger } from "../_core/logger";
 import { getDb } from "../db";
 
@@ -67,6 +68,49 @@ function buildBatchInsertRecord(payload: BatchInsertPayload): Record<string, unk
     publishB2b: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
+  };
+}
+
+export function buildInsertedBatchSnapshot(
+  id: number,
+  payload: BatchInsertPayload
+): Batch {
+  const now = new Date();
+
+  return {
+    id,
+    code: payload.code,
+    deletedAt: null,
+    version: 1,
+    sku: payload.sku,
+    productId: payload.productId,
+    lotId: payload.lotId,
+    batchStatus: payload.batchStatus as Batch["batchStatus"],
+    isPhotographyComplete: false,
+    statusId: null,
+    grade: payload.grade ?? null,
+    isSample: payload.isSample ?? 0,
+    sampleOnly: payload.sampleOnly ?? 0,
+    sampleAvailable: payload.sampleAvailable ?? 0,
+    cogsMode: payload.cogsMode as Batch["cogsMode"],
+    unitCogs: payload.unitCogs,
+    unitCogsMin: payload.unitCogsMin,
+    unitCogsMax: payload.unitCogsMax,
+    paymentTerms: payload.paymentTerms as Batch["paymentTerms"],
+    ownershipType: (payload.ownershipType ?? "CONSIGNED") as Batch["ownershipType"],
+    amountPaid: payload.amountPaid ?? "0",
+    metadata: payload.metadata,
+    photoSessionEventId: null,
+    onHandQty: payload.onHandQty,
+    sampleQty: payload.sampleQty,
+    reservedQty: payload.reservedQty,
+    quarantineQty: payload.quarantineQty,
+    holdQty: payload.holdQty,
+    defectiveQty: payload.defectiveQty,
+    publishEcom: 0,
+    publishB2b: 0,
+    createdAt: now,
+    updatedAt: now,
   };
 }
 


### PR DESCRIPTION
## Summary
- remove the immediate post-insert batch re-read from direct intake processing
- build the created batch snapshot from the insert payload for legacy staging schemas
- add regression coverage for the compatibility helper and direct-intake media flow

## Verification
- pnpm exec vitest run server/lib/batchInsertCompatibility.test.ts server/inventoryIntakeService.mediaUrls.test.ts server/inventory.test.ts
- pnpm check
- pnpm lint
- pnpm build
- pnpm test