### PR TITLE
fix(pick-pack): block legacy draft-numbered shipping rows

### DIFF
--- a/server/routers/pickPack.test.ts
+++ b/server/routers/pickPack.test.ts
@@ -4,21 +4,58 @@ import { isPickPackQueueEligible, mapPickPackDisplayStatus } from "./pickPack";
 
 describe("isPickPackQueueEligible", () => {
   it("allows only non-draft sales into the queue", () => {
-    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: false })).toBe(
-      true
-    );
-    expect(isPickPackQueueEligible({ orderType: "sale", isDraft: 0 })).toBe(
-      true
-    );
-    expect(isPickPackQueueEligible({ orderType: "QUOTE", isDraft: 1 })).toBe(
-      false
-    );
-    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: true })).toBe(
-      false
-    );
-    expect(isPickPackQueueEligible({ orderType: "SALE", isDraft: null })).toBe(
-      false
-    );
+    expect(
+      isPickPackQueueEligible({
+        orderType: "SALE",
+        isDraft: false,
+        orderNumber: "S-1773252046105",
+      })
+    ).toBe(true);
+    expect(
+      isPickPackQueueEligible({
+        orderType: "sale",
+        isDraft: 0,
+        orderNumber: "ORD-000399",
+      })
+    ).toBe(true);
+    expect(
+      isPickPackQueueEligible({
+        orderType: "QUOTE",
+        isDraft: 1,
+        orderNumber: "Q-1772732286605",
+      })
+    ).toBe(false);
+    expect(
+      isPickPackQueueEligible({
+        orderType: "SALE",
+        isDraft: true,
+        orderNumber: "D-1772572680223",
+      })
+    ).toBe(false);
+    expect(
+      isPickPackQueueEligible({
+        orderType: "SALE",
+        isDraft: null,
+        orderNumber: "O-1772576168494",
+      })
+    ).toBe(false);
+  });
+
+  it("rejects legacy draft or quote prefixes even when row flags drift", () => {
+    expect(
+      isPickPackQueueEligible({
+        orderType: "SALE",
+        isDraft: false,
+        orderNumber: "D-1772572680223",
+      })
+    ).toBe(false);
+    expect(
+      isPickPackQueueEligible({
+        orderType: "SALE",
+        isDraft: false,
+        orderNumber: "Q-1772732286605",
+      })
+    ).toBe(false);
   });
 });
 

--- a/server/routers/pickPack.ts
+++ b/server/routers/pickPack.ts
@@ -104,19 +104,30 @@ function normalizeDraftFlag(value: unknown): boolean | null {
   return null;
 }
 
+function hasExcludedQueuePrefix(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.trim().toUpperCase();
+  return normalized.startsWith("D-") || normalized.startsWith("Q-");
+}
+
 export function isPickPackQueueEligible(input: {
   orderType: unknown;
   isDraft: unknown;
+  orderNumber?: unknown;
 }): boolean {
   return (
     normalizeOrderType(input.orderType) === "SALE" &&
-    normalizeDraftFlag(input.isDraft) === false
+    normalizeDraftFlag(input.isDraft) === false &&
+    !hasExcludedQueuePrefix(input.orderNumber)
   );
 }
 
 function assertPickPackQueueEligible(
   orderId: number,
-  input: { orderType: unknown; isDraft: unknown }
+  input: { orderType: unknown; isDraft: unknown; orderNumber?: unknown }
 ): void {
   if (!isPickPackQueueEligible(input)) {
     throw new TRPCError({
@@ -549,6 +560,7 @@ export const pickPackRouter = router({
       const [order] = await db
         .select({
           id: orders.id,
+          orderNumber: orders.orderNumber,
           orderType: orders.orderType,
           isDraft: orders.isDraft,
           pickPackStatus: orders.pickPackStatus,
@@ -803,6 +815,7 @@ export const pickPackRouter = router({
       const [order] = await db
         .select({
           id: orders.id,
+          orderNumber: orders.orderNumber,
           orderType: orders.orderType,
           isDraft: orders.isDraft,
           items: orders.items,
@@ -932,6 +945,7 @@ export const pickPackRouter = router({
       const [order] = await db
         .select({
           id: orders.id,
+          orderNumber: orders.orderNumber,
           orderType: orders.orderType,
           isDraft: orders.isDraft,
           items: orders.items,
@@ -1017,6 +1031,7 @@ export const pickPackRouter = router({
       const [order] = await db
         .select({
           id: orders.id,
+          orderNumber: orders.orderNumber,
           orderType: orders.orderType,
           isDraft: orders.isDraft,
         })
@@ -1069,6 +1084,7 @@ export const pickPackRouter = router({
 
       const orderStatuses = await db
         .select({
+          orderNumber: orders.orderNumber,
           orderType: orders.orderType,
           isDraft: orders.isDraft,
           pickPackStatus: orders.pickPackStatus,


### PR DESCRIPTION
## Summary
- harden pick-pack eligibility with order-number fallback guards for legacy draft/quote rows
- carry orderNumber into queue/detail/mutation checks so stale shipping rows cannot open or mutate
- add regression coverage for live staging draft-number drift

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- ~/.local/bin/vet "Harden shipping queue eligibility so legacy draft-numbered or quote-numbered rows cannot surface, open, or mutate in pick-pack even when row flags drift." --staged
- live staging replay on /inventory?tab=shipping reproduced D- rows surfacing before this follow-up