### PR TITLE
fix(notifications): improve inline triage and empty states

### DIFF
--- a/client/public/version.json
+++ b/client/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "commit": "2d340c13",
-  "date": "2026-03-28",
-  "branch": "codex/push-po-surfaces-to-95",
+  "commit": "f1a1abb2",
+  "date": "2026-04-08",
+  "branch": "codex/open-ticket-atomic-train-20260409",
   "phase": "Development",
-  "buildTime": "2026-04-07T07:58:59.078Z"
+  "buildTime": "2026-04-09T20:07:10.064Z"
 }

--- a/client/src/components/dashboard/SimpleDashboard.test.tsx
+++ b/client/src/components/dashboard/SimpleDashboard.test.tsx
@@ -180,7 +180,7 @@ describe("SimpleDashboard", () => {
     expect(screen.getByText(/operational kpis/i)).toBeInTheDocument();
     expect(screen.getByText(/expected deliveries/i)).toBeInTheDocument();
     expect(screen.getByText(/pending fulfillment/i)).toBeInTheDocument();
-    expect(screen.getByText(/appointments today/i)).toBeInTheDocument();
+    expect(screen.getByText(/^appointments today$/i)).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText(/recent activity/i)).toBeInTheDocument();

--- a/client/src/components/notifications/InlineNotificationPanel.test.tsx
+++ b/client/src/components/notifications/InlineNotificationPanel.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { InlineNotificationPanel } from "./InlineNotificationPanel";
+
+const {
+  mockMarkRead,
+  mockMarkAllRead,
+  mockDelete,
+  mockInvalidate,
+} = vi.hoisted(() => ({
+  mockMarkRead: vi.fn(),
+  mockMarkAllRead: vi.fn(),
+  mockDelete: vi.fn(),
+  mockInvalidate: vi.fn(),
+}));
+
+const sampleNotifications = [
+  {
+    id: 1,
+    title: "Order confirmed",
+    message: "New order is ready for review",
+    type: "info",
+    link: "/orders/1",
+    metadata: null,
+    read: false,
+    createdAt: new Date("2026-04-09T18:00:00Z"),
+  },
+  {
+    id: 2,
+    title: "Payment failed",
+    message: "Needs operator attention",
+    type: "error",
+    link: "/accounting?tab=payments",
+    metadata: null,
+    read: false,
+    createdAt: new Date("2026-04-09T18:10:00Z"),
+  },
+  {
+    id: 3,
+    title: "Reminder",
+    message: "Follow up tomorrow",
+    type: "warning",
+    link: null,
+    metadata: null,
+    read: true,
+    createdAt: new Date("2026-04-09T18:15:00Z"),
+  },
+];
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    notifications: {
+      list: {
+        useQuery: vi.fn(() => ({
+          data: {
+            items: sampleNotifications,
+            total: sampleNotifications.length,
+            unread: 2,
+            pagination: { limit: 10, offset: 0 },
+          },
+          isLoading: false,
+        })),
+      },
+      markRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkRead,
+          isPending: false,
+        })),
+      },
+      markAllRead: {
+        useMutation: vi.fn(() => ({
+          mutate: mockMarkAllRead,
+          isPending: false,
+        })),
+      },
+      delete: {
+        useMutation: vi.fn(() => ({
+          mutate: mockDelete,
+          isPending: false,
+        })),
+      },
+      getUnreadCount: {
+        invalidate: mockInvalidate,
+      },
+    },
+    useContext: vi.fn(() => ({
+      notifications: {
+        list: { invalidate: mockInvalidate },
+        getUnreadCount: { invalidate: mockInvalidate },
+      },
+    })),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
+
+describe("InlineNotificationPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderPanel = () =>
+    render(
+      <ThemeProvider>
+        <InlineNotificationPanel title="System Notifications" limit={10} />
+      </ThemeProvider>
+    );
+
+  it("shows unread and action-oriented notification controls", () => {
+    renderPanel();
+
+    expect(screen.getByRole("button", { name: "FYI" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Needs Action" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Mark read" })).toHaveLength(
+      2
+    );
+  });
+
+  it("filters the panel down to FYI notifications", () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "FYI" }));
+
+    expect(screen.getByText("Order confirmed")).toBeInTheDocument();
+    expect(screen.queryByText("Payment failed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reminder")).not.toBeInTheDocument();
+  });
+
+  it("filters the panel down to action-needed notifications", () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "Needs Action" }));
+
+    expect(screen.getByText("Payment failed")).toBeInTheDocument();
+    expect(screen.getByText("Reminder")).toBeInTheDocument();
+    expect(screen.queryByText("Order confirmed")).not.toBeInTheDocument();
+  });
+
+  it("marks a notification as read without navigating when mark read is clicked", () => {
+    const onNotificationClick = vi.fn();
+
+    render(
+      <ThemeProvider>
+        <InlineNotificationPanel
+          title="System Notifications"
+          limit={10}
+          onNotificationClick={onNotificationClick}
+        />
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Mark read" })[0]);
+
+    expect(mockMarkRead).toHaveBeenCalledWith({ notificationId: 1 });
+    expect(onNotificationClick).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/notifications/InlineNotificationPanel.tsx
+++ b/client/src/components/notifications/InlineNotificationPanel.tsx
@@ -71,6 +71,8 @@ interface Notification {
   createdAt: Date | string;
 }
 
+type NotificationCategory = "all" | "fyi" | "action";
+
 const getNotificationIcon = (type: string) => {
   switch (type) {
     case "success":
@@ -82,6 +84,43 @@ const getNotificationIcon = (type: string) => {
     default:
       return <Info className="h-4 w-4 text-primary" />;
   }
+};
+
+const getNotificationCategory = (type: string): NotificationCategory => {
+  switch (type) {
+    case "error":
+    case "warning":
+      return "action";
+    default:
+      return "fyi";
+  }
+};
+
+const getEmptyStateCopy = (
+  filter: InlineNotificationPanelProps["filterType"],
+  category: NotificationCategory
+) => {
+  if (filter === "unread") {
+    return category === "action"
+      ? "No unread action-needed notifications"
+      : category === "fyi"
+        ? "No unread notifications - you're caught up"
+        : "No unread notifications - you're caught up";
+  }
+
+  if (filter === "read") {
+    return category === "action"
+      ? "No previously read action-needed notifications"
+      : category === "fyi"
+        ? "No previously read FYI notifications"
+        : "No read notifications yet";
+  }
+
+  return category === "action"
+    ? "No active alerts"
+    : category === "fyi"
+      ? "Nothing informational to review right now"
+      : "No notifications yet";
 };
 
 export const InlineNotificationPanel = React.memo(
@@ -97,6 +136,8 @@ export const InlineNotificationPanel = React.memo(
   }: InlineNotificationPanelProps) {
     const [isExpanded, setIsExpanded] = useState(defaultExpanded);
     const [currentFilter, setCurrentFilter] = useState(filterType);
+    const [currentCategory, setCurrentCategory] =
+      useState<NotificationCategory>("all");
     const utils = trpc.useContext();
 
     // Fetch notifications
@@ -140,9 +181,17 @@ export const InlineNotificationPanel = React.memo(
 
     // Apply filter
     const notifications = allNotifications.filter(n => {
-      if (currentFilter === "unread") return !n.read;
-      if (currentFilter === "read") return n.read;
-      return true;
+      const matchesReadState =
+        currentFilter === "unread"
+          ? !n.read
+          : currentFilter === "read"
+            ? n.read
+            : true;
+      const matchesCategory =
+        currentCategory === "all" ||
+        getNotificationCategory(n.type) === currentCategory;
+
+      return matchesReadState && matchesCategory;
     });
 
     const handleNotificationClick = useCallback(
@@ -167,14 +216,25 @@ export const InlineNotificationPanel = React.memo(
       [deleteNotification]
     );
 
+    const handleMarkReadOnly = useCallback(
+      (e: React.MouseEvent, notificationId: number) => {
+        e.stopPropagation();
+        markRead.mutate({ notificationId });
+      },
+      [markRead]
+    );
+
     const renderNotificationItem = (notification: Notification) => (
       <div
         key={notification.id}
         onClick={() => handleNotificationClick(notification)}
         className={cn(
-          "flex items-start gap-3 p-3 border-b last:border-b-0 cursor-pointer transition-colors",
+          "group flex items-start gap-3 border-b p-3 last:border-b-0 cursor-pointer transition-colors",
           "hover:bg-muted/50",
-          !notification.read && "bg-primary/5"
+          !notification.read &&
+            "border-l-2 border-l-primary bg-primary/10 pl-[10px]",
+          notification.type === "error" && "bg-destructive/5",
+          notification.type === "warning" && "bg-amber-500/5"
         )}
       >
         <div className="flex-shrink-0 mt-0.5">
@@ -185,14 +245,26 @@ export const InlineNotificationPanel = React.memo(
             <p
               className={cn(
                 "text-sm truncate",
-                !notification.read && "font-medium"
+                !notification.read && "font-semibold"
               )}
             >
               {notification.title}
             </p>
-            {!notification.read && (
-              <div className="h-2 w-2 rounded-full bg-primary flex-shrink-0" />
-            )}
+            <div className="flex items-center gap-1">
+              {!notification.read && (
+                <div className="h-3 w-3 rounded-full bg-primary flex-shrink-0" />
+              )}
+              {!notification.read && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-[11px] opacity-0 transition-opacity group-hover:opacity-100"
+                  onClick={e => handleMarkReadOnly(e, notification.id)}
+                >
+                  Mark read
+                </Button>
+              )}
+            </div>
           </div>
           {notification.message && (
             <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
@@ -298,6 +370,34 @@ export const InlineNotificationPanel = React.memo(
               )}
             </CardDescription>
           )}
+          {isExpanded && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                variant={currentCategory === "all" ? "secondary" : "outline"}
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setCurrentCategory("all")}
+              >
+                All
+              </Button>
+              <Button
+                variant={currentCategory === "fyi" ? "secondary" : "outline"}
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setCurrentCategory("fyi")}
+              >
+                FYI
+              </Button>
+              <Button
+                variant={currentCategory === "action" ? "secondary" : "outline"}
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setCurrentCategory("action")}
+              >
+                Needs Action
+              </Button>
+            </div>
+          )}
         </CardHeader>
 
         {isExpanded && (
@@ -310,11 +410,7 @@ export const InlineNotificationPanel = React.memo(
               <div className="py-8 text-center text-muted-foreground">
                 <Inbox className="h-10 w-10 mx-auto mb-3 opacity-50" />
                 <p className="text-sm">
-                  {currentFilter === "unread"
-                    ? "No unread notifications"
-                    : currentFilter === "read"
-                      ? "No read notifications"
-                      : "No notifications yet"}
+                  {getEmptyStateCopy(currentFilter, currentCategory)}
                 </p>
               </div>
             ) : (

--- a/client/version.json
+++ b/client/version.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0",
-  "commit": "2d340c13",
-  "date": "2026-03-28",
-  "branch": "codex/push-po-surfaces-to-95",
+  "commit": "f1a1abb2",
+  "date": "2026-04-08",
+  "branch": "codex/open-ticket-atomic-train-20260409",
   "phase": "Development",
-  "buildTime": "2026-04-07T07:58:59.078Z"
+  "buildTime": "2026-04-09T20:07:10.064Z"
 }


### PR DESCRIPTION
## Summary
- add inline mark-read controls and action/FYI category filtering to the notification panel
- add contextual empty-state copy and urgency tinting for warning/error rows
- harden the dashboard KPI test so it matches the exact appointments label

## Verification
- `pnpm check`
- `pnpm lint`
- `pnpm build`
- `pnpm vitest run client/src/components/dashboard/SimpleDashboard.test.tsx client/src/components/notifications/InlineNotificationPanel.test.tsx`
- full `pnpm test` rerun started after the dashboard test fix; no additional failures surfaced before the local Vitest run stopped returning output, so GitHub Actions should be treated as the final suite gate