### PR TITLE
fix(scheduling): layer modal backdrop below content with z-[-1] - TER-1191

### DIFF
--- a/client/src/components/scheduling/RoomBookingModal.tsx
+++ b/client/src/components/scheduling/RoomBookingModal.tsx
@@ -127,9 +127,9 @@ export function RoomBookingModal({
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex min-h-full items-center justify-center p-4">
-        {/* Backdrop */}
+        {/* Backdrop (TER-1191: z-[-1] so modal content stays clickable inside the z-50 parent) */}
         <div
-          className="fixed inset-0 bg-black/50 transition-opacity"
+          className="fixed inset-0 z-[-1] bg-black/50 transition-opacity"
           onClick={handleClose}
         />
 

--- a/client/src/components/scheduling/RoomManagementModal.tsx
+++ b/client/src/components/scheduling/RoomManagementModal.tsx
@@ -52,7 +52,9 @@ export function RoomManagementModal({
     features: [],
   });
   const [featureInput, setFeatureInput] = useState("");
-  const [deleteFeatureConfirm, setDeleteFeatureConfirm] = useState<string | null>(null);
+  const [deleteFeatureConfirm, setDeleteFeatureConfirm] = useState<
+    string | null
+  >(null);
 
   const utils = trpc.useUtils();
 
@@ -148,9 +150,9 @@ export function RoomManagementModal({
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex min-h-full items-center justify-center p-4">
-        {/* Backdrop */}
+        {/* Backdrop (TER-1191: z-[-1] so modal content stays clickable inside the z-50 parent) */}
         <div
-          className="fixed inset-0 bg-black/50 transition-opacity"
+          className="fixed inset-0 z-[-1] bg-black/50 transition-opacity"
           onClick={onClose}
         />
 
@@ -352,7 +354,10 @@ export function RoomManagementModal({
             {isLoading ? (
               <div className="animate-pulse space-y-4">
                 {[1, 2, 3].map(i => (
-                  <div key={`skeleton-${i}`} className="h-16 bg-gray-200 rounded" />
+                  <div
+                    key={`skeleton-${i}`}
+                    className="h-16 bg-gray-200 rounded"
+                  />
                 ))}
               </div>
             ) : (
@@ -413,7 +418,7 @@ export function RoomManagementModal({
       </div>
       <ConfirmDialog
         open={deleteFeatureConfirm !== null}
-        onOpenChange={(open) => !open && setDeleteFeatureConfirm(null)}
+        onOpenChange={open => !open && setDeleteFeatureConfirm(null)}
         title="Remove Feature"
         description="Are you sure you want to remove this feature from the room?"
         confirmLabel="Remove"

--- a/client/src/components/scheduling/ShiftScheduleView.tsx
+++ b/client/src/components/scheduling/ShiftScheduleView.tsx
@@ -395,7 +395,8 @@ function CreateShiftModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      {/* Backdrop (TER-1191: z-[-1] so modal content stays clickable inside the z-50 parent) */}
+      <div className="fixed inset-0 z-[-1] bg-black/50" onClick={onClose} />
       <div className="relative bg-white rounded-xl shadow-xl w-full max-w-md">
         <div className="flex items-center justify-between p-4 border-b">
           <h3 className="font-semibold text-gray-900">


### PR DESCRIPTION
## Problem

`RoomBookingModal`, `RoomManagementModal`, and `ShiftScheduleView` each render a backdrop (`fixed inset-0 bg-black/50 onClick={close}`) as a sibling of the modal content inside a `fixed inset-0 z-50` container. With both children positioned `fixed` / `relative` and no explicit z-index, the backdrop can stack above the modal in some paint orders, causing form clicks to dismiss the modal instead of hitting the inputs.

## Fix

Add `z-[-1]` to each backdrop so it sits behind the `relative` modal content within the parent's z-50 stacking context, while still capturing click-outside-to-close on the exposed viewport area.

## Files

- `client/src/components/scheduling/RoomBookingModal.tsx`
- `client/src/components/scheduling/RoomManagementModal.tsx`
- `client/src/components/scheduling/ShiftScheduleView.tsx`

## Linear

Closes TER-1191. Salvaged from closed PR #522 (`origin/claude/fix-recurring-bugs-5bFP6`).