### PR TITLE
fix(server): Wave 0 server 500s — TER-1146, TER-1147, TER-1148, TER-1156

### DIFF
--- a/server/inventoryDb.ts
+++ b/server/inventoryDb.ts
@@ -2092,7 +2092,8 @@ export async function calculateBatchProfitability(batchId: number) {
     totalRevenue > 0 ? (grossProfit / totalRevenue) * 100 : 0;
 
   // Calculate potential profit (remaining inventory)
-  const onHand = parseFloat(batch.onHandQty);
+  // TER-1148: Guard against null onHandQty so NaN never leaks into totals.
+  const onHand = parseFloat(batch.onHandQty || "0");
   const avgSellingPrice = unitsSold > 0 ? totalRevenue / unitsSold : 0;
   const potentialRevenue = onHand * avgSellingPrice;
   const potentialCost = onHand * unitCogs;

--- a/server/ordersDb.getAllOrders.test.ts
+++ b/server/ordersDb.getAllOrders.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for ordersDb.getAllOrders.
+ *
+ * TER-1146: /orders returned 500 whenever a single row had corrupted/legacy
+ * items JSON. The list endpoint now tolerates per-row parse failures — it
+ * logs and returns that row with items=[] so the rest of the list still
+ * renders. Single-order reads (getOrderById) remain strict on purpose.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("./db", () => {
+  const mockDb = {
+    select: vi.fn(),
+  };
+  return {
+    getDb: vi.fn().mockResolvedValue(mockDb),
+    db: mockDb,
+  };
+});
+
+import * as dbModule from "./db";
+import { getAllOrders } from "./ordersDb";
+
+type MockRow = Record<string, unknown>;
+
+function buildChainResolvingTo(rows: MockRow[]) {
+  const chain: Record<string, unknown> = {};
+  const passthrough = () => chain;
+  chain.from = vi.fn(passthrough);
+  chain.leftJoin = vi.fn(passthrough);
+  chain.where = vi.fn(passthrough);
+  chain.orderBy = vi.fn(passthrough);
+  chain.limit = vi.fn(passthrough);
+  chain.offset = vi.fn((): Promise<MockRow[]> => Promise.resolve(rows));
+  return chain;
+}
+
+describe("ordersDb.getAllOrders", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty array when no orders match (never 500)", async () => {
+    const db = await dbModule.getDb();
+    (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      buildChainResolvingTo([])
+    );
+
+    const result = await getAllOrders();
+    expect(result).toEqual([]);
+  });
+
+  it("does NOT throw when a row has corrupted items JSON; returns that row with empty items", async () => {
+    const db = await dbModule.getDb();
+
+    const healthyRow = {
+      orders: {
+        id: 1,
+        orderNumber: "S-2026-001",
+        orderType: "SALE",
+        clientId: 10,
+        items: JSON.stringify([
+          {
+            batchId: 1,
+            displayName: "OG Kush",
+            quantity: 2,
+            unitPrice: 100,
+            isSample: false,
+            unitCogs: 40,
+            cogsMode: "FIXED",
+          },
+        ]),
+        fulfillmentStatus: "CONFIRMED",
+        isDraft: false,
+      },
+      clients: { id: 10, name: "Acme" },
+    };
+
+    const corruptedRow = {
+      orders: {
+        id: 2,
+        orderNumber: "S-2026-002",
+        orderType: "SALE",
+        clientId: 11,
+        items: "{not valid json",
+        fulfillmentStatus: "CONFIRMED",
+        isDraft: false,
+      },
+      clients: { id: 11, name: "Beta Co" },
+    };
+
+    (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      buildChainResolvingTo([healthyRow, corruptedRow])
+    );
+
+    const result = await getAllOrders();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(1);
+    expect(result[0].items).toHaveLength(1);
+    expect(result[1].id).toBe(2);
+    expect(result[1].items).toEqual([]);
+    expect(result[1].lineItemCount).toBe(0);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("handles null items without throwing", async () => {
+    const db = await dbModule.getDb();
+
+    const rowEmpty = {
+      orders: {
+        id: 3,
+        orderNumber: "Q-2026-003",
+        orderType: "QUOTE",
+        clientId: 12,
+        items: null,
+        isDraft: true,
+      },
+      clients: { id: 12, name: "Gamma" },
+    };
+
+    (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
+      buildChainResolvingTo([rowEmpty])
+    );
+
+    const result = await getAllOrders();
+    expect(result).toHaveLength(1);
+    expect(result[0].items).toEqual([]);
+  });
+});

--- a/server/ordersDb.getAllOrders.test.ts
+++ b/server/ordersDb.getAllOrders.test.ts
@@ -50,6 +50,7 @@ describe("ordersDb.getAllOrders", () => {
 
   it("returns an empty array when no orders match (never 500)", async () => {
     const db = await dbModule.getDb();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
       buildChainResolvingTo([])
     );
@@ -97,6 +98,7 @@ describe("ordersDb.getAllOrders", () => {
       clients: { id: 11, name: "Beta Co" },
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
       buildChainResolvingTo([healthyRow, corruptedRow])
     );
@@ -127,6 +129,7 @@ describe("ordersDb.getAllOrders", () => {
       clients: { id: 12, name: "Gamma" },
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     (db!.select as ReturnType<typeof vi.fn>).mockReturnValue(
       buildChainResolvingTo([rowEmpty])
     );

--- a/server/ordersDb.ts
+++ b/server/ordersDb.ts
@@ -952,20 +952,18 @@ export async function getAllOrders(filters?: {
       .offset(safeOffset);
   }
 
-  // Transform results to include client data and parse JSON items
-  // ST-050: Error propagation - JSON parsing errors now throw instead of silently returning empty array
+  // Transform results to include client data and parse JSON items.
+  // TER-1146: list endpoints never 500 from a single corrupted items payload —
+  // log the row and fall back to items=[] so the rest of /orders still renders.
+  // Strict propagation still applies to single-order reads (getOrderById).
   const transformed: Order[] = results.map(row => {
-    // Parse items JSON string to array
     let parsedItems: OrderItem[] = [];
     if (row.orders.items) {
       try {
         parsedItems = parseStoredOrderItems(row.orders.items);
       } catch (e) {
         console.error(`Failed to parse items for order ${row.orders.id}:`, e);
-        throw new Error(
-          `Data corruption detected: Cannot parse items for order ${row.orders.id}. ` +
-            `This order requires data remediation. Original error: ${e instanceof Error ? e.message : String(e)}`
-        );
+        parsedItems = [];
       }
     }
 

--- a/server/routers/credit.ts
+++ b/server/routers/credit.ts
@@ -3,6 +3,19 @@ import { router, protectedProcedure } from "../_core/trpc";
 import * as creditEngine from "../creditEngine";
 import { requirePermission } from "../_core/permissionMiddleware";
 import { getAuthenticatedUserId } from "../_core/trpc";
+import { isSchemaDriftError } from "../_core/dbErrors";
+import { logger } from "../_core/logger";
+
+const CREDIT_VISIBILITY_DEFAULTS = {
+  showCreditInClientList: true,
+  showCreditBannerInOrders: true,
+  showCreditWidgetInProfile: true,
+  showSignalBreakdown: true,
+  showAuditLog: true,
+  creditEnforcementMode: "WARNING" as const,
+  warningThresholdPercent: 75,
+  alertThresholdPercent: 90,
+};
 
 export const creditRouter = router({
     // Calculate credit limit for a client
@@ -186,6 +199,9 @@ export const creditRouter = router({
       }),
 
     // Get visibility settings
+    // TER-1147: /orders/new must never 500 from this endpoint. When the
+    // credit_visibility_settings table is missing (legacy or partially
+    // migrated DBs) we log and fall back to defaults so the order UI renders.
     getVisibilitySettings: protectedProcedure.use(requirePermission("credits:read"))
       .input(z.object({ locationId: z.number().optional() }))
       .query(async ({ input }) => {
@@ -193,36 +209,37 @@ export const creditRouter = router({
         if (!db) throw new Error("Database not available");
         const { creditVisibilitySettings } = await import("../../drizzle/schema");
         const { eq, isNull, or } = await import("drizzle-orm");
-        
-        // Get location-specific settings, fall back to global
-        const settings = await db
-          .select()
-          .from(creditVisibilitySettings)
-          .where(
-            input.locationId
-              ? or(
-                  eq(creditVisibilitySettings.locationId, input.locationId),
-                  isNull(creditVisibilitySettings.locationId)
-                )
-              : isNull(creditVisibilitySettings.locationId)
-          )
-          .limit(2);
-        
-        // Prefer location-specific, fall back to global
-        const locationSettings = settings.find(s => s.locationId === input.locationId);
-        const globalSettings = settings.find(s => s.locationId === null);
-        
-        return locationSettings || globalSettings || {
-          // Default settings if none exist
-          showCreditInClientList: true,
-          showCreditBannerInOrders: true,
-          showCreditWidgetInProfile: true,
-          showSignalBreakdown: true,
-          showAuditLog: true,
-          creditEnforcementMode: "WARNING" as const,
-          warningThresholdPercent: 75,
-          alertThresholdPercent: 90,
-        };
+
+        try {
+          // Get location-specific settings, fall back to global
+          const settings = await db
+            .select()
+            .from(creditVisibilitySettings)
+            .where(
+              input.locationId
+                ? or(
+                    eq(creditVisibilitySettings.locationId, input.locationId),
+                    isNull(creditVisibilitySettings.locationId)
+                  )
+                : isNull(creditVisibilitySettings.locationId)
+            )
+            .limit(2);
+
+          // Prefer location-specific, fall back to global
+          const locationSettings = settings.find(s => s.locationId === input.locationId);
+          const globalSettings = settings.find(s => s.locationId === null);
+
+          return locationSettings || globalSettings || CREDIT_VISIBILITY_DEFAULTS;
+        } catch (error) {
+          if (isSchemaDriftError(error, ["credit_visibility_settings"])) {
+            logger.warn(
+              { error, context: "credit.getVisibilitySettings" },
+              "credit_visibility_settings table/columns missing — returning defaults"
+            );
+            return CREDIT_VISIBILITY_DEFAULTS;
+          }
+          throw error;
+        }
       }),
 
     // Update visibility settings

--- a/server/routers/featureFlags.test.ts
+++ b/server/routers/featureFlags.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setupDbMock } from "../test-utils/testDb";
+import { setupPermissionMock } from "../test-utils/testPermissions";
+
+// Hoisted mocks so vi.mock factories can reference them.
+const getAuditHistory = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/featureFlagService", () => ({
+  featureFlagService: {
+    getAuditHistory,
+  },
+}));
+
+vi.mock("../featureFlagsDb", () => ({
+  featureFlagsDb: {},
+}));
+
+vi.mock("../services/seedFeatureFlags", () => ({
+  seedFeatureFlags: vi.fn(),
+}));
+
+vi.mock("../services/permissionService", () => setupPermissionMock());
+vi.mock("../db", () => setupDbMock());
+
+import type { User } from "../../drizzle/schema";
+import { appRouter } from "../routers";
+
+const adminUser: User = {
+  id: 1,
+  openId: "admin-1",
+  email: "admin@example.com",
+  name: "Admin User",
+  role: "admin",
+  loginMethod: null,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  lastSignedIn: new Date(),
+};
+
+const createCaller = () =>
+  appRouter.createCaller({
+    req: {} as never,
+    res: {} as never,
+    user: adminUser,
+  });
+
+describe("featureFlags.getAuditHistory (TER-1156)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty list when the audit log query fails", async () => {
+    getAuditHistory.mockRejectedValue(
+      new Error("Table 'feature_flag_audit_logs' doesn't exist")
+    );
+
+    const caller = createCaller();
+    const result = await caller.featureFlags.getAuditHistory({ limit: 100 });
+
+    expect(result).toEqual([]);
+    expect(getAuditHistory).toHaveBeenCalledWith(undefined, 100);
+  });
+
+  it("returns real audit rows on success", async () => {
+    const rows = [
+      { id: 1, flagKey: "foo", action: "update", createdAt: new Date() },
+    ];
+    getAuditHistory.mockResolvedValue(rows);
+
+    const caller = createCaller();
+    const result = await caller.featureFlags.getAuditHistory({
+      flagKey: "foo",
+      limit: 10,
+    });
+
+    expect(result).toEqual(rows);
+    expect(getAuditHistory).toHaveBeenCalledWith("foo", 10);
+  });
+
+  it("returns an empty list when no history exists", async () => {
+    getAuditHistory.mockResolvedValue([]);
+
+    const caller = createCaller();
+    const result = await caller.featureFlags.getAuditHistory({ limit: 50 });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/server/routers/featureFlags.ts
+++ b/server/routers/featureFlags.ts
@@ -11,6 +11,7 @@ import { featureFlagService } from "../services/featureFlagService";
 import { featureFlagsDb } from "../featureFlagsDb";
 import { seedFeatureFlags } from "../services/seedFeatureFlags";
 import { TRPCError } from "@trpc/server";
+import { logger } from "../_core/logger";
 
 /**
  * Input validation schemas
@@ -385,7 +386,24 @@ export const featureFlagsRouter = router({
       })
     )
     .query(async ({ input }) => {
-      return featureFlagService.getAuditHistory(input.flagKey, input.limit);
+      // TER-1156: The audit log table may be empty or unavailable (missing
+      // migration, stale replica). Render an empty history instead of 500
+      // so /settings/feature-flags stays usable.
+      try {
+        return await featureFlagService.getAuditHistory(
+          input.flagKey,
+          input.limit
+        );
+      } catch (error) {
+        logger.error(
+          {
+            err: error instanceof Error ? error.message : String(error),
+            flagKey: input.flagKey,
+          },
+          "[FeatureFlags] getAuditHistory failed — returning empty list"
+        );
+        return [];
+      }
     }),
 
   /**

--- a/server/routers/inventory.test.ts
+++ b/server/routers/inventory.test.ts
@@ -952,6 +952,57 @@ describe("Inventory Router", () => {
     });
   });
 
+  // TER-1148: Dashboard must never 500 on incomplete profitability data.
+  describe("profitability", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("summary returns zero-state when the underlying query fails", async () => {
+      vi.mocked(inventoryDb.getProfitabilitySummary).mockRejectedValue(
+        new Error("relation \"batches\" does not exist")
+      );
+
+      const result = await caller.inventory.profitability.summary();
+
+      expect(result).toEqual({
+        totalRevenue: 0,
+        totalCost: 0,
+        grossProfit: 0,
+        avgMargin: 0,
+        totalUnits: 0,
+        batchesWithSales: 0,
+      });
+    });
+
+    it("summary returns real values on success", async () => {
+      vi.mocked(inventoryDb.getProfitabilitySummary).mockResolvedValue({
+        totalRevenue: 100,
+        totalCost: 40,
+        grossProfit: 60,
+        avgMargin: 60,
+        totalUnits: 10,
+        batchesWithSales: 2,
+      });
+
+      const result = await caller.inventory.profitability.summary();
+
+      expect(result.grossProfit).toBe(60);
+      expect(result.batchesWithSales).toBe(2);
+    });
+
+    it("top returns an empty paginated response when the DB query fails", async () => {
+      vi.mocked(inventoryDb.getTopProfitableBatches).mockRejectedValue(
+        new Error("Batch not found")
+      );
+
+      const result = await caller.inventory.profitability.top(5);
+
+      expect(result.items).toEqual([]);
+      expect(result.pagination?.total).toBe(0);
+    });
+  });
+
   describe("Edge Cases and Error Handling", () => {
     it("should handle empty batch list", async () => {
       // Arrange

--- a/server/routers/inventory.ts
+++ b/server/routers/inventory.ts
@@ -1910,9 +1910,11 @@ export const inventoryRouter = router({
       .use(requirePermission("inventory:read"))
       .input(z.number().optional().default(10))
       .query(async ({ input }) => {
+        // TER-1148: Dashboard must not 500 when profitability data is
+        // incomplete (missing COGS, empty orders, deleted batches mid-scan).
+        // Degrade to an empty result instead of propagating to the client.
         try {
           const result = await inventoryDb.getTopProfitableBatches(input);
-          // BUG-034: Standardized pagination response
           return createSafeUnifiedResponse(
             result,
             result?.length || 0,
@@ -1920,8 +1922,12 @@ export const inventoryRouter = router({
             0
           );
         } catch (error) {
-          handleError(error, "inventory.profitability.top");
-          throw error;
+          inventoryLogger.operationFailure(
+            "profitability.top",
+            error as Error,
+            { input }
+          );
+          return createSafeUnifiedResponse([], 0, input, 0);
         }
       }),
 
@@ -1929,11 +1935,25 @@ export const inventoryRouter = router({
     summary: protectedProcedure
       .use(requirePermission("inventory:read"))
       .query(async () => {
+        // TER-1148: Return zero-state summary when the underlying query fails
+        // (missing tables, null COGS rows, etc.) so the dashboard tile can
+        // render "no data" instead of error.
         try {
           return await inventoryDb.getProfitabilitySummary();
         } catch (error) {
-          handleError(error, "inventory.profitability.summary");
-          throw error;
+          inventoryLogger.operationFailure(
+            "profitability.summary",
+            error as Error,
+            {}
+          );
+          return {
+            totalRevenue: 0,
+            totalCost: 0,
+            grossProfit: 0,
+            avgMargin: 0,
+            totalUnits: 0,
+            batchesWithSales: 0,
+          };
         }
       }),
   }),

--- a/server/routers/orders.test.ts
+++ b/server/routers/orders.test.ts
@@ -363,6 +363,50 @@ describe("Orders Router", () => {
       expect(result.items[0].clientId).toBe(42);
       expect(result.items[0].client).toEqual({ id: 42, name: "Acme Corp" });
     });
+
+    // TER-1146: /orders must render even when a row was rescued at the Db layer
+    // with items=[] due to a corrupted legacy items payload. The router must not
+    // 500 and the paginated response must include the rescued row.
+    it("returns rows rescued to items=[] without 500ing the list", async () => {
+      const mockOrders = [
+        {
+          id: 1,
+          orderNumber: "S-2026-010",
+          orderType: "SALE",
+          clientId: 10,
+          isDraft: false,
+          items: [
+            {
+              batchId: 1,
+              displayName: "OG Kush",
+              quantity: 2,
+              unitPrice: 100,
+              isSample: false,
+            },
+          ],
+          lineItemCount: 1,
+          client: { id: 10, name: "Acme" },
+        },
+        {
+          id: 2,
+          orderNumber: "S-2026-011",
+          orderType: "SALE",
+          clientId: 11,
+          isDraft: false,
+          items: [],
+          lineItemCount: 0,
+          client: { id: 11, name: "Beta Co" },
+        },
+      ];
+
+      vi.mocked(ordersDb.getAllOrders).mockResolvedValue(mockOrders);
+
+      const result = await caller.orders.getAll({ isDraft: false });
+      expect(result.items).toHaveLength(2);
+      expect(result.items[1].id).toBe(2);
+      expect(result.items[1].items).toEqual([]);
+      expect(result.items[1].lineItemCount).toBe(0);
+    });
   });
 
   describe("update", () => {

--- a/server/routers/referrals.ts
+++ b/server/routers/referrals.ts
@@ -17,6 +17,7 @@ import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { logger } from "../_core/logger";
+import { isSchemaDriftError } from "../_core/dbErrors";
 import {
   clients,
   orders,
@@ -27,12 +28,17 @@ import { adminProcedure, router } from "../_core/trpc";
 
 /**
  * Detects MySQL errors caused by missing tables or columns in a legacy schema.
- * Use this to guard all referral table queries — the referral_credits and
- * referral_settings tables may not exist on older DB deployments.
+ * Delegates to the shared isSchemaDriftError helper so nested/wrapped errors
+ * (drizzle query wraps, errors exposing only `errno`, etc.) are also caught —
+ * TER-1147 surfaced cases where the original narrow `.code`-only check missed
+ * these, causing /orders/new to 500.
  */
 function isLegacySchemaError(error: unknown): boolean {
-  const code = (error as { code?: string })?.code;
-  return code === "ER_BAD_FIELD_ERROR" || code === "ER_NO_SUCH_TABLE";
+  return isSchemaDriftError(error, [
+    "referral_credits",
+    "referral_credit_settings",
+    "referral_settings",
+  ]);
 }
 
 /**

--- a/server/routers/wave0-500-guards.test.ts
+++ b/server/routers/wave0-500-guards.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for TER-1147: defensive handling on /orders/new.
+ *
+ * These procedures must never 500 the page when their backing tables are
+ * missing or legacy. They should log and return empty/default shapes:
+ *
+ *   - credit.getVisibilitySettings (was unguarded → 500 on missing table)
+ *   - referrals.getSettings        (guard only caught .code, not .errno/wrapped)
+ *   - referrals.getPendingCredits  (same guard gap)
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { setupDbMock } from "../test-utils/testDb";
+import { setupPermissionMock } from "../test-utils/testPermissions";
+
+vi.mock("../db", () => setupDbMock());
+vi.mock("../services/permissionService", () => setupPermissionMock());
+
+import * as dbModule from "../db";
+import { appRouter } from "../routers";
+import { createContext } from "../_core/context";
+
+const mockUser = {
+  id: 1,
+  email: "admin@terp.com",
+  name: "Admin User",
+  role: "admin",
+};
+
+async function createCaller() {
+  const ctx = await createContext({
+    req: { headers: {} } as Record<string, unknown>,
+    res: {} as Record<string, unknown>,
+  });
+  return appRouter.createCaller({ ...ctx, user: mockUser });
+}
+
+/**
+ * Build a drizzle query chain whose terminal await rejects with the given error.
+ * Every chain step returns `self` so .from().leftJoin().where().orderBy().limit()
+ * compositions still work before the final resolution.
+ */
+function buildChainRejectingWith(error: unknown) {
+  const chain: Record<string, unknown> = {};
+  const passthrough = () => chain;
+  chain.from = vi.fn(passthrough);
+  chain.leftJoin = vi.fn(passthrough);
+  chain.innerJoin = vi.fn(passthrough);
+  chain.where = vi.fn(passthrough);
+  chain.orderBy = vi.fn(passthrough);
+  chain.limit = vi.fn(() => Promise.reject(error));
+  chain.offset = vi.fn(() => Promise.reject(error));
+  chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+    Promise.reject(error).then(resolve, reject);
+  return chain;
+}
+
+describe("TER-1147: wave-0 /orders/new defensive guards", () => {
+  let caller: Awaited<ReturnType<typeof createCaller>>;
+
+  beforeAll(async () => {
+    caller = await createCaller();
+  });
+
+  describe("credit.getVisibilitySettings", () => {
+    it("returns defaults (does not 500) when credit_visibility_settings table is missing", async () => {
+      const err = Object.assign(
+        new Error(
+          "Table 'terp.credit_visibility_settings' doesn't exist"
+        ),
+        { code: "ER_NO_SUCH_TABLE", errno: 1146 }
+      );
+      vi.mocked(dbModule.db.select as ReturnType<typeof vi.fn>).mockReturnValue(
+        buildChainRejectingWith(err)
+      );
+
+      const result = await caller.credit.getVisibilitySettings({});
+      expect(result).toBeDefined();
+      expect(result.showCreditInClientList).toBe(true);
+      expect(result.creditEnforcementMode).toBe("WARNING");
+    });
+  });
+
+  describe("referrals.getSettings", () => {
+    it("returns defaults when error only exposes errno (no .code field)", async () => {
+      // drizzle/mysql2 sometimes surfaces errors with errno but without the
+      // string code — the original isLegacySchemaError guard missed these.
+      const err = Object.assign(
+        new Error("Unknown table 'referral_credit_settings'"),
+        { errno: 1146 }
+      );
+      vi.mocked(dbModule.db.select as ReturnType<typeof vi.fn>).mockReturnValue(
+        buildChainRejectingWith(err)
+      );
+
+      const result = await caller.referrals.getSettings();
+      expect(result).toEqual({ globalPercentage: 10.0, tierSettings: [] });
+    });
+  });
+
+  describe("referrals.getPendingCredits", () => {
+    it("returns empty result when error is nested under .cause (drizzle wrap)", async () => {
+      const inner = Object.assign(
+        new Error("Table 'terp.referral_credits' doesn't exist"),
+        { code: "ER_NO_SUCH_TABLE", errno: 1146 }
+      );
+      const outer = Object.assign(new Error("Failed query: select ..."), {
+        cause: inner,
+      });
+      vi.mocked(dbModule.db.select as ReturnType<typeof vi.fn>).mockReturnValue(
+        buildChainRejectingWith(outer)
+      );
+
+      const result = await caller.referrals.getPendingCredits({ clientId: 42 });
+      expect(result).toEqual({
+        totalPending: 0,
+        totalAvailable: 0,
+        credits: [],
+      });
+    });
+  });
+});


### PR DESCRIPTION
Wave 0 agent fixes for server-side 500 errors.

## Changes
- **TER-1146**: `ordersDb.getAllOrders` tolerates corrupted/legacy items JSON — logs per-row parse failures and returns `items=[]` so the full list still renders.
- **TER-1147**: credit + referrals routers guard against legacy schemas on `/orders/new` — never 500s.
- **TER-1148**: `inventory.profitability.summary` / `.top` return zero-state / empty list when underlying data is incomplete (missing COGS, deleted batches mid-scan, orders without items). Also fixes `parseFloat(batch.onHandQty)` NaN leak.
- **TER-1156**: `featureFlags.getAuditHistory` returns `[]` when the audit log table is missing or unreachable so `/settings/feature-flags` still renders.

## Test coverage
- `server/ordersDb.getAllOrders.test.ts` — 3 regression tests (TER-1146)
- `server/routers/orders.test.ts` — TER-1146 router coverage
- `server/wave0-500-guards.test.ts` — credit/referrals guard paths (TER-1147)
- `server/routers/inventory.test.ts` — profitability summary/top regression tests (TER-1148)
- `server/routers/featureFlags.test.ts` — getAuditHistory regression tests (TER-1156)

## Verification
- `pnpm tsc --noEmit` → clean (zero errors)
- `pnpm vitest run server/routers/inventory.test.ts` → 32 passed
- `pnpm vitest run server/routers/featureFlags.test.ts` → 3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)