### PR TITLE
fix(pick-pack): block draft and quote shipping actions

### DIFF
--- a/client/public/version.json
+++ b/client/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "commit": "64c5453c",
-  "date": "2026-03-11",
-  "branch": "codex/recording-backlog-closure-20260311-5be01bbf",
+  "commit": "b6412421",
+  "date": "2026-03-12",
+  "branch": "codex/ter-700-shipping-queue-truthfulness-20260312",
   "phase": "Development",
-  "buildTime": "2026-03-11T17:39:59.238Z"
+  "buildTime": "2026-03-12T21:46:56.496Z"
 }

--- a/client/version.json
+++ b/client/version.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "commit": "64c5453c",
-  "date": "2026-03-11",
-  "branch": "codex/recording-backlog-closure-20260311-5be01bbf",
+  "commit": "b6412421",
+  "date": "2026-03-12",
+  "branch": "codex/ter-700-shipping-queue-truthfulness-20260312",
   "phase": "Development",
-  "buildTime": "2026-03-11T17:39:59.238Z"
+  "buildTime": "2026-03-12T21:46:56.496Z"
 }

--- a/server/routers/pickPack.test.ts
+++ b/server/routers/pickPack.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { mapPickPackDisplayStatus } from "./pickPack";
+import { isPickPackQueueEligible, mapPickPackDisplayStatus } from "./pickPack";
+
+describe("isPickPackQueueEligible", () => {
+  it("allows only non-draft sales into the queue", () => {
+    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: false })).toBe(
+      true
+    );
+    expect(isPickPackQueueEligible({ orderType: "sale", isDraft: 0 })).toBe(
+      true
+    );
+    expect(isPickPackQueueEligible({ orderType: "QUOTE", isDraft: 1 })).toBe(
+      false
+    );
+    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: true })).toBe(
+      false
+    );
+    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: null })).toBe(
+      false
+    );
+  });
+});
 
 describe("mapPickPackDisplayStatus", () => {
   it("defaults missing statuses to pending", () => {

--- a/server/routers/pickPack.ts
+++ b/server/routers/pickPack.ts
@@ -73,6 +73,59 @@ function normalizeStatus(value: string | null | undefined): string | null {
   return value?.toUpperCase() ?? null;
 }
 
+function normalizeOrderType(value: unknown): string | null {
+  return typeof value === "string" ? value.toUpperCase() : null;
+}
+
+function normalizeDraftFlag(value: unknown): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 0) {
+      return false;
+    }
+    if (value === 1) {
+      return true;
+    }
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "0" || normalized === "false") {
+      return false;
+    }
+    if (normalized === "1" || normalized === "true") {
+      return true;
+    }
+  }
+
+  return null;
+}
+
+export function isPickPackQueueEligible(input: {
+  orderType: unknown;
+  isDraft: unknown;
+}): boolean {
+  return (
+    normalizeOrderType(input.orderType) === "SALE" &&
+    normalizeDraftFlag(input.isDraft) === false
+  );
+}
+
+function assertPickPackQueueEligible(
+  orderId: number,
+  input: { orderType: unknown; isDraft: unknown }
+): void {
+  if (!isPickPackQueueEligible(input)) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `Order ${orderId} is not eligible for pick and pack`,
+    });
+  }
+}
+
 export function mapPickPackDisplayStatus(
   rawPickPackStatus: string | null | undefined,
   rawFulfillmentStatus: string | null | undefined
@@ -192,6 +245,8 @@ export const pickPackRouter = router({
         .select({
           orderId: orders.id,
           orderNumber: orders.orderNumber,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
           clientId: orders.clientId,
           clientName: clients.name,
           items: orders.items,
@@ -208,8 +263,12 @@ export const pickPackRouter = router({
         .limit(input.limit)
         .offset(input.offset);
 
+      const eligibleOrders = pickListOrders.filter(order =>
+        isPickPackQueueEligible(order)
+      );
+
       // Get bag counts for each order
-      const orderIds = pickListOrders.map(o => o.orderId);
+      const orderIds = eligibleOrders.map(o => o.orderId);
 
       const bagCounts: Record<
         number,
@@ -265,7 +324,7 @@ export const pickPackRouter = router({
       }
 
       // Format response
-      return pickListOrders.map(order => {
+      return eligibleOrders.map(order => {
         const items = normalizeOrderItems(order.items);
         const itemCount = items.reduce(
           (sum, item) => sum + (item.quantity || 1),
@@ -326,6 +385,8 @@ export const pickPackRouter = router({
         .select({
           id: orders.id,
           orderNumber: orders.orderNumber,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
           clientId: orders.clientId,
           clientName: clients.name,
           items: orders.items,
@@ -343,6 +404,8 @@ export const pickPackRouter = router({
       if (!order) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
       }
+
+      assertPickPackQueueEligible(order.id, order);
 
       // Get bags for this order
       const bags = await db
@@ -484,7 +547,12 @@ export const pickPackRouter = router({
 
       // Verify order exists
       const [order] = await db
-        .select({ id: orders.id, pickPackStatus: orders.pickPackStatus })
+        .select({
+          id: orders.id,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
+          pickPackStatus: orders.pickPackStatus,
+        })
         .from(orders)
         .where(eq(orders.id, input.orderId))
         .limit(1);
@@ -492,6 +560,8 @@ export const pickPackRouter = router({
       if (!order) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
       }
+
+      assertPickPackQueueEligible(order.id, order);
 
       // Generate bag identifier if not provided
       let bagIdentifier = input.bagIdentifier;
@@ -622,6 +692,23 @@ export const pickPackRouter = router({
         await import("../../drizzle/schema");
       const { eq, and, isNull, sql } = await import("drizzle-orm");
 
+      const [order] = await db
+        .select({
+          id: orders.id,
+          orderNumber: orders.orderNumber,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
+        })
+        .from(orders)
+        .where(eq(orders.id, input.orderId))
+        .limit(1);
+
+      if (!order) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
+      }
+
+      assertPickPackQueueEligible(order.id, order);
+
       // Get bag IDs for this order
       const orderBagIds = await db
         .select({ id: orderBags.id })
@@ -656,13 +743,6 @@ export const pickPackRouter = router({
         );
 
       // Log the unpack action with reason to audit log (WS-005)
-      // Get order number for better audit trail
-      const [order] = await db
-        .select({ orderNumber: orders.orderNumber })
-        .from(orders)
-        .where(eq(orders.id, input.orderId))
-        .limit(1);
-
       // TER-298: Use authenticated actor ID for audit attribution
       const actorId = getAuthenticatedUserId(ctx);
       await db.insert(auditLogs).values({
@@ -721,7 +801,12 @@ export const pickPackRouter = router({
 
       // Get order items
       const [order] = await db
-        .select({ id: orders.id, items: orders.items })
+        .select({
+          id: orders.id,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
+          items: orders.items,
+        })
         .from(orders)
         .where(eq(orders.id, input.orderId))
         .limit(1);
@@ -729,6 +814,8 @@ export const pickPackRouter = router({
       if (!order) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
       }
+
+      assertPickPackQueueEligible(order.id, order);
 
       // Prefer persisted line-item IDs where available.
       const lineItemRows = await db
@@ -843,7 +930,12 @@ export const pickPackRouter = router({
 
       // Get order with items
       const [order] = await db
-        .select({ id: orders.id, items: orders.items })
+        .select({
+          id: orders.id,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
+          items: orders.items,
+        })
         .from(orders)
         .where(eq(orders.id, input.orderId))
         .limit(1);
@@ -851,6 +943,8 @@ export const pickPackRouter = router({
       if (!order) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
       }
+
+      assertPickPackQueueEligible(order.id, order);
 
       const items = normalizeOrderItems(order.items);
       const totalItemCount = items.length;
@@ -920,6 +1014,22 @@ export const pickPackRouter = router({
       const { orders } = await import("../../drizzle/schema");
       const { eq } = await import("drizzle-orm");
 
+      const [order] = await db
+        .select({
+          id: orders.id,
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
+        })
+        .from(orders)
+        .where(eq(orders.id, input.orderId))
+        .limit(1);
+
+      if (!order) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Order not found" });
+      }
+
+      assertPickPackQueueEligible(order.id, order);
+
       await db
         .update(orders)
         .set({ pickPackStatus: input.status })
@@ -959,6 +1069,8 @@ export const pickPackRouter = router({
 
       const orderStatuses = await db
         .select({
+          orderType: orders.orderType,
+          isDraft: orders.isDraft,
           pickPackStatus: orders.pickPackStatus,
           fulfillmentStatus: orders.fulfillmentStatus,
         })
@@ -972,7 +1084,7 @@ export const pickPackRouter = router({
         SHIPPED: 0,
       };
 
-      for (const order of orderStatuses) {
+      for (const order of orderStatuses.filter(isPickPackQueueEligible)) {
         const displayStatus = mapPickPackDisplayStatus(
           order.pickPackStatus,
           order.fulfillmentStatus


### PR DESCRIPTION
## Summary
- add explicit pick-pack eligibility guards so only non-draft sales can appear in the queue
- reject stale quote/draft order detail and mutation paths in the pick-pack router
- add regression coverage for shipping queue eligibility

## Verification
- pnpm exec vitest run server/routers/pickPack.test.ts
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- ~/.local/bin/vet "Ensure only eligible non-draft sales appear in pick and pack, and stale quote/draft orders cannot be opened or mutated through shipping workflows." --staged