### PR TITLE
feat(dashboard): operational KPIs - TER-1055

### DIFF
--- a/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
@@ -154,25 +154,71 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
     );
   }
 
-  const openOrdersCount = data?.openOrders.count ?? 0;
-  const openOrdersValue = data?.openOrders.totalValue ?? 0;
-  const fulfilledTodayCount = data?.fulfilledToday.count ?? 0;
-  const receivablesTotal = data?.outstandingReceivables.total ?? 0;
-  const receivablesInvoices = data?.outstandingReceivables.invoiceCount ?? 0;
-  const thisWeekCash = data?.cashCollected.thisWeek ?? 0;
-  const lastWeekCash = data?.cashCollected.lastWeek ?? 0;
-  const percentChange = data?.cashCollected.percentChange ?? 0;
+  if (isLoading || !data) {
+    return (
+      <div
+        aria-label="Operational KPIs"
+        aria-busy="true"
+        className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        <KpiTile
+          title="Open Orders"
+          icon={ShoppingCart}
+          value=""
+          onClick={() => {}}
+          loading
+        />
+        <KpiTile
+          title="Fulfilled Today"
+          icon={PackageCheck}
+          value=""
+          onClick={() => {}}
+          loading
+        />
+        <KpiTile
+          title="Outstanding Receivables"
+          icon={CircleDollarSign}
+          value=""
+          onClick={() => {}}
+          loading
+        />
+        <KpiTile
+          title="Cash Collected (7d)"
+          icon={Wallet}
+          value=""
+          onClick={() => {}}
+          loading
+        />
+      </div>
+    );
+  }
+
+  const openOrdersCount = data.openOrders.count;
+  const openOrdersValue = data.openOrders.totalValue;
+  const fulfilledTodayCount = data.fulfilledToday.count;
+  const receivablesTotal = data.outstandingReceivables.total;
+  const receivablesInvoices = data.outstandingReceivables.invoiceCount;
+  const thisWeekCash = data.cashCollected.thisWeek;
+  const lastWeekCash = data.cashCollected.lastWeek;
+  const percentChange = data.cashCollected.percentChange;
 
   const cashTrend: Trend =
-    percentChange > 0 ? "up" : percentChange < 0 ? "down" : "neutral";
-  const cashTrendLabel = `${
-    percentChange > 0 ? "+" : ""
-  }${percentChange}% vs last week`;
+    percentChange === null
+      ? "neutral"
+      : percentChange > 0
+        ? "up"
+        : percentChange < 0
+          ? "down"
+          : "neutral";
+  const cashTrendLabel =
+    percentChange === null
+      ? "N/A vs last week"
+      : `${percentChange > 0 ? "+" : ""}${percentChange}% vs last week`;
 
   return (
     <div
       aria-label="Operational KPIs"
-      className="grid gap-3 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
+      className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
     >
       <KpiTile
         title="Open Orders"

--- a/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
@@ -1,0 +1,232 @@
+import { memo } from "react";
+import { useLocation } from "wouter";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  CircleDollarSign,
+  Minus,
+  PackageCheck,
+  ShoppingCart,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { buildSalesWorkspacePath } from "@/lib/workspaceRoutes";
+
+/**
+ * TER-1055 — Operational KPI row
+ *
+ * Surfaces the four operating signals an owner checks first thing in the
+ * morning. Each tile navigates to the workspace that owns the signal, so the
+ * owner can drill straight from the dashboard into the actionable list.
+ */
+
+type Trend = "up" | "down" | "neutral";
+
+interface KpiTileProps {
+  title: string;
+  icon: LucideIcon;
+  value: string;
+  secondary?: string;
+  trend?: {
+    direction: Trend;
+    label: string;
+  };
+  onClick: () => void;
+  loading?: boolean;
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function trendVisual(direction: Trend) {
+  if (direction === "up") {
+    return {
+      Icon: ArrowUpRight,
+      className: "text-emerald-600",
+    };
+  }
+  if (direction === "down") {
+    return {
+      Icon: ArrowDownRight,
+      className: "text-red-600",
+    };
+  }
+  return {
+    Icon: Minus,
+    className: "text-muted-foreground",
+  };
+}
+
+const KpiTile = memo(function KpiTile({
+  title,
+  icon: Icon,
+  value,
+  secondary,
+  trend,
+  onClick,
+  loading,
+}: KpiTileProps) {
+  const TrendIcon = trend ? trendVisual(trend.direction).Icon : null;
+  const trendClass = trend ? trendVisual(trend.direction).className : "";
+
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={event => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+      className="cursor-pointer transition-shadow duration-200 hover:border-primary/50 hover:shadow-md"
+    >
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {title}
+            </p>
+            {loading ? (
+              <Skeleton className="mt-2 h-8 w-24" />
+            ) : (
+              <p className="mt-2 text-2xl font-semibold tracking-tight font-mono">
+                {value}
+              </p>
+            )}
+            {!loading && secondary && (
+              <p className="mt-1 text-xs text-muted-foreground truncate">
+                {secondary}
+              </p>
+            )}
+            {!loading && trend && TrendIcon && (
+              <div
+                className={`mt-1 flex items-center text-xs font-medium ${trendClass}`}
+              >
+                <TrendIcon className="h-3 w-3 mr-1" />
+                <span>{trend.label}</span>
+              </div>
+            )}
+          </div>
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 shrink-0">
+            <Icon className="h-5 w-5 text-primary" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+});
+
+export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
+  const [, setLocation] = useLocation();
+  const { data, isLoading, error } =
+    trpc.dashboard.getOperationalKpis.useQuery(undefined, {
+      refetchInterval: 60000,
+    });
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="p-5">
+          <EmptyState
+            variant="generic"
+            size="sm"
+            title="Unable to load operational KPIs"
+            description="Dashboard metrics could not be loaded right now."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const openOrdersCount = data?.openOrders.count ?? 0;
+  const openOrdersValue = data?.openOrders.totalValue ?? 0;
+  const fulfilledTodayCount = data?.fulfilledToday.count ?? 0;
+  const receivablesTotal = data?.outstandingReceivables.total ?? 0;
+  const receivablesInvoices = data?.outstandingReceivables.invoiceCount ?? 0;
+  const thisWeekCash = data?.cashCollected.thisWeek ?? 0;
+  const lastWeekCash = data?.cashCollected.lastWeek ?? 0;
+  const percentChange = data?.cashCollected.percentChange ?? 0;
+
+  const cashTrend: Trend =
+    percentChange > 0 ? "up" : percentChange < 0 ? "down" : "neutral";
+  const cashTrendLabel = `${
+    percentChange > 0 ? "+" : ""
+  }${percentChange}% vs last week`;
+
+  return (
+    <div
+      aria-label="Operational KPIs"
+      className="grid gap-3 grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
+    >
+      <KpiTile
+        title="Open Orders"
+        icon={ShoppingCart}
+        value={formatNumber(openOrdersCount)}
+        secondary={
+          openOrdersCount > 0
+            ? `${formatCurrency(openOrdersValue)} in flight`
+            : "No orders in flight"
+        }
+        onClick={() =>
+          setLocation(buildSalesWorkspacePath("orders") + "?status=open")
+        }
+        loading={isLoading}
+      />
+      <KpiTile
+        title="Fulfilled Today"
+        icon={PackageCheck}
+        value={formatNumber(fulfilledTodayCount)}
+        secondary={
+          fulfilledTodayCount > 0
+            ? "Shipped or delivered today"
+            : "Nothing shipped yet"
+        }
+        onClick={() =>
+          setLocation(
+            buildSalesWorkspacePath("orders") + "?fulfillment=shipped"
+          )
+        }
+        loading={isLoading}
+      />
+      <KpiTile
+        title="Outstanding Receivables"
+        icon={CircleDollarSign}
+        value={formatCurrency(receivablesTotal)}
+        secondary={
+          receivablesInvoices > 0
+            ? `${receivablesInvoices} open invoice${
+                receivablesInvoices === 1 ? "" : "s"
+              }`
+            : "No open invoices"
+        }
+        onClick={() => setLocation("/accounting/invoices")}
+        loading={isLoading}
+      />
+      <KpiTile
+        title="Cash Collected (7d)"
+        icon={Wallet}
+        value={formatCurrency(thisWeekCash)}
+        secondary={`Last week ${formatCurrency(lastWeekCash)}`}
+        trend={{ direction: cashTrend, label: cashTrendLabel }}
+        onClick={() => setLocation("/accounting/payments")}
+        loading={isLoading}
+      />
+    </div>
+  );
+});

--- a/client/src/components/dashboard/widgets-v2/index.ts
+++ b/client/src/components/dashboard/widgets-v2/index.ts
@@ -18,3 +18,5 @@ export { AvailableCashWidget } from "./AvailableCashWidget";
 export { AgingInventoryWidget } from "./AgingInventoryWidget";
 // FE-QA-011: Smart Opportunities Widget
 export { SmartOpportunitiesWidget } from "./SmartOpportunitiesWidget";
+// TER-1055: Operational KPI row
+export { OperationalKpisWidget } from "./OperationalKpisWidget";

--- a/client/src/pages/OwnerCommandCenterDashboard.tsx
+++ b/client/src/pages/OwnerCommandCenterDashboard.tsx
@@ -1,6 +1,7 @@
 import {
   InventorySnapshotWidget,
   AgingInventoryWidget,
+  OperationalKpisWidget,
 } from "@/components/dashboard/widgets-v2";
 import { OwnerCashDecisionPanel } from "@/components/dashboard/owner/OwnerCashDecisionPanel";
 import { OwnerDebtPositionWidget } from "@/components/dashboard/owner/OwnerDebtPositionWidget";
@@ -45,6 +46,11 @@ export default function OwnerCommandCenterDashboard() {
           Live &middot; Updated {updatedAt}
         </Badge>
       </div>
+
+      {/* Operational KPI row (TER-1055) */}
+      <ComponentErrorBoundary name="Operational KPIs">
+        <OperationalKpisWidget />
+      </ComponentErrorBoundary>
 
       {/* Row 1: Daily pulse — today's sales + appointments + cash */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">

--- a/docs/sessions/active/TER-1055-session.md
+++ b/docs/sessions/active/TER-1055-session.md
@@ -1,0 +1,33 @@
+# Agent Session: TER-1055
+
+- **Branch:** cc/TER-1055-dashboard-kpis
+- **Ticket:** TER-1055
+- **Status:** IN_PROGRESS
+- **Agent:** claude-opus-4-7
+
+## Scope
+
+Operational KPI widget row on the Owner Command Center dashboard:
+
+- Open orders count + total value
+- Orders fulfilled today (shipped or delivered)
+- Outstanding receivables (total + open invoice count)
+- Cash collected this week vs last week (% change with arrow)
+
+## Implementation
+
+- `server/routers/dashboard.ts` — added `dashboard.getOperationalKpis`
+  protected query (reuses `arApDb.getOutstandingReceivables` /
+  `arApDb.getPayments`, and queries the `orders` table directly for
+  in-flight / fulfilled-today counts).
+- `client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx` —
+  new 4-tile grid widget with click-through navigation and
+  `refetchInterval: 60000`.
+- `client/src/components/dashboard/widgets-v2/index.ts` — export new widget.
+- `client/src/pages/OwnerCommandCenterDashboard.tsx` — mounts the KPI row
+  above the daily pulse, wrapped in `ComponentErrorBoundary`.
+
+## Verification
+
+- `npx tsc --noEmit -p tsconfig.json` — exit 0.
+- `npx eslint <changed files>` — no findings.

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -18,13 +18,15 @@ import {
   batches,
   clients,
   lots,
+  orders as ordersTable,
   paymentHistory,
   sales as salesTable,
   type Invoice,
+  type Order,
   type Payment,
 } from "../../drizzle/schema";
 import { subDays, differenceInDays } from "date-fns";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, notInArray, sql } from "drizzle-orm";
 
 // ============================================================================
 // Input Schema Constants
@@ -182,6 +184,30 @@ interface TotalDebtResponse {
   totalDebtOwedToMe: number;
   totalDebtIOwedToVendors: number;
   netPosition: number;
+}
+
+/**
+ * Operational KPIs response (TER-1055)
+ * Lightweight daily operating snapshot surfaced in the dashboard header row.
+ */
+interface OperationalKpisResponse {
+  openOrders: {
+    count: number;
+    totalValue: number;
+  };
+  fulfilledToday: {
+    count: number;
+  };
+  outstandingReceivables: {
+    total: number;
+    invoiceCount: number;
+  };
+  cashCollected: {
+    thisWeek: number;
+    lastWeek: number;
+    /** Percent change this-week vs last-week. 0 when last-week was 0. */
+    percentChange: number;
+  };
 }
 
 /**
@@ -447,6 +473,126 @@ export const dashboardRouter = router({
         lowStockCount,
       };
     }),
+
+  /**
+   * Operational KPIs (TER-1055)
+   * Lightweight day-of operating snapshot: open orders, fulfillment, receivables,
+   * and week-over-week cash collection.
+   */
+  getOperationalKpis: protectedProcedure
+    .use(requirePermission("dashboard:read"))
+    .query(async (): Promise<OperationalKpisResponse> => {
+      const db = await getDb();
+      const now = new Date();
+      const startOfToday = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate()
+      );
+      const startOfThisWeek = subDays(startOfToday, 7);
+      const startOfLastWeek = subDays(startOfToday, 14);
+
+      // Open orders: confirmed SALE orders not yet paid/cancelled and not
+      // fulfilled beyond DELIVERED/CANCELLED.
+      let openOrdersCount = 0;
+      let openOrdersValue = 0;
+      let fulfilledTodayCount = 0;
+
+      if (db) {
+        const openOrdersRows: Pick<Order, "total">[] = await db
+          .select({ total: ordersTable.total })
+          .from(ordersTable)
+          .where(
+            and(
+              isNull(ordersTable.deletedAt),
+              eq(ordersTable.orderType, "SALE"),
+              sql`${ordersTable.isDraft} = 0`,
+              notInArray(ordersTable.fulfillmentStatus, [
+                "DELIVERED",
+                "CANCELLED",
+                "RETURNED",
+                "RESTOCKED",
+                "RETURNED_TO_VENDOR",
+              ])
+            )
+          );
+
+        openOrdersCount = openOrdersRows.length;
+        openOrdersValue = openOrdersRows.reduce(
+          (sum, row) => sum + Number(row.total || 0),
+          0
+        );
+
+        const fulfilledRows = await db
+          .select({ id: ordersTable.id })
+          .from(ordersTable)
+          .where(
+            and(
+              isNull(ordersTable.deletedAt),
+              eq(ordersTable.orderType, "SALE"),
+              inArray(ordersTable.fulfillmentStatus, [
+                "SHIPPED",
+                "DELIVERED",
+              ]),
+              sql`${ordersTable.shippedAt} >= ${startOfToday}`
+            )
+          );
+        fulfilledTodayCount = fulfilledRows.length;
+      }
+
+      // Outstanding receivables (reuse existing helper).
+      const receivablesResult = await arApDb.getOutstandingReceivables();
+      const receivablesInvoices = receivablesResult.invoices || [];
+      const receivablesTotal = Number(receivablesResult.total || 0);
+
+      // Cash collected: this week vs previous 7-day window.
+      const thisWeekPayments = await arApDb.getPayments({
+        paymentType: "RECEIVED",
+        startDate: startOfThisWeek,
+        endDate: now,
+      });
+      const lastWeekPayments = await arApDb.getPayments({
+        paymentType: "RECEIVED",
+        startDate: startOfLastWeek,
+        endDate: startOfThisWeek,
+      });
+
+      const thisWeekCash = (thisWeekPayments.payments || []).reduce(
+        (sum: number, p: Payment) => sum + Number(p.amount || 0),
+        0
+      );
+      const lastWeekCash = (lastWeekPayments.payments || []).reduce(
+        (sum: number, p: Payment) => sum + Number(p.amount || 0),
+        0
+      );
+
+      const percentChange =
+        lastWeekCash > 0
+          ? ((thisWeekCash - lastWeekCash) / lastWeekCash) * 100
+          : thisWeekCash > 0
+            ? 100
+            : 0;
+
+      return {
+        openOrders: {
+          count: openOrdersCount,
+          totalValue: openOrdersValue,
+        },
+        fulfilledToday: {
+          count: fulfilledTodayCount,
+        },
+        outstandingReceivables: {
+          total: receivablesTotal,
+          invoiceCount: receivablesInvoices.length,
+        },
+        cashCollected: {
+          thisWeek: thisWeekCash,
+          lastWeek: lastWeekCash,
+          percentChange: Math.round(percentChange * 100) / 100,
+        },
+      };
+    }),
+
   // Get user's widget layout
   getLayout: protectedProcedure
     .use(requirePermission("dashboard:read"))

--- a/server/routers/dashboard.ts
+++ b/server/routers/dashboard.ts
@@ -205,9 +205,14 @@ interface OperationalKpisResponse {
   cashCollected: {
     thisWeek: number;
     lastWeek: number;
-    /** Percent change this-week vs last-week. 0 when last-week was 0. */
-    percentChange: number;
+    /** Percent change this-week vs last-week. null when last-week was 0 (no baseline). */
+    percentChange: number | null;
   };
+}
+
+function toFiniteNumber(value: unknown): number {
+  const parsed = parseFloat(String(value ?? "0"));
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 /**
@@ -494,84 +499,95 @@ export const dashboardRouter = router({
 
       // Open orders: confirmed SALE orders not yet paid/cancelled and not
       // fulfilled beyond DELIVERED/CANCELLED.
-      let openOrdersCount = 0;
-      let openOrdersValue = 0;
-      let fulfilledTodayCount = 0;
-
-      if (db) {
-        const openOrdersRows: Pick<Order, "total">[] = await db
-          .select({ total: ordersTable.total })
-          .from(ordersTable)
-          .where(
-            and(
-              isNull(ordersTable.deletedAt),
-              eq(ordersTable.orderType, "SALE"),
-              sql`${ordersTable.isDraft} = 0`,
-              notInArray(ordersTable.fulfillmentStatus, [
-                "DELIVERED",
-                "CANCELLED",
-                "RETURNED",
-                "RESTOCKED",
-                "RETURNED_TO_VENDOR",
-              ])
+      const openOrdersQuery: Promise<Pick<Order, "total">[]> = db
+        ? db
+            .select({ total: ordersTable.total })
+            .from(ordersTable)
+            .where(
+              and(
+                isNull(ordersTable.deletedAt),
+                eq(ordersTable.orderType, "SALE"),
+                sql`${ordersTable.isDraft} = 0`,
+                notInArray(ordersTable.fulfillmentStatus, [
+                  "DELIVERED",
+                  "CANCELLED",
+                  "RETURNED",
+                  "RESTOCKED",
+                  "RETURNED_TO_VENDOR",
+                ])
+              )
             )
-          );
+        : Promise.resolve([]);
 
-        openOrdersCount = openOrdersRows.length;
-        openOrdersValue = openOrdersRows.reduce(
-          (sum, row) => sum + Number(row.total || 0),
-          0
-        );
-
-        const fulfilledRows = await db
-          .select({ id: ordersTable.id })
-          .from(ordersTable)
-          .where(
-            and(
-              isNull(ordersTable.deletedAt),
-              eq(ordersTable.orderType, "SALE"),
-              inArray(ordersTable.fulfillmentStatus, [
-                "SHIPPED",
-                "DELIVERED",
-              ]),
-              sql`${ordersTable.shippedAt} >= ${startOfToday}`
+      const fulfilledTodayQuery: Promise<{ id: number }[]> = db
+        ? db
+            .select({ id: ordersTable.id })
+            .from(ordersTable)
+            .where(
+              and(
+                isNull(ordersTable.deletedAt),
+                eq(ordersTable.orderType, "SALE"),
+                inArray(ordersTable.fulfillmentStatus, [
+                  "SHIPPED",
+                  "DELIVERED",
+                ]),
+                sql`${ordersTable.shippedAt} >= ${startOfToday}`,
+                sql`${ordersTable.shippedAt} <= ${now}`
+              )
             )
-          );
-        fulfilledTodayCount = fulfilledRows.length;
-      }
+        : Promise.resolve([]);
 
-      // Outstanding receivables (reuse existing helper).
-      const receivablesResult = await arApDb.getOutstandingReceivables();
+      // All five queries run in parallel so dashboard TTFB is gated by the
+      // slowest one rather than the sum.
+      const [
+        openOrdersRows,
+        fulfilledRows,
+        receivablesResult,
+        thisWeekPayments,
+        lastWeekPayments,
+      ] = await Promise.all([
+        openOrdersQuery,
+        fulfilledTodayQuery,
+        arApDb.getOutstandingReceivables(),
+        arApDb.getPayments({
+          paymentType: "RECEIVED",
+          startDate: startOfThisWeek,
+          endDate: now,
+        }),
+        arApDb.getPayments({
+          paymentType: "RECEIVED",
+          startDate: startOfLastWeek,
+          endDate: startOfThisWeek,
+        }),
+      ]);
+
+      const openOrdersCount = openOrdersRows.length;
+      const openOrdersValue = openOrdersRows.reduce(
+        (sum, row) => sum + toFiniteNumber(row.total),
+        0
+      );
+      const fulfilledTodayCount = fulfilledRows.length;
+
       const receivablesInvoices = receivablesResult.invoices || [];
-      const receivablesTotal = Number(receivablesResult.total || 0);
-
-      // Cash collected: this week vs previous 7-day window.
-      const thisWeekPayments = await arApDb.getPayments({
-        paymentType: "RECEIVED",
-        startDate: startOfThisWeek,
-        endDate: now,
-      });
-      const lastWeekPayments = await arApDb.getPayments({
-        paymentType: "RECEIVED",
-        startDate: startOfLastWeek,
-        endDate: startOfThisWeek,
-      });
+      const receivablesTotal = toFiniteNumber(receivablesResult.total);
 
       const thisWeekCash = (thisWeekPayments.payments || []).reduce(
-        (sum: number, p: Payment) => sum + Number(p.amount || 0),
+        (sum: number, p: Payment) => sum + toFiniteNumber(p.amount),
         0
       );
       const lastWeekCash = (lastWeekPayments.payments || []).reduce(
-        (sum: number, p: Payment) => sum + Number(p.amount || 0),
+        (sum: number, p: Payment) => sum + toFiniteNumber(p.amount),
         0
       );
 
+      // Null when no baseline exists — client renders "N/A" rather than
+      // fabricating a "+0% vs last week" trend.
       const percentChange =
         lastWeekCash > 0
-          ? ((thisWeekCash - lastWeekCash) / lastWeekCash) * 100
-          : thisWeekCash > 0
-            ? 100
-            : 0;
+          ? Math.round(
+              ((thisWeekCash - lastWeekCash) / lastWeekCash) * 100 * 100
+            ) / 100
+          : null;
 
       return {
         openOrders: {
@@ -588,7 +604,7 @@ export const dashboardRouter = router({
         cashCollected: {
           thisWeek: thisWeekCash,
           lastWeek: lastWeekCash,
-          percentChange: Math.round(percentChange * 100) / 100,
+          percentChange,
         },
       };
     }),


### PR DESCRIPTION
## Summary

Adds an operational KPI row to the Owner Command Center (TER-1055). Surfaces
the four signals an owner checks first thing in the morning, each with a
deep-link into the workspace that owns the signal:

- **Open Orders** — count + total value (non-terminal SALE orders)
- **Fulfilled Today** — orders marked SHIPPED or DELIVERED today
- **Outstanding Receivables** — reuses `arApDb.getOutstandingReceivables`
- **Cash Collected (7d)** — this week vs. last week with % change arrow

## Implementation

- New `dashboard.getOperationalKpis` tRPC query reusing AR/payment helpers
  and querying the `orders` table directly for in-flight / fulfilled-today
  counts.
- New `OperationalKpisWidget` (widgets-v2) with 60s auto-refresh.
- Mounted above the daily pulse row in `OwnerCommandCenterDashboard`,
  wrapped in `ComponentErrorBoundary`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint <changed files>` — clean
- [ ] Visual verification on staging once deployed

Closes TER-1055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)