### PR TITLE
perf(vendor-supply): remove N+1 matching-engine call from list path - TER-1198

### DIFF
--- a/server/vendorSupplyDb.ts
+++ b/server/vendorSupplyDb.ts
@@ -258,40 +258,19 @@ export async function getVendorSupplyWithMatches(filters?: {
   try {
     const supplies = await getVendorSupply(filters);
 
-    // FE-QA-FIX: Calculate actual buyer counts using matching engine
-    const { findBuyersForVendorSupply } =
-      await import("./matchingEngineEnhanced");
-
-    const suppliesWithCounts = await Promise.all(
-      supplies.map(async supply => {
-        try {
-          // Only calculate matches for available items
-          if (supply.status === "AVAILABLE") {
-            const buyers = await findBuyersForVendorSupply(supply.id);
-            return {
-              ...supply,
-              buyerCount: buyers.length,
-            };
-          }
-          return {
-            ...supply,
-            buyerCount: 0,
-          };
-        } catch (matchError) {
-          // Log but don't fail - return 0 if matching fails for one item
-          logger.warn(
-            { supplyId: supply.id, error: matchError },
-            "Failed to find buyers for supply item"
-          );
-          return {
-            ...supply,
-            buyerCount: 0,
-          };
-        }
-      })
-    );
-
-    return suppliesWithCounts;
+    // TER-1198: the previous implementation called
+    // `findBuyersForVendorSupply(supply.id)` per row, which issued several
+    // DB queries per supply (active client needs scan + strain-family
+    // lookups per need) AND wrote match records via `recordMatch` for every
+    // list fetch — a full N*M*k fan-out with side effects on every page
+    // load. We now return a zeroed `buyerCount` from the list path; real
+    // match counts are computed lazily by `vendorSupply.findBuyers` on the
+    // detail view. A proper batched buyer-count query will be filed as a
+    // follow-up if the UI needs list-level totals again.
+    return supplies.map(supply => ({
+      ...supply,
+      buyerCount: 0,
+    }));
   } catch (error) {
     logger.error({ error }, "Error fetching vendor supply with matches");
     throw new Error(


### PR DESCRIPTION
## Problem

`getVendorSupplyWithMatches` in `server/vendorSupplyDb.ts` iterated over every supply and called `findBuyersForVendorSupply(supply.id)` per row. Each call:

1. Queries all active client needs.
2. For each need, calls `calculateMatchConfidence`, which invokes `strainService.getStrainFamily` — another DB call — for needs with a `strainId`.
3. Calls `recordMatch` to **write** match records to the DB for any confidence >= 50.

So every page load of the vendor-supply list fanned out to `supplies * activeNeeds * strainService` reads AND wrote match rows. A full N*M*k fan-out with unintended write side effects on a pure read path.

## Fix

Return the list with `buyerCount: 0` and rely on the existing `vendorSupply.findBuyers` tRPC endpoint (`server/routers/vendorSupply.ts:335`) to compute real counts lazily from the detail view.

The UI regressions (list-level sort-by-buyer-count column will show zeros) are minor and temporary — a follow-up ticket can add a properly batched buyer-count query if product needs list-level totals.

## Verification

- `rg 'getVendorSupplyWithMatches' server` — only callsite is `routers/vendorSupply.ts` which already tolerates the zero case.
- `rg 'buyerCount' client/src` — consumers treat `buyerCount` as `number | null | undefined`; zeros sort correctly.
- No longer writes match records to the DB on list fetch — pure read path.

## Linear

Closes TER-1198. Salvaged from closed PR #581 (cherry-pick SHA `b563c94`).