### PR TITLE
chore(session): move TER-1210 session file to completed/

### DIFF
--- a/docs/sessions/active/Session-20260421-post-TER-1210-multi-lane.md
+++ b/docs/sessions/active/Session-20260421-post-TER-1210-multi-lane.md
@@ -1,20 +1,22 @@
 # Session: Post-TER-1210 Multi-Lane Execution
 
-**Task IDs:** TER-1209, TER-1193, TER-1194, TER-1191, CI hardening
+**Task IDs:** TER-1209, TER-1193, TER-1194, TER-1191, TER-1197, TER-1198, CI hardening
 **Agent:** Factory Droid (droplet)
 **Started:** 2026-04-21T01:00:00Z
-**Last Updated:** 2026-04-21T01:35:00Z
-**Status:** In flight — 6 PRs open against main
-**Branch(es):** chore/ter-1210-session-completion (this PR), plus 5 others tracked below
+**Last Updated:** 2026-04-21T01:55:00Z
+**Status:** In flight — 8 PRs open against main, 6 all-green and ready to merge
+**Branch(es):** chore/ter-1210-session-completion (this PR), plus 7 others tracked below
 **Related PRs:**
 
 - #596 merged (TER-1210 partial) — 8c7e7680
-- #597 open — move TER-1210 session file to completed/ (this branch)
-- #598 open — TER-1209 version.json pretest fix
-- #599 open — TER-1193 cartItemStatus enum fix
-- #600 open — add unit-tests job to merge.yml
-- #601 open — TER-1194 sampleLocationEnum split
-- #602 open — TER-1191 modal backdrop z-index
+- #597 open — move TER-1210 session file to completed/ (this branch) — ALL GREEN
+- #598 open — TER-1209 version.json pretest fix — ALL GREEN
+- #599 open — TER-1193 cartItemStatus enum fix — ALL GREEN
+- #600 open — add unit-tests job to merge.yml — ALL GREEN
+- #601 open — TER-1194 sampleLocationEnum split — ALL GREEN
+- #602 open — TER-1191 modal backdrop z-index — ALL GREEN
+- #603 open — TER-1197 centralize logout auth storage — CI in flight
+- #604 open — TER-1198 remove N+1 matching call from vendor-supply list — CI in flight
 
 ## Scope
 
@@ -30,39 +32,45 @@ Post-merge fan-out after PR #596 landed. Driven by the lane plan documented in t
 - 2026-04-21T01:24:00Z: Opened PR #600 — mirrored `unit-tests` job from `pre-merge.yml` into `merge.yml` so main pushes fail loudly on unit-test drift instead of silently blocking the next PR's CI.
 - 2026-04-21T01:28:00Z: Opened PR #601 — split `sampleLocationEnum` into three inline `mysqlEnum` calls (`location`, `fromLocation`, `toLocation`) sharing `SAMPLE_LOCATION_VALUES`. Fixes 3-column collision per TER-1194.
 - 2026-04-21T01:32:00Z: Opened PR #602 — added `z-[-1]` to three scheduling modal backdrops (RoomBookingModal, RoomManagementModal, ShiftScheduleView) so click handlers don't dismiss the modal when the user clicks form inputs.
+- 2026-04-21T01:45:00Z: Opened PR #603 — TER-1197. Created `client/src/lib/logout.ts` exporting `AUTH_STORAGE_KEYS` + `clearAuthStorage()`, wired into `useAuth.ts` logout `finally` block. Clears six keys from both localStorage and sessionStorage to prevent stale token leakage after sign-out.
+- 2026-04-21T01:50:00Z: Opened PR #604 — TER-1198. Stripped the N+1 `findBuyersForVendorSupply` call from `getVendorSupplyWithMatches` in `server/vendorSupplyDb.ts`. The list path no longer fans out to `supplies * needs * strainService` reads and no longer writes match rows as a side effect of a GET. Returns `buyerCount: 0` from list; real counts via `vendorSupply.findBuyers` detail endpoint.
+- 2026-04-21T01:55:00Z: Spot-checked TER-1056 and TER-1065 — shipped via merged PR #574 (2026-04-08). Linear status stuck at "In Review"; no code action. Logged as follow-up.
 
-## CI state (rough)
+## CI state (post re-run)
 
-- #597: `Validate Agent Session` initially failed (this branch empties active/). This session file fixes that. Others pass.
-- #598: all required checks pass on first run; `droid-review: pass`.
-- #599: mostly pass; `unit-tests` re-running.
-- #600: mostly pass; `unit-tests` and `droid-review` re-running.
-- #601: mostly pass; `unit-tests` and `targeted-e2e` running.
-- #602: freshly pushed; checks in flight.
+- #597: ALL GREEN after this session-file update re-ran Validate Agent Session.
+- #598: ALL GREEN (targeted-e2e + golden-flows + validate-schema + typescript-check + unit-tests).
+- #599: ALL GREEN.
+- #600: ALL GREEN.
+- #601: ALL GREEN.
+- #602: ALL GREEN.
+- #603: CI in flight (unit-tests + droid-review pending).
+- #604: CI in flight (unit-tests + typescript-check + validate-schema + static-analysis + droid-review pending).
 
 ## Lane plan / remaining next steps
 
-1. **Wait for CI on #597–#602** and land them in order #598 → #599/#600/#601/#602 (each independent). #597 is a pure chore that can ride alongside.
-2. **Lane 2 remaining tickets** (in rough effort order):
-   - TER-1197 — centralize logout + clear auth localStorage keys. Security-adjacent, needs careful diff against `useAuth.ts`. Cherry-pick `884c508` from closed PR #581.
-   - TER-1198 — remove N+1 call from `getVendorSupplyWithMatches`. Cherry-pick `b563c94`.
-   - TER-1195 — delete legacy matching engine files, point consumers at `matchingEngineEnhanced`. Cherry-picks `2b9f547`, `6901d90`. Higher blast radius.
-   - TER-1202 — audit every `sql.raw()` call, parameterize risky, document safe. Workspace-wide sweep. Cherry-pick `b446068`.
-3. **Lane 3**:
-   - TER-1142 Tranche B — fan out into atomic children before implementation.
-   - TER-1143 C1/C3/C8/C13 — design docs first, then PRs.
-   - TER-1144 — single-PR Tranche D.
-4. **Lane 4**:
-   - Spot-check TER-1056 / TER-1065 existing PR state.
-5. **Session wind-down**:
-   - Once the 6 open PRs are merged, move this file from `active/` to `completed/` in a cleanup commit.
+1. **Merge ready PRs in any order**: #597, #598, #599, #600, #601, #602 are all green and independent. #598 should land first since it fixes the version.json test-script prereq that all unit-test CI relies on.
+2. **Watch #603 and #604** until they go green, then merge.
+3. **Lane 2 — skipped/deferred**:
+   - TER-1195 — delete legacy matching engine, repoint consumers. Behavior-change risk; `Match` interface diverges between the two files. Needs explicit spec + manual QA. Not safe autonomously.
+   - TER-1202 — workspace-wide `sql.raw()` audit. Open-ended scope; needs product alignment on acceptance bar. Filed as-is.
+4. **Lane 3 — skipped/deferred**:
+   - TER-1142 Tranche B — needs fan-out into atomic tickets before any code.
+   - TER-1143 C1/C3/C8/C13 — design docs required before implementation.
+   - TER-1144 — single-PR Tranche D needs its own session.
+5. **Lane 4 — filed as follow-up**:
+   - TER-1056 and TER-1065 shipped via PR #574 but Linear status still "In Review". Move to Done manually (or via Linear automation) — no code change needed.
+6. **TER-1210 tail**: 20 unit tests remain `describe.skip`ed. Open one ticket per surface once copy/behavior is re-characterized.
+7. **Session wind-down**: Once these 8 PRs merge, move this file from `active/` to `completed/` in a cleanup commit.
 
 ## Blockers
 
-None. All 6 PRs passed adversarial self-review and are waiting on CI.
+None. All 8 PRs passed adversarial self-review. 6 are all-green; 2 are waiting on CI.
 
 ## Follow-ups (tracked in Linear)
 
-- TER-1209, TER-1193, TER-1194, TER-1191 — covered by PRs #598/#599/#601/#602.
+- TER-1209, TER-1193, TER-1194, TER-1191, TER-1197, TER-1198 — covered by PRs #598/#599/#601/#602/#603/#604.
+- TER-1056, TER-1065 — shipped in PR #574; need Linear state transition to Done.
 - TER-1210 — remains open for the 20 skipped unit tests (one ticket per surface once copy is re-characterized).
-- TER-1197, TER-1198, TER-1195, TER-1202 — Lane 2 backlog.
+- TER-1195, TER-1202 — Lane 2 backlog (deferred, require design/scoping).
+- TER-1142 / TER-1143 / TER-1144 — Lane 3 backlog (deferred, require fan-out/design).

--- a/docs/sessions/active/Session-20260421-post-TER-1210-multi-lane.md
+++ b/docs/sessions/active/Session-20260421-post-TER-1210-multi-lane.md
@@ -1,0 +1,68 @@
+# Session: Post-TER-1210 Multi-Lane Execution
+
+**Task IDs:** TER-1209, TER-1193, TER-1194, TER-1191, CI hardening
+**Agent:** Factory Droid (droplet)
+**Started:** 2026-04-21T01:00:00Z
+**Last Updated:** 2026-04-21T01:35:00Z
+**Status:** In flight — 6 PRs open against main
+**Branch(es):** chore/ter-1210-session-completion (this PR), plus 5 others tracked below
+**Related PRs:**
+
+- #596 merged (TER-1210 partial) — 8c7e7680
+- #597 open — move TER-1210 session file to completed/ (this branch)
+- #598 open — TER-1209 version.json pretest fix
+- #599 open — TER-1193 cartItemStatus enum fix
+- #600 open — add unit-tests job to merge.yml
+- #601 open — TER-1194 sampleLocationEnum split
+- #602 open — TER-1191 modal backdrop z-index
+
+## Scope
+
+Post-merge fan-out after PR #596 landed. Driven by the lane plan documented in the closed session file `Session-20260421-TER-1210-unit-tests-partial.md`.
+
+## Work Log
+
+- 2026-04-21T01:05:00Z: Merged PR #596 (squash). Main at 8c7e7680.
+- 2026-04-21T01:10:00Z: Moved TER-1210 session file to completed/, opened PR #597.
+- 2026-04-21T01:15:00Z: Rebased PR #592 (TER-1055 dashboard KPIs) and PR #582 (cogs adjust) on new main, force-pushed.
+- 2026-04-21T01:20:00Z: Opened PR #598 — package.json test scripts now prepend `node scripts/generate-version.cjs` so vitest can always resolve `../../../version.json`. Verified fix locally by deleting both version.json files, reproducing the exact import-analysis error, then re-running with the regen and watching AppHeader.test.tsx load cleanly.
+- 2026-04-21T01:22:00Z: Opened PR #599 — `mysqlEnum("cartItemStatus", ...)` → `mysqlEnum("itemStatus", ...)` to match the real DB column added by 0030_live_shopping_item_status.sql.
+- 2026-04-21T01:24:00Z: Opened PR #600 — mirrored `unit-tests` job from `pre-merge.yml` into `merge.yml` so main pushes fail loudly on unit-test drift instead of silently blocking the next PR's CI.
+- 2026-04-21T01:28:00Z: Opened PR #601 — split `sampleLocationEnum` into three inline `mysqlEnum` calls (`location`, `fromLocation`, `toLocation`) sharing `SAMPLE_LOCATION_VALUES`. Fixes 3-column collision per TER-1194.
+- 2026-04-21T01:32:00Z: Opened PR #602 — added `z-[-1]` to three scheduling modal backdrops (RoomBookingModal, RoomManagementModal, ShiftScheduleView) so click handlers don't dismiss the modal when the user clicks form inputs.
+
+## CI state (rough)
+
+- #597: `Validate Agent Session` initially failed (this branch empties active/). This session file fixes that. Others pass.
+- #598: all required checks pass on first run; `droid-review: pass`.
+- #599: mostly pass; `unit-tests` re-running.
+- #600: mostly pass; `unit-tests` and `droid-review` re-running.
+- #601: mostly pass; `unit-tests` and `targeted-e2e` running.
+- #602: freshly pushed; checks in flight.
+
+## Lane plan / remaining next steps
+
+1. **Wait for CI on #597–#602** and land them in order #598 → #599/#600/#601/#602 (each independent). #597 is a pure chore that can ride alongside.
+2. **Lane 2 remaining tickets** (in rough effort order):
+   - TER-1197 — centralize logout + clear auth localStorage keys. Security-adjacent, needs careful diff against `useAuth.ts`. Cherry-pick `884c508` from closed PR #581.
+   - TER-1198 — remove N+1 call from `getVendorSupplyWithMatches`. Cherry-pick `b563c94`.
+   - TER-1195 — delete legacy matching engine files, point consumers at `matchingEngineEnhanced`. Cherry-picks `2b9f547`, `6901d90`. Higher blast radius.
+   - TER-1202 — audit every `sql.raw()` call, parameterize risky, document safe. Workspace-wide sweep. Cherry-pick `b446068`.
+3. **Lane 3**:
+   - TER-1142 Tranche B — fan out into atomic children before implementation.
+   - TER-1143 C1/C3/C8/C13 — design docs first, then PRs.
+   - TER-1144 — single-PR Tranche D.
+4. **Lane 4**:
+   - Spot-check TER-1056 / TER-1065 existing PR state.
+5. **Session wind-down**:
+   - Once the 6 open PRs are merged, move this file from `active/` to `completed/` in a cleanup commit.
+
+## Blockers
+
+None. All 6 PRs passed adversarial self-review and are waiting on CI.
+
+## Follow-ups (tracked in Linear)
+
+- TER-1209, TER-1193, TER-1194, TER-1191 — covered by PRs #598/#599/#601/#602.
+- TER-1210 — remains open for the 20 skipped unit tests (one ticket per surface once copy is re-characterized).
+- TER-1197, TER-1198, TER-1195, TER-1202 — Lane 2 backlog.

--- a/docs/sessions/completed/Session-20260421-TER-1210-unit-tests-partial.md
+++ b/docs/sessions/completed/Session-20260421-TER-1210-unit-tests-partial.md
@@ -4,10 +4,10 @@
 **Agent:** Factory Droid (droplet)
 **Started:** 2026-04-20T23:30:00Z
 **Last Updated:** 2026-04-21T00:55:00Z
-**Status:** In Review — PR #596 all checks green, awaiting merge
-**Branch:** fix/ter-1210-unit-tests-partial
-**PR:** https://github.com/EvanTenenbaum/TERP/pull/596
-**Last commit:** 028849bf chore(session): add TER-1210 session file for agent-session gate
+**Status:** Shipped — PR #596 squash-merged to main as `8c7e7680`
+**Branch:** fix/ter-1210-unit-tests-partial (deleted on merge)
+**PR:** https://github.com/EvanTenenbaum/TERP/pull/596 (merged)
+**Merge commit:** 8c7e7680 test(unit): unblock pre-merge CI on main — TER-1210 partial (#596)
 
 ## Scope
 


### PR DESCRIPTION
Moves `Session-20260421-TER-1210-unit-tests-partial.md` from `docs/sessions/active/` to `docs/sessions/completed/` now that PR #596 is merged (8c7e7680).

Closes TER-1210 session lifecycle.