### PR TITLE
fix(client): Wave 0 client bugs - TER-640/1150/1151/1152/1153/1154/1155

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -614,6 +614,13 @@ function Router() {
                   )}
                 />
                 <Route
+                  path="/settings/display"
+                  component={RedirectWithSearch(
+                    "/settings/display",
+                    "/account"
+                  )}
+                />
+                <Route
                   path="/settings/feature-flags"
                   component={RedirectWithTab(
                     "/settings/feature-flags",

--- a/client/src/components/calendar/EventFormDialog.tsx
+++ b/client/src/components/calendar/EventFormDialog.tsx
@@ -206,12 +206,13 @@ export default function EventFormDialog({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
-    // BUG-099: Explicit required-field validation before submission
+    // Explicit required-field validation before submission.
+    // Calendar is optional — server does not require it, and blocking submission
+    // here left users with no calendar access unable to create events at all (TER-1154).
     const missing: string[] = [];
     if (!title.trim()) missing.push("Title");
     if (!startDate) missing.push("Start Date");
     if (!endDate) missing.push("End Date");
-    if (!calendarId) missing.push("Calendar");
     if (missing.length > 0) {
       toast.error(`Required fields missing: ${missing.join(", ")}`);
       return;
@@ -401,7 +402,7 @@ export default function EventFormDialog({
             <div className="space-y-2">
               <Label className="flex items-center gap-1">
                 <Calendar className="h-4 w-4" />
-                Calendar *
+                Calendar
               </Label>
               <Select
                 value={calendarId?.toString() || ""}

--- a/client/src/components/comments/MentionInput.tsx
+++ b/client/src/components/comments/MentionInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { trpc } from "@/lib/trpc";
@@ -30,7 +30,6 @@ export function MentionInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // FIXED: Clean up timeout on unmount to prevent memory leaks
   useEffect(() => {
     return () => {
       if (focusTimeoutRef.current) {
@@ -39,8 +38,9 @@ export function MentionInput({
     };
   }, []);
 
-  // Fetch all users for mentions
-  const { data: allUsers = [] } = trpc.userManagement.listUsers.useQuery();
+  // Use comments-scoped mention endpoint so any commenter can see the picker
+  // without requiring the stricter `users:read` permission.
+  const { data: allUsers = [] } = trpc.comments.listMentionableUsers.useQuery();
 
   // Filter users based on mention query
   const filteredUsers = allUsers.filter((user: User) => {
@@ -51,26 +51,41 @@ export function MentionInput({
     return name.includes(query) || email.includes(query);
   });
 
-  useEffect(() => {
-    // Detect @ mentions
-    const cursorPosition = textareaRef.current?.selectionStart || 0;
-    const textBeforeCursor = value.substring(0, cursorPosition);
-    const lastAtSymbol = textBeforeCursor.lastIndexOf("@");
+  const detectMention = useCallback(
+    (nextValue: string, cursorPosition: number) => {
+      const textBeforeCursor = nextValue.substring(0, cursorPosition);
+      const lastAtSymbol = textBeforeCursor.lastIndexOf("@");
 
-    if (lastAtSymbol !== -1) {
-      const textAfterAt = textBeforeCursor.substring(lastAtSymbol + 1);
-      // Check if there's a space after @ or if we're still typing
-      if (!textAfterAt.includes(" ")) {
-        setMentionQuery(textAfterAt);
-        setShowSuggestions(true);
-        setSelectedIndex(0);
-      } else {
+      if (lastAtSymbol === -1) {
         setShowSuggestions(false);
+        return;
       }
-    } else {
-      setShowSuggestions(false);
-    }
-  }, [value]);
+
+      // @ must be at the start or preceded by whitespace to count as a mention trigger
+      const charBefore =
+        lastAtSymbol > 0 ? textBeforeCursor[lastAtSymbol - 1] : "";
+      if (charBefore && !/\s/.test(charBefore)) {
+        setShowSuggestions(false);
+        return;
+      }
+
+      const textAfterAt = textBeforeCursor.substring(lastAtSymbol + 1);
+      if (textAfterAt.includes(" ") || textAfterAt.includes("\n")) {
+        setShowSuggestions(false);
+        return;
+      }
+
+      setMentionQuery(textAfterAt);
+      setShowSuggestions(true);
+      setSelectedIndex(0);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const cursorPosition = textareaRef.current?.selectionStart ?? value.length;
+    detectMention(value, cursorPosition);
+  }, [value, detectMention]);
 
   const insertMention = (user: User) => {
     const cursorPosition = textareaRef.current?.selectionStart || 0;
@@ -104,11 +119,11 @@ export function MentionInput({
     if (showSuggestions && filteredUsers.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % filteredUsers.length);
+        setSelectedIndex(prev => (prev + 1) % filteredUsers.length);
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setSelectedIndex(
-          (prev) => (prev - 1 + filteredUsers.length) % filteredUsers.length
+          prev => (prev - 1 + filteredUsers.length) % filteredUsers.length
         );
       } else if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
@@ -125,13 +140,21 @@ export function MentionInput({
     onKeyDown?.(e);
   };
 
+  const handleSelectionChange = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+    detectMention(el.value, el.selectionStart ?? el.value.length);
+  };
+
   return (
     <div className="relative">
       <Textarea
         ref={textareaRef}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={e => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
+        onKeyUp={handleSelectionChange}
+        onClick={handleSelectionChange}
         placeholder={placeholder}
         className={className}
       />
@@ -152,7 +175,9 @@ export function MentionInput({
             >
               <div className="font-medium">{user.name || "Unknown"}</div>
               {user.email && (
-                <div className="text-xs text-muted-foreground">{user.email}</div>
+                <div className="text-xs text-muted-foreground">
+                  {user.email}
+                </div>
               )}
             </button>
           ))}

--- a/client/src/components/dashboard/widgets-v2/AvailableCashWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/AvailableCashWidget.tsx
@@ -8,7 +8,7 @@ import { useLocation } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { ArrowRight, DollarSign, Clock, Wallet } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
@@ -17,10 +17,11 @@ import { formatDateTime } from "@/lib/dateFormat";
 export const AvailableCashWidget = memo(function AvailableCashWidget() {
   const [, setLocation] = useLocation();
 
-  const { data, isLoading, error } = trpc.cashAudit.getCashDashboard.useQuery(
-    undefined,
-    { refetchInterval: 60000 } // Refresh every minute
-  );
+  const { data, isLoading, error, refetch } =
+    trpc.cashAudit.getCashDashboard.useQuery(
+      undefined,
+      { refetchInterval: 60000 } // Refresh every minute
+    );
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat("en-US", {
@@ -74,11 +75,10 @@ export const AvailableCashWidget = memo(function AvailableCashWidget() {
             </div>
           </div>
         ) : error ? (
-          <EmptyState
-            variant="generic"
-            size="sm"
-            title="Unable to load cash data"
-            description="Please try refreshing the page"
+          <DatabaseErrorState
+            entity="cash data"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
           />
         ) : data ? (
           <div className="space-y-4">

--- a/client/src/components/dashboard/widgets-v2/CashCollectedLeaderboard.tsx
+++ b/client/src/components/dashboard/widgets-v2/CashCollectedLeaderboard.tsx
@@ -16,6 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { trpc } from "@/lib/trpc";
 
 // LINT-005: Define interface for cash collected client data
@@ -29,11 +30,15 @@ export const CashCollectedLeaderboard = memo(
   function CashCollectedLeaderboard() {
     const [months, setMonths] = useState(24);
 
-    const { data: response, isLoading } =
-      trpc.dashboard.getCashCollected.useQuery(
-        { months },
-        { refetchInterval: 60000 } // Refetch every 60 seconds
-      );
+    const {
+      data: response,
+      isLoading,
+      error,
+      refetch,
+    } = trpc.dashboard.getCashCollected.useQuery(
+      { months },
+      { refetchInterval: 60000 } // Refetch every 60 seconds
+    );
 
     const data = response?.data || [];
 
@@ -71,6 +76,12 @@ export const CashCollectedLeaderboard = memo(
               <Skeleton className="h-8 w-full" />
               <Skeleton className="h-8 w-full" />
             </div>
+          ) : error ? (
+            <DatabaseErrorState
+              entity="cash collection data"
+              errorMessage={error.message}
+              onRetry={() => void refetch()}
+            />
           ) : data.length > 0 ? (
             <Table>
               <TableHeader>
@@ -97,9 +108,12 @@ export const CashCollectedLeaderboard = memo(
               </TableBody>
             </Table>
           ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              No cash collection data available
-            </div>
+            <EmptyState
+              variant="analytics"
+              size="sm"
+              title="No cash collection yet"
+              description="Cash collected by client appears here once payments land."
+            />
           )}
         </CardContent>
       </Card>

--- a/client/src/components/dashboard/widgets-v2/CashFlowWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/CashFlowWidget.tsx
@@ -17,7 +17,7 @@ import {
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 
@@ -27,10 +27,11 @@ export const CashFlowWidget = memo(function CashFlowWidget() {
   const [, setLocation] = useLocation();
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("LIFETIME");
 
-  const { data, isLoading } = trpc.dashboard.getCashFlow.useQuery(
-    { timePeriod },
-    { refetchInterval: 60000 }
-  );
+  const { data, isLoading, error, refetch } =
+    trpc.dashboard.getCashFlow.useQuery(
+      { timePeriod },
+      { refetchInterval: 60000 }
+    );
 
   const formatCurrency = (value: number) => {
     return `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -73,6 +74,12 @@ export const CashFlowWidget = memo(function CashFlowWidget() {
             <Skeleton className="h-8 w-full" />
             <Skeleton className="h-8 w-full" />
           </div>
+        ) : error ? (
+          <DatabaseErrorState
+            entity="cash flow data"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
+          />
         ) : data ? (
           <Table>
             <TableBody>

--- a/client/src/components/dashboard/widgets-v2/ClientDebtLeaderboard.tsx
+++ b/client/src/components/dashboard/widgets-v2/ClientDebtLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { trpc } from "@/lib/trpc";
 
 // LINT-005: Define interface for client debt data
@@ -20,10 +21,12 @@ interface ClientDebtData {
 }
 
 export const ClientDebtLeaderboard = memo(function ClientDebtLeaderboard() {
-  const { data: response, isLoading } = trpc.dashboard.getClientDebt.useQuery(
-    {},
-    { refetchInterval: 60000 }
-  );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = trpc.dashboard.getClientDebt.useQuery({}, { refetchInterval: 60000 });
 
   const data = response?.data || [];
 
@@ -48,6 +51,12 @@ export const ClientDebtLeaderboard = memo(function ClientDebtLeaderboard() {
             <Skeleton className="h-8 w-full" />
             <Skeleton className="h-8 w-full" />
           </div>
+        ) : error ? (
+          <DatabaseErrorState
+            entity="client debt"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
+          />
         ) : data.length > 0 ? (
           <Table>
             <TableHeader>
@@ -78,9 +87,12 @@ export const ClientDebtLeaderboard = memo(function ClientDebtLeaderboard() {
             </TableBody>
           </Table>
         ) : (
-          <div className="text-center py-8 text-muted-foreground">
-            No client debt data available
-          </div>
+          <EmptyState
+            variant="clients"
+            size="sm"
+            title="No client debt yet"
+            description="Client debt will appear once invoices are outstanding."
+          />
         )}
       </CardContent>
     </Card>

--- a/client/src/components/dashboard/widgets-v2/ClientProfitMarginLeaderboard.tsx
+++ b/client/src/components/dashboard/widgets-v2/ClientProfitMarginLeaderboard.tsx
@@ -9,6 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { trpc } from "@/lib/trpc";
 
 // LINT-005: Define interface for client profit margin data
@@ -20,11 +21,15 @@ interface ClientProfitMarginData {
 
 export const ClientProfitMarginLeaderboard = memo(
   function ClientProfitMarginLeaderboard() {
-    const { data: response, isLoading } =
-      trpc.dashboard.getClientProfitMargin.useQuery(
-        {},
-        { refetchInterval: 60000 }
-      );
+    const {
+      data: response,
+      isLoading,
+      error,
+      refetch,
+    } = trpc.dashboard.getClientProfitMargin.useQuery(
+      {},
+      { refetchInterval: 60000 }
+    );
 
     const data = response?.data || [];
 
@@ -46,6 +51,12 @@ export const ClientProfitMarginLeaderboard = memo(
               <Skeleton className="h-8 w-full" />
               <Skeleton className="h-8 w-full" />
             </div>
+          ) : error ? (
+            <DatabaseErrorState
+              entity="client profit margin data"
+              errorMessage={error.message}
+              onRetry={() => void refetch()}
+            />
           ) : data.length > 0 ? (
             <Table>
               <TableHeader>
@@ -82,9 +93,12 @@ export const ClientProfitMarginLeaderboard = memo(
               </TableBody>
             </Table>
           ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              No profit margin data available
-            </div>
+            <EmptyState
+              variant="analytics"
+              size="sm"
+              title="No profit margin data yet"
+              description="Per-client profit margins appear once sales are recorded."
+            />
           )}
         </CardContent>
       </Card>

--- a/client/src/components/dashboard/widgets-v2/InventorySnapshotWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/InventorySnapshotWidget.tsx
@@ -15,7 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { ChevronRight, ChevronDown, ExternalLink } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { useLocation } from "wouter";
@@ -72,7 +72,7 @@ export const InventorySnapshotWidget = memo(function InventorySnapshotWidget() {
   );
   const [viewMode, setViewMode] = useState<ViewMode>("category");
 
-  const { data, isLoading, error } =
+  const { data, isLoading, error, refetch } =
     trpc.dashboard.getInventorySnapshot.useQuery(undefined, {
       refetchInterval: 60000,
     });
@@ -158,14 +158,10 @@ export const InventorySnapshotWidget = memo(function InventorySnapshotWidget() {
       </CardHeader>
       <CardContent>
         {error ? (
-          <EmptyState
-            variant="generic"
-            size="sm"
-            title="Failed to load inventory data"
-            description={
-              error.message ||
-              "An error occurred while fetching inventory snapshot"
-            }
+          <DatabaseErrorState
+            entity="inventory snapshot"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
           />
         ) : isLoading ? (
           <div className="space-y-2">

--- a/client/src/components/dashboard/widgets-v2/ProfitabilityWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/ProfitabilityWidget.tsx
@@ -1,14 +1,19 @@
 import { memo } from "react";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/ui/empty-state";
+import {
+  EmptyState,
+  DatabaseErrorState,
+  isDatabaseError,
+} from "@/components/ui/empty-state";
 import { trpc } from "@/lib/trpc";
 import { TrendingUp, DollarSign, Percent, Package } from "lucide-react";
 
 export const ProfitabilityWidget = memo(function ProfitabilityWidget() {
-  const { data: summary, isLoading } =
-    trpc.inventory.profitability.summary.useQuery();
-  const { data: topBatches } = trpc.inventory.profitability.top.useQuery(5);
+  const summaryQuery = trpc.inventory.profitability.summary.useQuery();
+  const topBatchesQuery = trpc.inventory.profitability.top.useQuery(5);
+  const { data: summary, isLoading, error, refetch } = summaryQuery;
+  const { data: topBatches } = topBatchesQuery;
 
   if (isLoading) {
     return (
@@ -29,6 +34,29 @@ export const ProfitabilityWidget = memo(function ProfitabilityWidget() {
     );
   }
 
+  if (error) {
+    return (
+      <Card className="p-6">
+        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+          <TrendingUp className="h-5 w-5 text-green-600" />
+          Profitability Analysis
+        </h3>
+        <DatabaseErrorState
+          entity="profitability data"
+          errorMessage={
+            isDatabaseError(error)
+              ? undefined
+              : error.message || "Failed to load profitability analysis."
+          }
+          onRetry={() => {
+            void refetch();
+            void topBatchesQuery.refetch();
+          }}
+        />
+      </Card>
+    );
+  }
+
   if (!summary) {
     return (
       <Card className="p-6">
@@ -39,8 +67,8 @@ export const ProfitabilityWidget = memo(function ProfitabilityWidget() {
         <EmptyState
           variant="analytics"
           size="sm"
-          title="No profitability data"
-          description="Profitability analysis will appear once sales are recorded"
+          title="No profitability data yet"
+          description="Profitability analysis will appear once sales are recorded."
         />
       </Card>
     );

--- a/client/src/components/dashboard/widgets-v2/SalesByClientWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/SalesByClientWidget.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 
@@ -35,11 +35,15 @@ export const SalesByClientWidget = memo(function SalesByClientWidget() {
   const [, setLocation] = useLocation();
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("LIFETIME");
 
-  const { data: response, isLoading } =
-    trpc.dashboard.getSalesByClient.useQuery(
-      { timePeriod },
-      { refetchInterval: 60000 }
-    );
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = trpc.dashboard.getSalesByClient.useQuery(
+    { timePeriod },
+    { refetchInterval: 60000 }
+  );
 
   const data = response?.data || [];
 
@@ -81,6 +85,12 @@ export const SalesByClientWidget = memo(function SalesByClientWidget() {
             <Skeleton className="h-8 w-full" />
             <Skeleton className="h-8 w-full" />
           </div>
+        ) : error ? (
+          <DatabaseErrorState
+            entity="sales by client"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
+          />
         ) : data.length > 0 ? (
           <Table>
             <TableHeader>

--- a/client/src/components/dashboard/widgets-v2/SalesComparisonWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/SalesComparisonWidget.tsx
@@ -16,16 +16,16 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 
 export const SalesComparisonWidget = memo(function SalesComparisonWidget() {
   const [, setLocation] = useLocation();
-  const { data, isLoading } = trpc.dashboard.getSalesComparison.useQuery(
-    undefined,
-    { refetchInterval: 60000 }
-  );
+  const { data, isLoading, error, refetch } =
+    trpc.dashboard.getSalesComparison.useQuery(undefined, {
+      refetchInterval: 60000,
+    });
 
   const formatCurrency = (value: number) => {
     return `$${value.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -60,6 +60,12 @@ export const SalesComparisonWidget = memo(function SalesComparisonWidget() {
             <Skeleton className="h-8 w-full" />
             <Skeleton className="h-8 w-full" />
           </div>
+        ) : error ? (
+          <DatabaseErrorState
+            entity="sales comparison"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
+          />
         ) : data ? (
           <Table>
             <TableHeader>

--- a/client/src/components/dashboard/widgets-v2/TotalDebtWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/TotalDebtWidget.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
@@ -14,9 +14,10 @@ import { trpc } from "@/lib/trpc";
  */
 export const TotalDebtWidget = memo(function TotalDebtWidget() {
   const [, setLocation] = useLocation();
-  const { data, isLoading } = trpc.dashboard.getTotalDebt.useQuery(undefined, {
-    refetchInterval: 60000,
-  });
+  const { data, isLoading, error, refetch } =
+    trpc.dashboard.getTotalDebt.useQuery(undefined, {
+      refetchInterval: 60000,
+    });
 
   const formatCurrency = (value: number) => {
     return `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -41,6 +42,12 @@ export const TotalDebtWidget = memo(function TotalDebtWidget() {
             <Skeleton className="h-8 w-full" />
             <Skeleton className="h-8 w-full" />
           </div>
+        ) : error ? (
+          <DatabaseErrorState
+            entity="debt totals"
+            errorMessage={error.message}
+            onRetry={() => void refetch()}
+          />
         ) : data ? (
           <Table>
             <TableBody>

--- a/client/src/components/dashboard/widgets-v2/TransactionSnapshotWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/TransactionSnapshotWidget.tsx
@@ -15,7 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
-import { EmptyState } from "@/components/ui/empty-state";
+import { EmptyState, DatabaseErrorState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
 import { trpc } from "@/lib/trpc";
@@ -25,10 +25,10 @@ import { useLocation } from "wouter";
 export const TransactionSnapshotWidget = memo(
   function TransactionSnapshotWidget() {
     const [, setLocation] = useLocation();
-    const { data, isLoading } = trpc.dashboard.getTransactionSnapshot.useQuery(
-      undefined,
-      { refetchInterval: 60000 }
-    );
+    const { data, isLoading, error, refetch } =
+      trpc.dashboard.getTransactionSnapshot.useQuery(undefined, {
+        refetchInterval: 60000,
+      });
 
     const formatCurrency = (value: number) => {
       return `$${value.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -56,6 +56,12 @@ export const TransactionSnapshotWidget = memo(
               <Skeleton className="h-8 w-full" />
               <Skeleton className="h-8 w-full" />
             </div>
+          ) : error ? (
+            <DatabaseErrorState
+              entity="transaction snapshot"
+              errorMessage={error.message}
+              onRetry={() => void refetch()}
+            />
           ) : data ? (
             <Table>
               <TableHeader>

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -135,6 +135,15 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
 
         <div className="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 bg-card/90 p-1 shadow-sm">
           <NotificationBell className="relative flex h-11 w-11 items-center justify-center sm:h-9 sm:w-9" />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="flex h-11 w-11 touch-manipulation rounded-full border-0 bg-transparent shadow-none sm:hidden"
+            onClick={() => setLocation("/settings")}
+            aria-label="Settings"
+          >
+            <Settings className="h-5 w-5" />
+          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button

--- a/client/src/components/ui/client-combobox.tsx
+++ b/client/src/components/ui/client-combobox.tsx
@@ -213,8 +213,6 @@ export function ClientCombobox({
           aria-label="Select a client"
           data-testid="client-select"
           disabled={disabled || isLoading}
-          onClick={e => e.stopPropagation()}
-          onPointerDown={e => e.stopPropagation()}
           className={cn(
             "w-full justify-between font-normal",
             !selectedDisplayLabel && "text-muted-foreground",

--- a/client/src/pages/OwnerCommandCenterDashboard.tsx
+++ b/client/src/pages/OwnerCommandCenterDashboard.tsx
@@ -9,6 +9,7 @@ import { OwnerQuickCardsWidget } from "@/components/dashboard/owner/OwnerQuickCa
 import { OwnerAppointmentsWidget } from "@/components/dashboard/owner/OwnerAppointmentsWidget";
 import { OwnerSkuStatusBrowserWidget } from "@/components/dashboard/owner/OwnerSkuStatusBrowserWidget";
 import { Badge } from "@/components/ui/badge";
+import { ComponentErrorBoundary } from "@/components/ErrorBoundary";
 
 export default function OwnerCommandCenterDashboard() {
   const now = new Date();
@@ -48,39 +49,55 @@ export default function OwnerCommandCenterDashboard() {
       {/* Row 1: Daily pulse — today's sales + appointments + cash */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
         <div className="lg:col-span-4">
-          <OwnerQuickCardsWidget />
+          <ComponentErrorBoundary name="Quick Cards">
+            <OwnerQuickCardsWidget />
+          </ComponentErrorBoundary>
         </div>
         <div className="lg:col-span-4">
-          <OwnerAppointmentsWidget />
+          <ComponentErrorBoundary name="Appointments">
+            <OwnerAppointmentsWidget />
+          </ComponentErrorBoundary>
         </div>
         <div className="lg:col-span-4">
-          <OwnerCashDecisionPanel />
+          <ComponentErrorBoundary name="Cash Decision">
+            <OwnerCashDecisionPanel />
+          </ComponentErrorBoundary>
         </div>
       </div>
 
       {/* Row 2: Money in vs. money out */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
         <div className="lg:col-span-5">
-          <OwnerDebtPositionWidget />
+          <ComponentErrorBoundary name="Debt Position">
+            <OwnerDebtPositionWidget />
+          </ComponentErrorBoundary>
         </div>
         <div className="lg:col-span-7">
-          <OwnerVendorsNeedPaymentWidget />
+          <ComponentErrorBoundary name="Vendors Needing Payment">
+            <OwnerVendorsNeedPaymentWidget />
+          </ComponentErrorBoundary>
         </div>
       </div>
 
       {/* Row 3: Inventory health */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
         <div className="lg:col-span-6">
-          <InventorySnapshotWidget />
+          <ComponentErrorBoundary name="Inventory Snapshot">
+            <InventorySnapshotWidget />
+          </ComponentErrorBoundary>
         </div>
         <div className="lg:col-span-6">
-          <AgingInventoryWidget />
+          <ComponentErrorBoundary name="Aging Inventory">
+            <AgingInventoryWidget />
+          </ComponentErrorBoundary>
         </div>
       </div>
 
       {/* Row 4: SKU Status Browser (hidden by default, collapsed) */}
       <div>
-        <OwnerSkuStatusBrowserWidget />
+        <ComponentErrorBoundary name="SKU Status Browser">
+          <OwnerSkuStatusBrowserWidget />
+        </ComponentErrorBoundary>
       </div>
     </div>
   );

--- a/server/routers/comments.ts
+++ b/server/routers/comments.ts
@@ -13,10 +13,10 @@ import * as commentsDb from "../commentsDb";
 import * as inboxDb from "../inboxDb";
 import * as mentionParser from "../services/mentionParser";
 import { requirePermission } from "../_core/permissionMiddleware";
-import {
-  DEFAULT_PAGE_SIZE,
-} from "../_core/pagination";
-import { type Comment } from "../../drizzle/schema";
+import { DEFAULT_PAGE_SIZE } from "../_core/pagination";
+import { getDb } from "../db";
+import { users, type Comment } from "../../drizzle/schema";
+import { isNull } from "drizzle-orm";
 
 // ============================================================================
 // TYPE DEFINITIONS
@@ -116,11 +116,16 @@ export interface DeleteSuccessResponse {
  */
 export const getEntityCommentsInputSchema = z.object({
   commentableType: z.string().min(1, "Commentable type is required"),
-  commentableId: z.number().int().positive("Commentable ID must be a positive integer"),
+  commentableId: z
+    .number()
+    .int()
+    .positive("Commentable ID must be a positive integer"),
   limit: z.number().int().min(1).max(100).default(DEFAULT_PAGE_SIZE).optional(),
   offset: z.number().int().min(0).default(0).optional(),
 });
-export type GetEntityCommentsInput = z.infer<typeof getEntityCommentsInputSchema>;
+export type GetEntityCommentsInput = z.infer<
+  typeof getEntityCommentsInputSchema
+>;
 
 /**
  * Schema for getting a comment by ID
@@ -135,8 +140,14 @@ export type GetCommentByIdInput = z.infer<typeof getCommentByIdInputSchema>;
  */
 export const createCommentInputSchema = z.object({
   commentableType: z.string().min(1, "Commentable type is required"),
-  commentableId: z.number().int().positive("Commentable ID must be a positive integer"),
-  content: z.string().min(1, "Comment content is required").max(10000, "Comment content is too long"),
+  commentableId: z
+    .number()
+    .int()
+    .positive("Commentable ID must be a positive integer"),
+  content: z
+    .string()
+    .min(1, "Comment content is required")
+    .max(10000, "Comment content is too long"),
 });
 export type CreateCommentInput = z.infer<typeof createCommentInputSchema>;
 
@@ -145,7 +156,10 @@ export type CreateCommentInput = z.infer<typeof createCommentInputSchema>;
  */
 export const updateCommentInputSchema = z.object({
   commentId: z.number().int().positive("Comment ID must be a positive integer"),
-  content: z.string().min(1, "Comment content is required").max(10000, "Comment content is too long"),
+  content: z
+    .string()
+    .min(1, "Comment content is required")
+    .max(10000, "Comment content is too long"),
 });
 export type UpdateCommentInput = z.infer<typeof updateCommentInputSchema>;
 
@@ -162,7 +176,10 @@ export type CommentIdInput = z.infer<typeof commentIdInputSchema>;
  */
 export const entityIdentifierInputSchema = z.object({
   commentableType: z.string().min(1, "Commentable type is required"),
-  commentableId: z.number().int().positive("Commentable ID must be a positive integer"),
+  commentableId: z
+    .number()
+    .int()
+    .positive("Commentable ID must be a positive integer"),
 });
 export type EntityIdentifierInput = z.infer<typeof entityIdentifierInputSchema>;
 
@@ -461,4 +478,45 @@ export const commentsRouter = router({
       const mentions = await commentsDb.getUserMentions(ctx.user.id);
       return mentions as UserMentionWithContext[];
     }),
+
+  /**
+   * List users available for @mention in comments.
+   * Available to any authenticated user who can create comments,
+   * since mentions are a core feature of commenting.
+   */
+  listMentionableUsers: protectedProcedure
+    .use(requirePermission("comments:create"))
+    .query(
+      async ({
+        ctx,
+      }): Promise<
+        Array<{ id: number; name: string | null; email: string | null }>
+      > => {
+        if (!ctx.user) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Authentication required",
+          });
+        }
+
+        const db = await getDb();
+        if (!db) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Database not available",
+          });
+        }
+
+        const rows = await db
+          .select({
+            id: users.id,
+            name: users.name,
+            email: users.email,
+          })
+          .from(users)
+          .where(isNull(users.deletedAt));
+
+        return rows;
+      }
+    ),
 });


### PR DESCRIPTION
Fixes 7 Wave 0 client-side bugs from the P3 UX audit.

## Summary
- **TER-640** – Combobox type-ahead dropdown failing to open.
- **TER-1150** – Dashboard widgets no longer conflate loading/empty/error.
- **TER-1151** – Custom dashboard layout renders blank; wrap in error boundary.
- **TER-1152** – Settings/profile icons unresponsive on mobile (touch targets + handler).
- **TER-1153** – Comments post + @ mention restored. Added comments-scoped mention endpoint gated on `comments:create` so users without `users:read` still see the picker; hardened the @ trigger to require start-of-word and react to caret moves.
- **TER-1154** – Calendar Create Event no longer client-blocked by missing calendar selection (server never required it).
- **TER-1155** – Legacy /settings/display now redirects to /account instead of 404ing.

## Test plan
- [x] pnpm tsc --noEmit (zero errors)
- [ ] Post a comment and @-mention a user on a client/task/batch detail page.
- [ ] Open Calendar, click Create Event, submit with just title + start date.
- [ ] Visit /settings/display, confirm redirect to /account.
- [ ] Confirm settings/profile icons respond on mobile (>=44px touch targets).