### PR TITLE
fix(dashboard): route orders shortcut to sales tab

### DIFF
--- a/client/src/components/dashboard/SimpleDashboard.test.tsx
+++ b/client/src/components/dashboard/SimpleDashboard.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
+import { SimpleDashboard } from "./SimpleDashboard";
+
+const mockSetLocation = vi.fn();
+
+vi.mock("wouter", () => ({
+  useLocation: () => ["/", mockSetLocation] as const,
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    dashboard: {
+      getTransactionSnapshot: {
+        useQuery: () => ({
+          data: {
+            today: {
+              sales: 1383.82,
+              unitsSold: 4,
+              cashCollected: 186016,
+            },
+            thisWeek: {
+              sales: 4123.5,
+            },
+          },
+          isLoading: false,
+        }),
+      },
+      getTotalDebt: {
+        useQuery: () => ({
+          data: {
+            totalDebtOwedToMe: 963104,
+          },
+          isLoading: false,
+        }),
+      },
+    },
+    inventory: {
+      dashboardStats: {
+        useQuery: () => ({
+          data: {
+            statusCounts: {
+              LIVE: 178,
+              QUARANTINED: 9,
+              ON_HOLD: 9,
+            },
+          },
+          isLoading: false,
+        }),
+      },
+    },
+    purchaseOrders: {
+      getAll: {
+        useQuery: () => ({
+          data: {
+            items: [
+              { purchaseOrderStatus: "CONFIRMED" },
+              { purchaseOrderStatus: "SENT" },
+            ],
+          },
+          isLoading: false,
+        }),
+      },
+    },
+    appointmentRequests: {
+      list: {
+        useQuery: () => ({
+          data: {
+            requests: [],
+          },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
+
+describe("SimpleDashboard", () => {
+  beforeEach(() => {
+    mockSetLocation.mockReset();
+  });
+
+  it("routes the Today's Orders shortcut to the sales orders tab", () => {
+    render(<SimpleDashboard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /view orders/i }));
+
+    expect(mockSetLocation).toHaveBeenCalledWith(
+      buildSalesWorkspacePath("orders")
+    );
+  });
+});

--- a/client/src/components/dashboard/SimpleDashboard.tsx
+++ b/client/src/components/dashboard/SimpleDashboard.tsx
@@ -11,6 +11,7 @@ import { useLocation } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
 import {
   ShoppingCart,
   FileText,
@@ -76,7 +77,7 @@ const TodaysOrdersCard = memo(function TodaysOrdersCard() {
               variant="ghost"
               size="sm"
               className="mt-2 h-7 text-xs px-0"
-              onClick={() => setLocation("/sales")}
+              onClick={() => setLocation(buildSalesWorkspacePath("orders"))}
             >
               View orders <ArrowRight className="h-3 w-3 ml-1" />
             </Button>


### PR DESCRIPTION
## Summary
- route the dashboard Today's Orders shortcut to the canonical sales orders workspace path
- add a regression test so the dashboard button keeps targeting the orders tab explicitly

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- pnpm exec vitest run client/src/components/dashboard/SimpleDashboard.test.tsx

## Notes
- vet attempted, but the CLI returned an Anthropic billing/credits error in this environment