### PR TITLE
chore(ci): add unit-tests job to merge.yml - TER-1210 follow-up

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,6 +15,34 @@ env:
 
 jobs:
   # ================================================================
+  # JOB 0: Unit tests — fast drift detector for main
+  # Mirrors the pre-merge.yml unit-tests job so that if main is ever
+  # merged with a red unit-test suite (e.g. via force-merge / admin
+  # bypass / concurrent-PR interference), this job fails loudly on
+  # every main push instead of staying silent until the next PR rebases.
+  # Ref: TER-1210 — main silently drifted red and blocked 3 open PRs.
+  # ================================================================
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm test --run
+
+  # ================================================================
   # JOB 1: Integration tests + build verification
   # These validate that the merge didn't break core data operations.
   # ================================================================


### PR DESCRIPTION
## Problem

During TER-1210 triage we found main had 21 unit-test failures while `.github/workflows/merge.yml` only ran **integration** tests. The unit-test drift was silent: every open PR's `pre-merge.yml unit-tests` job inherited the failures on rebase, blocking the merge queue until someone noticed.

## Fix

Add a new `unit-tests` job to `merge.yml` that mirrors the `pre-merge.yml` job. On every push to main, it runs `pnpm test --run` and fails loudly if the suite is red, so drift surfaces immediately instead of getting discovered by the next PR that rebases.

## Scope

One-file change. No runtime code modified.

## Linear

TER-1210 follow-up task #8 from the session handoff plan.