### PR TITLE
fix(auth): centralize logout + clear all auth-bearing storage keys - TER-1197

### DIFF
--- a/client/src/_core/hooks/useAuth.ts
+++ b/client/src/_core/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { getLoginUrl } from "@/const";
+import { clearAuthStorage } from "@/lib/logout";
 import { trpc } from "@/lib/trpc";
 import { TRPCClientError } from "@trpc/client";
 import { useCallback, useEffect, useMemo } from "react";
@@ -60,6 +61,9 @@ export function useAuth(options?: UseAuthOptions) {
       // data, and wouter SPA navigation keeps React/Zustand state alive.
       utils.auth.me.setData(undefined, undefined);
       await utils.invalidate();
+      // TER-1197: centralized clear for every auth-bearing storage key so
+      // stale user info / VIP portal session cannot leak across logins.
+      clearAuthStorage();
       if (typeof window !== "undefined") {
         window.location.assign(getLoginUrl());
       }

--- a/client/src/lib/logout.ts
+++ b/client/src/lib/logout.ts
@@ -1,0 +1,48 @@
+/**
+ * Centralized client-side logout helper (TER-1197).
+ *
+ * Every auth- or identity-bearing browser-storage key the client writes
+ * must be listed here so that `clearAuthStorage()` wipes all of them
+ * during logout. Previously each caller only cleared its own key, so
+ * stale state (cached user info, VIP portal session data, impersonation
+ * flag) leaked across logins and produced confused admin/VIP mixing.
+ *
+ * When adding a new auth-related storage key anywhere in the client,
+ * add it to AUTH_STORAGE_KEYS below.
+ */
+export const AUTH_STORAGE_KEYS = [
+  // Staff/admin runtime cache (client/src/_core/hooks/useAuth.ts)
+  "manus-runtime-user-info",
+  // VIP portal session (client/src/hooks/useVIPPortalAuth.ts)
+  "vip_session_token",
+  "vip_client_id",
+  "vip_client_name",
+  "vip_impersonation",
+  "vip_session_guid",
+] as const;
+
+export type AuthStorageKey = (typeof AUTH_STORAGE_KEYS)[number];
+
+/**
+ * Remove every auth/identity key from both localStorage and sessionStorage.
+ *
+ * Safe to call from SSR contexts — no-ops when `window` is undefined.
+ * Individual storage errors (e.g. Safari private mode) are swallowed so
+ * the logout flow is never blocked.
+ */
+export function clearAuthStorage(): void {
+  if (typeof window === "undefined") return;
+
+  for (const key of AUTH_STORAGE_KEYS) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+    try {
+      window.sessionStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The staff/admin logout path in `client/src/_core/hooks/useAuth.ts` invalidates the tRPC cache and force-navigates to the login URL, but it does not clear any browser storage. Each call site was left to clear its own key, so:

- `manus-runtime-user-info` (cached staff user info) stayed in `localStorage` after logout
- VIP portal keys (`vip_session_token`, `vip_client_id`, `vip_client_name`, `vip_impersonation`, `vip_session_guid`) stayed across logins
- Admin → VIP and VIP → admin transitions inherited stale identity state

## Fix

Add `client/src/lib/logout.ts` exporting `AUTH_STORAGE_KEYS` (const array of every auth-bearing key) and `clearAuthStorage()` (wipes all of them from both `localStorage` and `sessionStorage`, SSR-safe, per-key try/catch so Safari private mode cannot block the logout flow).

Wire `clearAuthStorage()` into `useAuth.logout()` inside the existing `finally` block, after the tRPC cache invalidation and before the hard navigation:

```ts
utils.auth.me.setData(undefined, undefined);
await utils.invalidate();
clearAuthStorage(); // TER-1197
if (typeof window !== "undefined") {
  window.location.assign(getLoginUrl());
}
```

## Verification

- `rg 'localStorage' client/src` — confirmed every auth/VIP key in the client is listed in `AUTH_STORAGE_KEYS` (non-auth keys like theme, sidebar width, agg flags are intentionally left alone).
- `clearAuthStorage()` is pure & idempotent, tolerates SSR, and cannot throw.

## Linear

Closes TER-1197. Salvaged from closed PR #581 (cherry-pick SHA `884c508`).