### PR TITLE
fix(orders): gate invoice action by permissions

### DIFF
--- a/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
+++ b/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
@@ -3,6 +3,7 @@ import {
   buildConfirmedQueryInput,
   buildDraftQueryInput,
   canDownloadInvoice,
+  canGenerateInvoice,
   getMakePaymentRoute,
   getDisplayOrderNumber,
   parseDeepLinkedOrderId,
@@ -126,6 +127,75 @@ describe("canDownloadInvoice", () => {
     expect(canDownloadInvoice({ invoiceId: null }, true)).toBe(false);
     expect(canDownloadInvoice({ invoiceId: 12 }, false)).toBe(false);
     expect(canDownloadInvoice(null, true)).toBe(false);
+  });
+});
+
+describe("canGenerateInvoice", () => {
+  it("requires accounting access before surfacing invoice generation", () => {
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "SALE",
+          invoiceId: null,
+          fulfillmentStatus: "PACKED",
+        },
+        true
+      )
+    ).toBe(true);
+
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "SALE",
+          invoiceId: null,
+          fulfillmentStatus: "PACKED",
+        },
+        false
+      )
+    ).toBe(false);
+  });
+
+  it("blocks invoice generation when the order is not invoice-eligible", () => {
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "QUOTE",
+          invoiceId: null,
+          fulfillmentStatus: "PACKED",
+        },
+        true
+      )
+    ).toBe(false);
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "SALE",
+          invoiceId: 17,
+          fulfillmentStatus: "PACKED",
+        },
+        true
+      )
+    ).toBe(false);
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "SALE",
+          invoiceId: null,
+          fulfillmentStatus: "READY_FOR_PACKING",
+        },
+        true
+      )
+    ).toBe(true);
+    expect(
+      canGenerateInvoice(
+        {
+          orderType: "SALE",
+          invoiceId: null,
+          fulfillmentStatus: "DELIVERED",
+        },
+        true
+      )
+    ).toBe(false);
   });
 });
 

--- a/client/src/components/work-surface/OrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/OrdersWorkSurface.tsx
@@ -148,6 +148,27 @@ export function canDownloadInvoice(
   return Boolean(canAccessAccounting && order?.invoiceId);
 }
 
+export function canGenerateInvoice(
+  order:
+    | {
+        orderType?: string | null;
+        invoiceId?: number | null;
+        fulfillmentStatus?: string | null;
+      }
+    | null,
+  canAccessAccounting: boolean
+): boolean {
+  return Boolean(
+    canAccessAccounting &&
+      order?.orderType === "SALE" &&
+      !order.invoiceId &&
+      order.fulfillmentStatus &&
+      ["READY_FOR_PACKING", "PACKED", "SHIPPED"].includes(
+        order.fulfillmentStatus
+      )
+  );
+}
+
 export function getMakePaymentRoute(
   order: Pick<Order, "id" | "invoiceId"> | null
 ): string | null {
@@ -767,12 +788,14 @@ function OrderInspectorContent({
                     Ship Order
                   </Button>
                 )}
-              {order.orderType === "SALE" &&
-                !order.invoiceId &&
-                fulfillmentStatus &&
-                ["READY_FOR_PACKING", "PACKED", "SHIPPED"].includes(
-                  fulfillmentStatus
-                ) &&
+              {canGenerateInvoice(
+                {
+                  orderType: order.orderType,
+                  invoiceId: order.invoiceId,
+                  fulfillmentStatus,
+                },
+                canAccessAccounting
+              ) &&
                 onGenerateInvoice && (
                   <Button
                     variant="default"


### PR DESCRIPTION
## Summary
- hide the sales order invoice action unless the current role has accounting access
- centralize the invoice-eligibility check in a helper so the inspector logic stays consistent
- add regression coverage for the permission gate and invoice-eligibility cases

## Verification
- pnpm exec vitest run client/src/components/work-surface/OrdersWorkSurface.query.test.ts
- pnpm check
- pnpm lint
- pnpm test
- pnpm build

## Live staging finding addressed
Sales Manager on staging could see  in the order inspector, but clicking it returned a  from . This patch stops surfacing that dead-end action to roles without accounting permissions.