### PR TITLE
fix(schema): split sampleLocationEnum into per-column enums - TER-1194

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -3566,16 +3566,24 @@ export const sampleRequestStatusEnum = mysqlEnum("sampleRequestStatus", [
 ]);
 
 /**
- * Sample Location Enum (SAMPLE-008)
- * Tracks where each sample is physically located
+ * Sample Location Enum Values (SAMPLE-008)
+ * Shared value list for the sample-location ENUM. The Drizzle `mysqlEnum`
+ * helper treats its first positional arg as the SQL column name, so we
+ * cannot reuse a single `sampleLocationEnum` binding across three columns
+ * (`location`, `fromLocation`, `toLocation`). Instead, each column
+ * declares its own `mysqlEnum("<colName>", SAMPLE_LOCATION_VALUES)`.
+ *
+ * TER-1194: fix column-name collision that caused Drizzle to issue
+ * queries against a non-existent `sampleLocation` column.
  */
-export const sampleLocationEnum = mysqlEnum("sampleLocation", [
+export const SAMPLE_LOCATION_VALUES = [
   "WAREHOUSE",
   "WITH_CLIENT",
   "WITH_SALES_REP",
   "RETURNED",
   "LOST",
-]);
+] as const;
+export type SampleLocationValue = (typeof SAMPLE_LOCATION_VALUES)[number];
 
 /**
  * Sample Requests Table
@@ -3623,7 +3631,7 @@ export const sampleRequests = mysqlTable(
     vendorShippedDate: timestamp("vendorShippedDate"),
     vendorConfirmedDate: timestamp("vendorConfirmedDate"),
     // Location tracking (SAMPLE-008)
-    location: sampleLocationEnum.default("WAREHOUSE"),
+    location: mysqlEnum("location", SAMPLE_LOCATION_VALUES).default("WAREHOUSE"),
     // Expiration tracking (SAMPLE-009)
     expirationDate: timestamp("expirationDate"),
     createdAt: timestamp("createdAt").defaultNow().notNull(),
@@ -3701,8 +3709,8 @@ export const sampleLocationHistory = mysqlTable(
     sampleRequestId: int("sampleRequestId")
       .notNull()
       .references(() => sampleRequests.id, { onDelete: "cascade" }),
-    fromLocation: sampleLocationEnum,
-    toLocation: sampleLocationEnum.notNull(),
+    fromLocation: mysqlEnum("fromLocation", SAMPLE_LOCATION_VALUES),
+    toLocation: mysqlEnum("toLocation", SAMPLE_LOCATION_VALUES).notNull(),
     changedBy: int("changedBy")
       .notNull()
       .references(() => users.id),


### PR DESCRIPTION
## Problem

`sampleLocationEnum` in `drizzle/schema.ts` was declared once with the column name `"sampleLocation"` and reused on **three** columns:

| Column (schema property) | Real DB column (per autoMigrate.ts TER-98 blocks 2 & 4) |
| ----- | ----- |
| `sampleRequests.location` | `location` |
| `sampleLocationHistory.fromLocation` | `fromLocation` |
| `sampleLocationHistory.toLocation` | `toLocation` |

Because Drizzle's `mysqlEnum` first positional arg is the SQL column name, all three resolved to `sampleLocation` — a column that does not exist, silently breaking any query that touched sample location state.

## Fix

- Extract `SAMPLE_LOCATION_VALUES` as a shared `const` array (with a `SampleLocationValue` TS type export).
- Delete the `sampleLocationEnum` binding.
- Declare each column inline: `mysqlEnum("location", SAMPLE_LOCATION_VALUES)`, `mysqlEnum("fromLocation", SAMPLE_LOCATION_VALUES)`, `mysqlEnum("toLocation", SAMPLE_LOCATION_VALUES).notNull()`.

No migration needed — the DB already has the correct column names per the autoMigrate blocks.

## Verification

- `rg 'sampleLocationEnum' --type=ts` — zero hits outside the doc file mentioned in the original waves prompt. No external callers to update.

## Linear

Closes TER-1194. Salvaged from closed PR #522. Same pattern as PR #599 (TER-1193).