### PR TITLE
fix(pricing): align draft profile margins with gross margin math

### DIFF
--- a/client/src/components/orders/MarginInput.test.tsx
+++ b/client/src/components/orders/MarginInput.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { MarginInput } from "./MarginInput";
 
 describe("MarginInput", () => {
-  it("uses dollar-first mode and converts dollar edits to percent", () => {
+  it("uses dollar-first mode and converts dollar edits to gross margin percent", () => {
     const onChange = vi.fn();
 
     render(
@@ -27,7 +27,29 @@ describe("MarginInput", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(onChange).toHaveBeenCalledWith(50, true);
+    expect(onChange).toHaveBeenCalledWith(33.33, true);
+  });
+
+  it("converts percent edits to the matching dollar margin", () => {
+    render(
+      <MarginInput
+        marginPercent={20}
+        marginDollar={2.5}
+        cogsPerUnit={10}
+        source="CUSTOMER_PROFILE"
+        isOverridden={false}
+        onChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText("20.0%"));
+    fireEvent.click(screen.getByRole("radio", { name: "Percent" }));
+    fireEvent.change(screen.getByLabelText("Margin (%)"), {
+      target: { value: "50" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Dollar" }));
+
+    expect(screen.getByLabelText("Margin ($)")).toHaveValue(10);
   });
 
   it("shows field/rule/fix validation guidance when value is invalid", () => {

--- a/client/src/components/orders/MarginInput.tsx
+++ b/client/src/components/orders/MarginInput.tsx
@@ -52,11 +52,28 @@ export function MarginInput({
     );
   }, [inputMode, isEditing, marginDollar, marginPercent]);
 
+  const roundToTwoDecimals = (value: number): number =>
+    Math.round(value * 100) / 100;
+
   const marginPercentFromDollar = (value: number): number => {
+    const retailPrice = cogsPerUnit + value;
+    if (retailPrice <= 0) {
+      return 0;
+    }
+    return roundToTwoDecimals((value / retailPrice) * 100);
+  };
+
+  const marginDollarFromPercent = (value: number): number => {
     if (cogsPerUnit <= 0) {
       return 0;
     }
-    return (value / cogsPerUnit) * 100;
+
+    if (value >= 100) {
+      return 0;
+    }
+
+    const retailPrice = cogsPerUnit / (1 - value / 100);
+    return roundToTwoDecimals(retailPrice - cogsPerUnit);
   };
 
   const sourceLabel =
@@ -117,7 +134,11 @@ export function MarginInput({
     }
 
     if (inputMode === "percent" && parsed < -100) {
-      return "Field: Margin (%). Rule: cannot be less than -100%. Fix: use a value between -100 and your target markup.";
+      return "Field: Margin (%). Rule: cannot be less than -100%. Fix: use a value between -100 and your target margin.";
+    }
+
+    if (inputMode === "percent" && parsed >= 100) {
+      return "Field: Margin (%). Rule: must stay below 100%. Fix: use a value below 100 or switch to dollar mode.";
     }
 
     if (inputMode === "dollar" && cogsPerUnit <= 0 && parsed !== 0) {
@@ -210,7 +231,7 @@ export function MarginInput({
                 const numericValue = parseFloat(inputValue);
                 if (nextMode !== inputMode && Number.isFinite(numericValue)) {
                   if (nextMode === "dollar") {
-                    const dollarValue = (cogsPerUnit * numericValue) / 100;
+                    const dollarValue = marginDollarFromPercent(numericValue);
                     setInputValue(dollarValue.toFixed(2));
                   } else {
                     const percentValue = marginPercentFromDollar(numericValue);

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -248,6 +248,23 @@ const parseRouteEntityId = (value: string | null): number | null => {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 };
 
+const calculateMarginPercentFromRetailPrice = (
+  cogsPerUnit: number,
+  retailPrice: number
+): number => {
+  if (
+    !Number.isFinite(cogsPerUnit) ||
+    !Number.isFinite(retailPrice) ||
+    retailPrice <= 0
+  ) {
+    return 0;
+  }
+
+  return (
+    Math.round(((retailPrice - cogsPerUnit) / retailPrice) * 100 * 100) / 100
+  );
+};
+
 const mapDraftLineItemsToEditorState = (
   lineItems: DraftLineItemPayload[]
 ): LineItem[] =>
@@ -827,10 +844,10 @@ export default function OrderCreatorPageV2() {
           : item.cogsPerUnit;
         const retailPrice =
           profilePricing.retailPrice ?? profilePricing.basePrice ?? cogsPerUnit;
-        const marginPercent =
-          cogsPerUnit > 0
-            ? ((retailPrice - cogsPerUnit) / cogsPerUnit) * 100
-            : 0;
+        const marginPercent = calculateMarginPercentFromRetailPrice(
+          cogsPerUnit,
+          retailPrice
+        );
         const recalculated = calculateLineItem(
           item.batchId,
           item.quantity,
@@ -1199,8 +1216,10 @@ export default function OrderCreatorPageV2() {
       const cogsPerUnit =
         item.effectiveCogs ?? item.basePrice ?? item.unitCogs ?? 0;
       const retailPrice = item.retailPrice || item.basePrice || 0;
-      const marginPercent =
-        cogsPerUnit > 0 ? ((retailPrice - cogsPerUnit) / cogsPerUnit) * 100 : 0;
+      const marginPercent = calculateMarginPercentFromRetailPrice(
+        cogsPerUnit,
+        retailPrice
+      );
 
       const availableUnits = Math.max(1, Math.floor(item.quantity ?? 1));
       const quantity =

--- a/server/routers/orders.pricing-context.test.ts
+++ b/server/routers/orders.pricing-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDraftPricingLookupOptions } from "./orders";
+
+describe("buildDraftPricingLookupOptions", () => {
+  it("preserves downstream pricing metadata needed for profile rule matching", () => {
+    expect(
+      buildDraftPricingLookupOptions({
+        productName: "Blue Dream 14g",
+        productSubcategory: "Indoor Flower",
+        batchGrade: "A",
+        supplierName: "Redwood Supply",
+      })
+    ).toEqual({
+      itemName: "Blue Dream 14g",
+      subcategory: "Indoor Flower",
+      grade: "A",
+      vendor: "Redwood Supply",
+    });
+  });
+
+  it("drops null metadata instead of sending empty pricing conditions", () => {
+    expect(
+      buildDraftPricingLookupOptions({
+        productName: null,
+        productSubcategory: null,
+        batchGrade: null,
+        supplierName: null,
+      })
+    ).toEqual({
+      itemName: undefined,
+      subcategory: undefined,
+      grade: undefined,
+      vendor: undefined,
+    });
+  });
+});

--- a/server/routers/orders.ts
+++ b/server/routers/orders.ts
@@ -148,6 +148,64 @@ const createOrderInputSchema = z.object({
 
 type DraftLineItemInput = z.infer<typeof lineItemInputSchema>;
 
+type DraftBatchPricingContext = Pick<
+  Batch,
+  "id" | "productId" | "cogsMode" | "unitCogs" | "unitCogsMin" | "unitCogsMax"
+> & {
+  batchGrade: string | null;
+  productCategory: string | null;
+  productName: string | null;
+  productSubcategory: string | null;
+  supplierName: string | null;
+};
+
+export function buildDraftPricingLookupOptions(
+  batchContext: Pick<
+    DraftBatchPricingContext,
+    "productName" | "productSubcategory" | "batchGrade" | "supplierName"
+  >
+) {
+  return {
+    itemName: batchContext.productName ?? undefined,
+    subcategory: batchContext.productSubcategory ?? undefined,
+    grade: batchContext.batchGrade ?? undefined,
+    vendor: batchContext.supplierName ?? undefined,
+  };
+}
+
+async function getDraftBatchPricingContext(
+  db: Exclude<Awaited<ReturnType<typeof getDb>>, null>,
+  batchId: number
+): Promise<DraftBatchPricingContext> {
+  const batchContext = await db
+    .select({
+      id: batches.id,
+      productId: batches.productId,
+      cogsMode: batches.cogsMode,
+      unitCogs: batches.unitCogs,
+      unitCogsMin: batches.unitCogsMin,
+      unitCogsMax: batches.unitCogsMax,
+      batchGrade: batches.grade,
+      productCategory: products.category,
+      productName: products.nameCanonical,
+      productSubcategory: products.subcategory,
+      supplierName: clients.name,
+    })
+    .from(batches)
+    .innerJoin(products, eq(batches.productId, products.id))
+    .innerJoin(lots, eq(batches.lotId, lots.id))
+    .leftJoin(clients, eq(lots.supplierClientId, clients.id))
+    .where(eq(batches.id, batchId))
+    .limit(1)
+    .then(rows => rows[0]);
+
+  if (!batchContext) {
+    throw new Error(`Batch ${batchId} not found`);
+  }
+
+  return batchContext;
+}
+
 function resolveDraftLineItemCogs(
   batch: Pick<
     Batch,
@@ -845,28 +903,7 @@ export const ordersRouter = router({
       // Calculate line item prices and totals
       const lineItemsWithPrices = await Promise.all(
         input.lineItems.map(async item => {
-          // Get batch info for COGS
-          const batch = await db.query.batches.findFirst({
-            where: eq(batches.id, item.batchId),
-            columns: {
-              id: true,
-              productId: true,
-              cogsMode: true,
-              unitCogs: true,
-              unitCogsMin: true,
-              unitCogsMax: true,
-            },
-          });
-
-          if (!batch) {
-            throw new Error(`Batch ${item.batchId} not found`);
-          }
-
-          // Get product info for category lookup
-          const product = await db.query.products.findFirst({
-            where: eq(products.id, batch.productId),
-            columns: { category: true },
-          });
+          const batch = await getDraftBatchPricingContext(db, item.batchId);
 
           const resolvedCogs = resolveDraftLineItemCogs(batch, item);
           if (
@@ -888,13 +925,13 @@ export const ordersRouter = router({
             marginPercent = item.marginPercent;
             marginSource = "MANUAL";
           } else {
-            // Try to get margin using product category or fallback to "OTHER"
-            const productCategory = product?.category || "OTHER";
+            const productCategory = batch.productCategory || "OTHER";
             const marginResult = await pricingService.getMarginWithFallback(
               input.clientId,
               productCategory,
               {
                 basePrice: resolvedCogs.cogsPerUnit,
+                ...buildDraftPricingLookupOptions(batch),
               }
             );
 
@@ -1100,29 +1137,7 @@ export const ordersRouter = router({
       // Calculate line item prices (same logic as createDraftEnhanced)
       const lineItemsWithPrices = await Promise.all(
         input.lineItems.map(async item => {
-          const batch = await db.query.batches.findFirst({
-            where: eq(batches.id, item.batchId),
-            columns: {
-              id: true,
-              productId: true,
-              cogsMode: true,
-              unitCogs: true,
-              unitCogsMin: true,
-              unitCogsMax: true,
-            },
-          });
-
-          if (!batch) {
-            throw new Error(`Batch ${item.batchId} not found`);
-          }
-
-          // BUG-086 FIX: Get product category like createDraftEnhanced does
-          const product = batch.productId
-            ? await db.query.products.findFirst({
-                where: eq(products.id, batch.productId),
-                columns: { category: true },
-              })
-            : null;
+          const batch = await getDraftBatchPricingContext(db, item.batchId);
 
           const resolvedCogs = resolveDraftLineItemCogs(batch, item);
           if (
@@ -1143,13 +1158,13 @@ export const ordersRouter = router({
             marginPercent = item.marginPercent;
             marginSource = "MANUAL";
           } else {
-            // BUG-086 FIX: Use actual product category, not hardcoded "OTHER"
-            const productCategory = product?.category || "OTHER";
+            const productCategory = batch.productCategory || "OTHER";
             const marginResult = await pricingService.getMarginWithFallback(
               input.clientId,
               productCategory,
               {
                 basePrice: resolvedCogs.cogsPerUnit,
+                ...buildDraftPricingLookupOptions(batch),
               }
             );
 

--- a/server/services/pricingService.test.ts
+++ b/server/services/pricingService.test.ts
@@ -41,7 +41,7 @@ describe("pricingService range pricing defaults", () => {
     vi.clearAllMocks();
   });
 
-  it("uses pricing profile rules when a base price is provided", async () => {
+  it("uses pricing profile rules with the full downstream pricing context", async () => {
     const selectChain = createSelectChain([
       { id: 15, pricingProfileId: 42, customPricingRules: null },
     ]);
@@ -64,12 +64,26 @@ describe("pricingService range pricing defaults", () => {
 
     const result = await pricingService.getMarginWithFallback(15, "FLOWER", {
       basePrice: 10,
+      itemName: "Blue Dream 14g",
+      subcategory: "Indoor Flower",
+      grade: "A",
+      vendor: "Redwood Supply",
     });
 
     expect(mockedGetClientPricingRules).toHaveBeenCalledWith(15);
-    expect(mockedCalculateRetailPrice).toHaveBeenCalledOnce();
+    expect(mockedCalculateRetailPrice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Blue Dream 14g",
+        category: "FLOWER",
+        subcategory: "Indoor Flower",
+        grade: "A",
+        vendor: "Redwood Supply",
+        basePrice: 10,
+      }),
+      expect.any(Array)
+    );
     expect(result).toEqual({
-      marginPercent: 50,
+      marginPercent: 33.33,
       source: "CUSTOMER_PROFILE",
       customerId: 15,
       productCategory: "FLOWER",

--- a/server/services/pricingService.ts
+++ b/server/services/pricingService.ts
@@ -20,6 +20,7 @@ import {
   type InventoryItem,
 } from "../pricingEngine";
 import type { CogsRangeBasis, PricingChannel } from "../cogsCalculator";
+import { marginCalculationService } from "./marginCalculationService";
 
 export interface MarginResult {
   marginPercent: number | null;
@@ -103,8 +104,10 @@ export const pricingService = {
 
         if (basePrice > 0) {
           return {
-            marginPercent:
-              ((pricedItem.retailPrice - basePrice) / basePrice) * 100,
+            marginPercent: marginCalculationService.calculateMarginPercent(
+              basePrice,
+              pricedItem.retailPrice
+            ),
             source: "CUSTOMER_PROFILE",
             customerId,
             productCategory,


### PR DESCRIPTION
## Summary
- load the full draft batch pricing context when draft sale orders use customer pricing profiles
- calculate and round margin values using gross-margin math in the pricing service and order editor
- add regression coverage for draft pricing lookup context and percent-dollar conversion behavior

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- ~/.local/bin/vet --staged --repo /Users/evan/spec-erp-docker/TERP/worktrees/pricing-profile-propagation-20260312 "Verify pricing profile propagation preserves correct gross margin math and draft pricing context for sales orders"