### PR TITLE
fix(routes): canonicalize sales and operations redirects

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -63,7 +63,6 @@ import WorkflowQueuePage from "@/pages/WorkflowQueuePage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import SearchResultsPage from "@/pages/SearchResultsPage";
 import LeaderboardPage from "@/pages/LeaderboardPage";
-import UnifiedSalesPortalPage from "@/pages/UnifiedSalesPortalPage";
 import { QuickAddTaskModal } from "@/components/todos/QuickAddTaskModal";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -544,11 +543,15 @@ function Router() {
                 />
                 <Route
                   path="/sales-portal"
-                  component={withErrorBoundary(UnifiedSalesPortalPage)}
+                  component={RedirectWithTab(
+                    "/sales-portal",
+                    "/sales",
+                    "live-shopping"
+                  )}
                 />
                 <Route
                   path="/orders"
-                  component={withErrorBoundary(SalesWorkspacePage)}
+                  component={RedirectWithTab("/orders", "/sales", "orders")}
                 />
                 <Route
                   path="/pick-pack"
@@ -686,10 +689,9 @@ function Router() {
                 />
                 <Route
                   path="/inventory-browse"
-                  component={RedirectWithTab(
+                  component={RedirectToOperationsTab(
                     "/inventory-browse",
-                    "/purchase-orders",
-                    "inventory-browse"
+                    "inventory"
                   )}
                 />
                 <Route

--- a/client/src/components/dashboard/owner/OwnerQuickCardsWidget.tsx
+++ b/client/src/components/dashboard/owner/OwnerQuickCardsWidget.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { useLocation } from "wouter";
 
 export const OwnerQuickCardsWidget = memo(function OwnerQuickCardsWidget() {
@@ -95,7 +96,7 @@ export const OwnerQuickCardsWidget = memo(function OwnerQuickCardsWidget() {
             <div className="grid grid-cols-2 gap-2">
               <button
                 className="rounded border bg-muted/40 p-2 text-left hover:bg-muted/60 transition-colors"
-                onClick={() => setLocation("/orders")}
+                onClick={() => setLocation(buildSalesWorkspacePath("orders"))}
               >
                 <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                   Sold Today

--- a/client/src/components/dashboard/widgets-v2/TransactionSnapshotWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/TransactionSnapshotWidget.tsx
@@ -19,6 +19,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { useLocation } from "wouter";
 
 export const TransactionSnapshotWidget = memo(
@@ -42,7 +43,7 @@ export const TransactionSnapshotWidget = memo(
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => setLocation("/orders")}
+            onClick={() => setLocation(buildSalesWorkspacePath("orders"))}
             className="text-xs"
           >
             View Orders <ArrowRight className="h-3 w-3 ml-1" />
@@ -67,7 +68,7 @@ export const TransactionSnapshotWidget = memo(
               <TableBody>
                 <TableRow
                   className="cursor-pointer hover:bg-muted/50 transition-colors"
-                  onClick={() => setLocation("/orders")}
+                  onClick={() => setLocation(buildSalesWorkspacePath("orders"))}
                 >
                   <TableCell className="font-medium">Sales</TableCell>
                   <TableCell className="text-right font-mono">

--- a/client/src/components/inbox/InboxItem.route.test.ts
+++ b/client/src/components/inbox/InboxItem.route.test.ts
@@ -4,7 +4,7 @@ import { buildInboxEntityRoute } from "./InboxItem";
 
 describe("buildInboxEntityRoute", () => {
   it("routes core entities into canonical workspace paths", () => {
-    expect(buildInboxEntityRoute("order", 55)).toBe("/orders?id=55");
+    expect(buildInboxEntityRoute("order", 55)).toBe("/sales?tab=orders&id=55");
     expect(buildInboxEntityRoute("invoice", 91)).toBe(
       "/accounting?tab=invoices&id=91"
     );

--- a/client/src/components/inbox/InboxItem.test.tsx
+++ b/client/src/components/inbox/InboxItem.test.tsx
@@ -58,7 +58,7 @@ vi.mock("@/lib/trpc", () => ({
 
 describe("buildInboxEntityRoute", () => {
   it.each([
-    ["order", 12, "/orders?id=12"],
+    ["order", 12, "/sales?tab=orders&id=12"],
     ["invoice", 21, "/accounting?tab=invoices&id=21"],
     ["payment", 34, "/accounting?tab=payments&id=34"],
     ["bill", 55, "/accounting?tab=bills&id=55"],

--- a/client/src/components/inbox/InboxItem.tsx
+++ b/client/src/components/inbox/InboxItem.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { trpc } from "@/lib/trpc";
 import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -57,7 +58,7 @@ export function buildInboxEntityRoute(
 ): string | null {
   switch (referenceType) {
     case "order":
-      return `/orders?id=${referenceId}`;
+      return buildSalesWorkspacePath("orders", { id: referenceId });
     case "invoice":
       return `/accounting?tab=invoices&id=${referenceId}`;
     case "payment":

--- a/client/src/components/inventory/ProductConnections.tsx
+++ b/client/src/components/inventory/ProductConnections.tsx
@@ -13,6 +13,7 @@
 import React, { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { buildRelationshipProfilePath } from "@/lib/relationshipProfile";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import {
   Card,
   CardContent,
@@ -300,7 +301,9 @@ export function ProductConnections({
                                     onCreateOrderClick(connection.clientId);
                                   } else {
                                     setLocation(
-                                      `/orders/new?clientId=${connection.clientId}`
+                                      buildSalesWorkspacePath("create-order", {
+                                        clientId: connection.clientId,
+                                      })
                                     );
                                   }
                                 }}

--- a/client/src/components/sales/SalesSheetPreview.tsx
+++ b/client/src/components/sales/SalesSheetPreview.tsx
@@ -122,7 +122,9 @@ function SortableItem({
     typeof item.effectiveCogs === "number";
   const internalRangeMin = showInternalRangeContext ? item.unitCogsMin : null;
   const internalRangeMax = showInternalRangeContext ? item.unitCogsMax : null;
-  const internalEffectiveCogs = showInternalRangeContext ? item.effectiveCogs : null;
+  const internalEffectiveCogs = showInternalRangeContext
+    ? item.effectiveCogs
+    : null;
   const displayPrice = item.priceOverride ?? item.retailPrice;
   const hasOverride = item.priceOverride !== undefined;
 
@@ -191,7 +193,8 @@ function SortableItem({
                   Internal
                 </Badge>
                 <span>
-                  {INTERNAL_BASIS_LABELS[item.effectiveCogsBasis || "MID"]} basis
+                  {INTERNAL_BASIS_LABELS[item.effectiveCogsBasis || "MID"]}{" "}
+                  basis
                 </span>
                 <span>
                   Vendor COGS ${internalRangeMin?.toFixed(2)} to $
@@ -367,7 +370,7 @@ export function SalesSheetPreview({
   const convertToOrderMutation = trpc.salesSheets.convertToOrder.useMutation({
     onSuccess: data => {
       toast.success("Converted to order successfully");
-      setLocation(`/orders?id=${data.orderId}`);
+      setLocation(buildSalesWorkspacePath("orders", { id: data.orderId }));
     },
     onError: error => {
       toast.error("Failed to convert to order: " + error.message);

--- a/client/src/components/work-surface/ClientLedgerWorkSurface.tsx
+++ b/client/src/components/work-surface/ClientLedgerWorkSurface.tsx
@@ -15,6 +15,7 @@
 
 import React, { useState, useCallback, useRef, useMemo } from "react";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import { cn, formatCurrency, formatDate } from "@/lib/utils";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -818,7 +819,7 @@ export function ClientLedgerWorkSurface() {
       let path = "";
       switch (type) {
         case "ORDER":
-          path = `/orders?id=${id}`;
+          path = buildSalesWorkspacePath("orders", { id });
           break;
         case "PAYMENT":
           path = `/accounting/payments?id=${id}`;

--- a/client/src/lib/data-cards/metricConfigs.ts
+++ b/client/src/lib/data-cards/metricConfigs.ts
@@ -28,6 +28,9 @@ import {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { MetricConfig, ModuleConfig } from "./types";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
+
+const SALES_ORDERS_PATH = buildSalesWorkspacePath("orders");
 
 // ============================================================================
 // METRIC CONFIGURATIONS
@@ -183,7 +186,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
     },
   },
 
@@ -196,7 +199,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ status: "READY_FOR_PACKING" }),
     },
   },
@@ -210,7 +213,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ status: "PACKED" }),
     },
   },
@@ -224,7 +227,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ status: "SHIPPED" }),
     },
   },
@@ -238,7 +241,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ status: "DELIVERED" }),
     },
   },
@@ -252,7 +255,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "currency",
     category: "financial",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ sortBy: "totalAmount", sortOrder: "desc" }),
     },
   },
@@ -266,7 +269,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "analytical",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ period: "current_week" }),
     },
   },
@@ -280,7 +283,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ overdue: "true" }),
     },
   },
@@ -294,7 +297,7 @@ export const METRIC_CONFIGS: Record<string, MetricConfig> = {
     format: "count",
     category: "operational",
     destination: {
-      path: "/orders",
+      path: SALES_ORDERS_PATH,
       getParams: () => ({ hasReturns: "true" }),
     },
   },

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -230,7 +230,7 @@ export default function AnalyticsPage() {
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <MetricCard
               title="Total Orders"
-              href="/orders"
+              href="/sales?tab=orders"
               value={(data?.totalOrders ?? 0).toLocaleString()}
               subtitle={`${data?.ordersThisPeriod ?? 0} this period`}
               icon={TrendingUp}

--- a/client/src/pages/ClientProfilePage.tsx
+++ b/client/src/pages/ClientProfilePage.tsx
@@ -89,7 +89,7 @@ const sourcePathForLedgerEntry = (
 ) => {
   switch (entry.sourceType) {
     case "ORDER":
-      return `/orders?id=${entry.sourceId}`;
+      return buildSalesWorkspacePath("orders", { id: entry.sourceId });
     case "PAYMENT":
       return `/accounting/payments?id=${entry.sourceId}`;
     case "PURCHASE_ORDER":
@@ -454,7 +454,9 @@ export default function ClientProfilePage() {
                   <div className="space-y-2 text-sm">
                     <p className="font-medium">Core Handles</p>
                     <p>Code name: {shell.name}</p>
-                    <p>Relationship code: {shell.teriCode || "Not assigned yet"}</p>
+                    <p>
+                      Relationship code: {shell.teriCode || "Not assigned yet"}
+                    </p>
                     <p>
                       Email handle: {shell.email || "No email handle on file"}
                     </p>
@@ -570,7 +572,9 @@ export default function ClientProfilePage() {
             {shell.wishlist ? (
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-base">Preferences & Notes</CardTitle>
+                  <CardTitle className="text-base">
+                    Preferences & Notes
+                  </CardTitle>
                 </CardHeader>
                 <CardContent className="text-sm text-muted-foreground whitespace-pre-wrap">
                   {shell.wishlist}

--- a/client/src/pages/ProcurementWorkspacePage.tsx
+++ b/client/src/pages/ProcurementWorkspacePage.tsx
@@ -7,7 +7,7 @@ import { useQueryTabState } from "@/hooks/useQueryTabState";
 import { useWorkspaceHomeTelemetry } from "@/hooks/useWorkspaceHomeTelemetry";
 import PurchaseOrdersSlicePage from "@/components/uiux-slice/PurchaseOrdersSlicePage";
 import { buildOperationsWorkspacePath } from "@/lib/workspaceRoutes";
-import { Redirect } from "wouter";
+import { Redirect, useSearch } from "wouter";
 
 type ProcurementTab = "purchase-orders";
 type ProcurementQueryTab =
@@ -21,6 +21,7 @@ const PROCUREMENT_TABS = [
 ] as const satisfies readonly LinearWorkspaceTab<ProcurementTab>[];
 
 export default function ProcurementWorkspacePage() {
+  const search = useSearch();
   const { activeTab, setActiveTab } = useQueryTabState<ProcurementQueryTab>({
     defaultTab: "purchase-orders",
     validTabs: [
@@ -30,15 +31,28 @@ export default function ProcurementWorkspacePage() {
       "receiving",
     ],
   });
+  const redirectParams = Object.fromEntries(
+    Array.from(new URLSearchParams(search).entries()).filter(
+      ([key]) => key !== "tab"
+    )
+  );
 
   useWorkspaceHomeTelemetry("procurement", activeTab);
 
   if (activeTab === "receiving" || activeTab === "product-intake") {
-    return <Redirect to={buildOperationsWorkspacePath("receiving")} />;
+    return (
+      <Redirect
+        to={buildOperationsWorkspacePath("receiving", redirectParams)}
+      />
+    );
   }
 
   if (activeTab === "inventory-browse") {
-    return <Redirect to={buildOperationsWorkspacePath("inventory")} />;
+    return (
+      <Redirect
+        to={buildOperationsWorkspacePath("inventory", redirectParams)}
+      />
+    );
   }
 
   return (

--- a/client/src/pages/ReturnsPage.tsx
+++ b/client/src/pages/ReturnsPage.tsx
@@ -34,6 +34,7 @@ import { Checkbox } from "../components/ui/checkbox";
 import { useAuth } from "@/hooks/useAuth";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { ReturnGLStatus } from "@/components/accounting/GLReversalStatus";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 
 type ReturnReason =
   | "DEFECTIVE"
@@ -214,7 +215,11 @@ export default function ReturnsPage({ embedded = false }: ReturnsPageProps) {
   return (
     <div className="p-4 md:p-8">
       {!embedded && (
-        <BackButton label="Back to Orders" to="/orders" className="mb-4" />
+        <BackButton
+          label="Back to Orders"
+          to={buildSalesWorkspacePath("orders")}
+          className="mb-4"
+        />
       )}
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Returns Management</h1>

--- a/client/src/pages/SalesSheetCreatorPage.tsx
+++ b/client/src/pages/SalesSheetCreatorPage.tsx
@@ -413,9 +413,17 @@ export default function SalesSheetCreatorPage({
   );
 
   return (
-    <div className={embedded ? "space-y-6" : "container mx-auto p-4 md:p-6 space-y-6"}>
+    <div
+      className={
+        embedded ? "space-y-6" : "container mx-auto p-4 md:p-6 space-y-6"
+      }
+    >
       {!embedded ? (
-        <BackButton label="Back to Orders" to="/orders" className="mb-4" />
+        <BackButton
+          label="Back to Orders"
+          to={buildSalesWorkspacePath("orders")}
+          className="mb-4"
+        />
       ) : null}
       <Card>
         <CardHeader>

--- a/client/src/pages/SalesWorkspacePage.tsx
+++ b/client/src/pages/SalesWorkspacePage.tsx
@@ -13,7 +13,7 @@ import {
   LinearWorkspaceShell,
   type LinearWorkspaceTab,
 } from "@/components/layout/LinearWorkspaceShell";
-import { Redirect } from "wouter";
+import { Redirect, useSearch } from "wouter";
 
 type BaseSalesTab = (typeof SALES_WORKSPACE.tabs)[number]["value"];
 type SalesTab = BaseSalesTab | "create-order";
@@ -29,14 +29,22 @@ const SALES_TABS = SALES_TABS_CONFIG.map(
 ) as readonly SalesTab[];
 
 export default function SalesWorkspacePage() {
+  const search = useSearch();
   const { activeTab, setActiveTab } = useQueryTabState<SalesQueryTab>({
     defaultTab: "orders",
     validTabs: [...SALES_TABS, "pick-pack"],
   });
+  const redirectParams = Object.fromEntries(
+    Array.from(new URLSearchParams(search).entries()).filter(
+      ([key]) => key !== "tab"
+    )
+  );
   useWorkspaceHomeTelemetry("sales", activeTab);
 
   if (activeTab === "pick-pack") {
-    return <Redirect to={buildOperationsWorkspacePath("shipping")} />;
+    return (
+      <Redirect to={buildOperationsWorkspacePath("shipping", redirectParams)} />
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- redirect legacy sales portal and orders routes into the canonical Sales workspace tabs
- redirect legacy inventory-browse and procurement detours into the canonical Operations tabs while preserving deep-link params
- update inbox, metrics, widgets, and related links to open order flows through the canonical Sales workspace

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- git diff --cached --check
- attempted vet with conversation history; command stalled in this environment after analysis started, so I manually reviewed the diff before commit