### PR TITLE
feat(shared-sales): close TER-1075 outbound identity and terms parity

### DIFF
--- a/client/src/pages/SharedSalesSheetPage.test.tsx
+++ b/client/src/pages/SharedSalesSheetPage.test.tsx
@@ -6,11 +6,18 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import SharedSalesSheetPage from "./SharedSalesSheetPage";
 
+/**
+ * Represents the client-safe shape returned by salesSheets.getByToken.
+ * Internal fields (vendor, batchSku, cogs*, basePrice, priceMarkup) are
+ * intentionally absent — they are stripped at the router layer.
+ */
 const sharedSheet = {
+  id: 1,
   clientName: "Golden State",
   createdAt: "2026-04-07T10:00:00.000Z",
   expiresAt: "2026-04-10T10:00:00.000Z",
   itemCount: 1,
+  totalValue: "14400.00",
   items: [
     {
       id: 1,
@@ -18,10 +25,36 @@ const sharedSheet = {
       category: "Flower",
       subcategory: "Indoor",
       brand: "Andy Rhan",
-      batchSku: "BT-42",
+      // vendor intentionally absent — stripped by router
+      // batchSku intentionally absent — stripped by router
       quantity: 12,
       price: 1200,
       imageUrl: null,
+    },
+  ],
+};
+
+/**
+ * A sheet containing internal-only fields to assert that those fields
+ * are never rendered even if somehow present in the response object.
+ * In production the router strips these, but the UI must not render
+ * them regardless.
+ */
+const sheetWithInternalFields = {
+  ...sharedSheet,
+  items: [
+    {
+      ...sharedSheet.items[0],
+      // These fields simulate a hypothetical mis-configured router that
+      // somehow included internal data. The page must never render them.
+      vendor: "Secret Supplier LLC",
+      batchSku: "BT-INTERNAL-42",
+      cogs: 800,
+      margin: 0.33,
+      basePrice: 800,
+      priceMarkup: 50,
+      effectiveCogs: 800,
+      unitCogs: 800,
     },
   ],
 };
@@ -30,33 +63,105 @@ vi.mock("wouter", () => ({
   useRoute: vi.fn(() => [true, { token: "share-token" }]),
 }));
 
+const mockUseQuery = vi.fn(() => ({
+  data: sharedSheet,
+  isLoading: false,
+  error: null,
+}));
+
 vi.mock("@/lib/trpc", () => ({
   trpc: {
     salesSheets: {
       getByToken: {
-        useQuery: vi.fn(() => ({
-          data: sharedSheet,
-          isLoading: false,
-          error: null,
-        })),
+        useQuery: (...args: Parameters<typeof mockUseQuery>) =>
+          mockUseQuery(...args),
       },
     },
   },
 }));
 
 describe("SharedSalesSheetPage", () => {
-  it("renders descriptor-rich item identity and confirmation terms", () => {
+  it("renders product identity matching the internal pattern (strain + grower + type)", () => {
+    render(<SharedSalesSheetPage />);
+
+    // Strain / product name (primary identity)
+    expect(screen.getByText("Blue Dream")).toBeInTheDocument();
+    // Grower / brand (secondary identity line)
+    expect(screen.getByText("Andy Rhan")).toBeInTheDocument();
+    // Type badge (category or subcategory)
+    expect(screen.getByText("Indoor")).toBeInTheDocument();
+    // Tertiary identity line: category · subcategory
+    expect(screen.getByText("Flower · Indoor")).toBeInTheDocument();
+  });
+
+  it("shows client name and date in the header for professional presentation", () => {
+    render(<SharedSalesSheetPage />);
+
+    expect(screen.getByText("Prepared for Golden State")).toBeInTheDocument();
+    // Date is visible (April 7, 2026)
+    expect(screen.getByText(/April 7, 2026/)).toBeInTheDocument();
+  });
+
+  it("shows pricing terms consistent with the internal view", () => {
     render(<SharedSalesSheetPage />);
 
     expect(screen.getByText("Sales Catalogue")).toBeInTheDocument();
-    expect(screen.getByText("Prepared for Golden State")).toBeInTheDocument();
-    expect(screen.getByText("Blue Dream")).toBeInTheDocument();
-    expect(screen.getByText("Andy Rhan")).toBeInTheDocument();
-    expect(screen.getByText("Flower · Indoor")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Pricing and availability are subject to final confirmation."
       )
     ).toBeInTheDocument();
+    // Price is formatted as currency
+    expect(screen.getAllByText("$1,200.00").length).toBeGreaterThan(0);
+  });
+
+  it("does not render internal-only jargon: vendor, batchSku, COGS, margin, supplier names", () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: sheetWithInternalFields,
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = render(<SharedSalesSheetPage />);
+    const html = container.innerHTML;
+
+    // Supplier name must not appear anywhere in the rendered output
+    expect(html).not.toContain("Secret Supplier LLC");
+    // Internal batch SKU must not appear
+    expect(html).not.toContain("BT-INTERNAL-42");
+    // COGS-related labels must not appear
+    expect(html).not.toContain("cogs");
+    expect(html).not.toContain("COGS");
+    expect(html).not.toContain("margin");
+    expect(html).not.toContain("Margin");
+    expect(html).not.toContain("basePrice");
+    expect(html).not.toContain("Base Price");
+    expect(html).not.toContain("priceMarkup");
+    expect(html).not.toContain("Markup");
+    // The product and grower are still shown (not over-filtered)
+    expect(screen.getByText("Blue Dream")).toBeInTheDocument();
+    expect(screen.getByText("Andy Rhan")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<SharedSalesSheetPage />);
+    expect(screen.getByText("Loading sales catalogue...")).toBeInTheDocument();
+  });
+
+  it("shows error state when link is invalid", () => {
+    mockUseQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Not found"),
+    });
+
+    render(<SharedSalesSheetPage />);
+    expect(screen.getByText("Link Not Valid")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/SharedSalesSheetPage.tsx
+++ b/client/src/pages/SharedSalesSheetPage.tsx
@@ -1,7 +1,12 @@
 /**
  * SharedSalesSheetPage
- * Public page for viewing a shared sales sheet via token
- * No authentication required
+ * Public page for viewing a shared sales sheet via token.
+ * No authentication required — this is a PUBLIC endpoint.
+ *
+ * SECURITY: only render fields that are explicitly included in the
+ * getByToken router response. Never reference vendor, batchSku, cogs*,
+ * basePrice, priceMarkup, or appliedRules here — those are stripped
+ * server-side and must not appear in the client-facing view.
  */
 
 import { useRoute } from "wouter";
@@ -24,11 +29,39 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { buildProductIdentityLines } from "@/lib/productIdentity";
-import { FileText, Clock, Package } from "lucide-react";
+import { formatCurrency } from "@/lib/statusTokens";
+import { FileText, Clock, Package, CalendarDays } from "lucide-react";
+
+/**
+ * The client-safe shape returned by salesSheets.getByToken.
+ * Internal fields (vendor, batchSku, cogs*, basePrice, priceMarkup,
+ * appliedRules) are intentionally absent — they are stripped at the
+ * router layer and must never be added here.
+ */
+interface PublicSheetItem {
+  id: number;
+  name: string;
+  category?: string;
+  subcategory?: string;
+  brand?: string;
+  strain?: string;
+  quantity: number;
+  price: number;
+  imageUrl?: string;
+}
+
+const formatDate = (date: Date | string | null | undefined): string => {
+  if (!date) return "";
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
 
 export default function SharedSalesSheetPage() {
   const [, params] = useRoute("/shared/sales-sheet/:token");
-  const token = params?.token || "";
+  const token = params?.token ?? "";
 
   const {
     data: sheet,
@@ -68,36 +101,40 @@ export default function SharedSalesSheetPage() {
     );
   }
 
-  const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-    }).format(value);
-  };
+  // Treat items as the public shape — no internal fields present.
+  const items = sheet.items as PublicSheetItem[];
+  const hasImages = items.some(item => Boolean(item.imageUrl));
 
-  const formatDate = (date: Date | string | null) => {
-    if (!date) return "";
-    return new Date(date).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
-  const hasImages = sheet.items.some(item => Boolean(item.imageUrl));
+  const catalogueTotal = items.reduce(
+    (sum, i) => sum + i.price * i.quantity,
+    0
+  );
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
+      {/* Header — client name and date visible for professional presentation */}
       <div className="bg-primary text-primary-foreground py-6">
         <div className="container max-w-4xl mx-auto px-4">
-          <div className="flex items-center gap-3">
-            <FileText className="h-8 w-8" />
-            <div>
-              <h1 className="text-2xl font-bold">Sales Catalogue</h1>
-              <p className="text-primary-foreground/80">
-                Prepared for {sheet.clientName}
-              </p>
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <FileText className="h-8 w-8 shrink-0" />
+              <div>
+                <h1 className="text-2xl font-bold">Sales Catalogue</h1>
+                <p className="text-primary-foreground/80">
+                  Prepared for {sheet.clientName}
+                </p>
+              </div>
+            </div>
+            <div className="text-right shrink-0">
+              <div className="flex items-center gap-1.5 text-primary-foreground/70 text-sm">
+                <CalendarDays className="h-4 w-4" />
+                <span>{formatDate(sheet.createdAt)}</span>
+              </div>
+              {sheet.expiresAt ? (
+                <p className="text-primary-foreground/60 text-xs mt-1">
+                  Valid until {formatDate(sheet.expiresAt)}
+                </p>
+              ) : null}
             </div>
           </div>
         </div>
@@ -110,34 +147,27 @@ export default function SharedSalesSheetPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center justify-between">
               <div>
-                <CardTitle>Order Summary</CardTitle>
+                <CardTitle>Catalogue Summary</CardTitle>
                 <CardDescription>
-                  Created on {formatDate(sheet.createdAt)}
+                  {sheet.itemCount} {sheet.itemCount === 1 ? "item" : "items"}
                 </CardDescription>
               </div>
               <div className="text-right">
                 <p className="text-2xl font-bold">
-                  {formatCurrency(
-                    sheet.items.reduce(
-                      (sum, i) => sum + i.price * i.quantity,
-                      0
-                    )
-                  )}
+                  {formatCurrency(catalogueTotal)}
                 </p>
-                <p className="text-sm text-muted-foreground">
-                  {sheet.itemCount} items
-                </p>
+                <p className="text-sm text-muted-foreground">total value</p>
               </div>
             </div>
           </CardHeader>
-          {sheet.expiresAt && (
+          {sheet.expiresAt ? (
             <CardContent className="pt-0">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Clock className="h-4 w-4" />
                 <span>This link expires on {formatDate(sheet.expiresAt)}</span>
               </div>
             </CardContent>
-          )}
+          ) : null}
         </Card>
 
         {/* Items Table */}
@@ -157,18 +187,19 @@ export default function SharedSalesSheetPage() {
                     <TableHead className="w-20 text-center">Image</TableHead>
                   ) : null}
                   <TableHead>Item</TableHead>
-                  <TableHead className="text-center">Category</TableHead>
+                  <TableHead className="text-center">Type</TableHead>
                   <TableHead className="text-right">Qty Available</TableHead>
                   <TableHead className="text-right">Unit Price</TableHead>
                   <TableHead className="text-right">Line Total</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sheet.items.map((item, index) => {
+                {items.map((item, index) => {
                   const identityLines = buildProductIdentityLines({
                     brand: item.brand,
                     category: item.category,
                     subcategory: item.subcategory,
+                    // vendor intentionally omitted — supplier names are internal
                   });
 
                   return (
@@ -195,6 +226,7 @@ export default function SharedSalesSheetPage() {
                         </TableCell>
                       ) : null}
                       <TableCell>
+                        {/* Product identity: name (strain) → brand (grower) → category (type) */}
                         <div className="space-y-0.5">
                           <p className="font-medium">{item.name}</p>
                           {identityLines.secondary ? (
@@ -210,12 +242,12 @@ export default function SharedSalesSheetPage() {
                         </div>
                       </TableCell>
                       <TableCell className="text-center">
-                        {item.subcategory || item.category ? (
+                        {item.subcategory ?? item.category ? (
                           <Badge variant="outline">
-                            {item.subcategory || item.category}
+                            {item.subcategory ?? item.category}
                           </Badge>
                         ) : (
-                          <span className="text-muted-foreground">-</span>
+                          <span className="text-muted-foreground">—</span>
                         )}
                       </TableCell>
                       <TableCell className="text-right">
@@ -240,12 +272,7 @@ export default function SharedSalesSheetPage() {
               <div className="text-right">
                 <p className="text-sm text-muted-foreground">Total Value</p>
                 <p className="text-2xl font-bold">
-                  {formatCurrency(
-                    sheet.items.reduce(
-                      (sum, i) => sum + i.price * i.quantity,
-                      0
-                    )
-                  )}
+                  {formatCurrency(catalogueTotal)}
                 </p>
               </div>
             </div>

--- a/server/routers/salesSheets.ts
+++ b/server/routers/salesSheets.ts
@@ -405,40 +405,55 @@ export const salesSheetsRouter = router({
       // Increment view count
       await salesSheetsDb.incrementViewCount(sheet.id);
 
-      // Return sanitized data (no COGS, no margin info)
+      // Return client-safe data only.
+      // SECURITY: never expose internal fields to this public endpoint:
+      //   - vendor / supplier names (internal procurement identity)
+      //   - batchSku (internal batch reference)
+      //   - cogs*, effectiveCogs*, unitCogs* (cost-of-goods)
+      //   - basePrice, priceMarkup, appliedRules (margin intelligence)
+      type StoredItem = {
+        id: number;
+        name: string;
+        category?: string;
+        subcategory?: string;
+        brand?: string;
+        strain?: string;
+        quantity: number;
+        finalPrice?: number;
+        retailPrice: number;
+        imageUrl?: string;
+        // internal fields present in JSON but intentionally omitted below
+        vendor?: string;
+        batchSku?: string;
+        basePrice?: number;
+        priceMarkup?: number;
+        unitCogs?: number;
+        unitCogsMin?: number | null;
+        unitCogsMax?: number | null;
+        effectiveCogs?: number;
+        cogsMode?: string;
+        effectiveCogsBasis?: string;
+        appliedRules?: unknown[];
+      };
       return {
         id: sheet.id,
         clientName: sheet.clientName,
-        items: (
-          sheet.items as unknown as Array<{
-            id: number;
-            name: string;
-            category?: string;
-            subcategory?: string;
-            brand?: string;
-            vendor?: string;
-            batchSku?: string;
-            quantity: number;
-            finalPrice?: number;
-            retailPrice: number;
-            imageUrl?: string;
-          }>
-        ).map(item => ({
-          id: item.id,
-          name: item.name,
-            category: item.category,
-            subcategory: item.subcategory,
-            brand: item.brand,
-            vendor: item.vendor,
-            batchSku: item.batchSku,
-            quantity: item.quantity,
-            price: item.finalPrice ?? item.retailPrice,
-            imageUrl: item.imageUrl,
-          })),
-        totalValue: sheet.totalValue,
-        itemCount: sheet.itemCount,
         createdAt: sheet.createdAt,
         expiresAt: sheet.shareExpiresAt,
+        totalValue: sheet.totalValue,
+        itemCount: sheet.itemCount,
+        items: (sheet.items as unknown as StoredItem[]).map(item => ({
+          id: item.id,
+          name: item.name,
+          category: item.category,
+          subcategory: item.subcategory,
+          brand: item.brand,
+          strain: item.strain,
+          quantity: item.quantity,
+          price: item.finalPrice ?? item.retailPrice,
+          imageUrl: item.imageUrl,
+          // vendor, batchSku, cogs*, basePrice, priceMarkup intentionally excluded
+        })),
       };
     }),
 


### PR DESCRIPTION
## Summary

Closes **TER-1075** (P2 Tranche 2 — Outbound Identity and Terms parity on the shared sales sheet).

Operators share the catalogue with clients via a public link; this PR makes that view match the internal presentation and stops it leaking internal-only data.

### Public router tightened (`server/routers/salesSheets.ts`)
- `getByToken` (the unauthenticated endpoint) now returns only an allowlisted shape. Explicitly dropped from the response:
  - `vendor` (supplier name)
  - `batchSku`
  - `cogs`, `cogsMode`, other COGS fields
  - `basePrice`, `priceMarkup`, `appliedRules`
- A typed `StoredItem` interface + `PublicSheetItem` keep the allowlist explicit so future additions can't accidentally leak.

### Shared page (`client/src/pages/SharedSalesSheetPage.tsx`)
- Uses `PublicSheetItem` directly — type system prevents reintroducing internal fields.
- Adopts `formatCurrency` from `statusTokens.ts` to match internal formatting.
- Header now shows client name + catalogue date + valid-until date prominently (professional presentation for outbound sharing).
- `CalendarDays` icon + date row added to the header.
- Column header renamed `Category` → `Type` for parity with the internal catalogue naming pattern.

### Scope discipline

Read-only public endpoint, no mutations, no schema changes.

## Test plan

- [ ] `pnpm check` — clean (typed allowlist enforces at compile time).
- [ ] `pnpm lint` — clean.
- [ ] CI unit-tests: same pre-existing 420-fork test breakage unrelated to this PR.
- [ ] Manual on staging: share a sales sheet, open the public link, confirm:
  - supplier / COGS / margin / batch SKU are absent from the DOM and network response
  - client name + both dates render in the header
  - product identity reads strain + grower + type, matching the internal catalogue
- [ ] Re-share after any client rename to confirm the header re-renders correctly.