### PR TITLE
feat(inventory): add Price, COGS, and Margin columns to grid - TER-1047

### DIFF
--- a/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
+++ b/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
@@ -171,6 +171,20 @@ const EXPORT_COLUMNS: ExportColumn<InventoryPilotRow>[] = [
     label: "Unit COGS",
     formatter: v => (v === null || v === undefined ? "" : String(v)),
   },
+  {
+    key: "unitPrice",
+    label: "Unit Price",
+    formatter: v => (v === null || v === undefined ? "" : String(v)),
+  },
+  {
+    key: "marginPercent",
+    label: "Margin %",
+    formatter: v => {
+      if (v === null || v === undefined) return "";
+      const margin = Number(v);
+      return Number.isFinite(margin) ? `${margin.toFixed(1)}%` : "";
+    },
+  },
   { key: "ageLabel", label: "Age" },
   {
     key: "stockStatus",
@@ -716,6 +730,31 @@ export function InventoryManagementSurface() {
         cellClass: canUpdateInventory
           ? "powersheet-cell--editable"
           : "powersheet-cell--locked",
+      },
+      {
+        field: "unitPrice",
+        headerName: "Price",
+        minWidth: 100,
+        maxWidth: 120,
+        valueFormatter: params => formatCurrency(params.value ?? null),
+        cellClass: "powersheet-cell--locked",
+      },
+      {
+        field: "marginPercent",
+        headerName: "Margin",
+        minWidth: 100,
+        maxWidth: 120,
+        valueFormatter: params => {
+          if (params.value === null || params.value === undefined) {
+            return "-";
+          }
+          const margin = Number(params.value);
+          if (!Number.isFinite(margin)) {
+            return "-";
+          }
+          return `${margin.toFixed(1)}%`;
+        },
+        cellClass: "powersheet-cell--locked",
       },
       {
         field: "ageLabel",


### PR DESCRIPTION
## Summary
Adds Price, COGS, and Margin columns to the Inventory grid's default view.

## Changes
- Added **Price** column showing calculated unit price from margin defaults
- Added **Margin** column showing margin percentage
- COGS column already exists, now shown alongside Price and Margin
- Handle null/zero values gracefully (display '-' for missing data)
- Columns are sortable by default
- Include new columns in CSV export

## Acceptance Criteria
- [x] Inventory grid shows Price, COGS, Margin columns by default
- [x] Margin is calculated as (Price - COGS) / Price * 100, displayed as percentage
- [x] Handle null/zero values gracefully (show "-" not NaN)
- [x] Columns are sortable
- [x] Include in CSV export

## Technical Details
- Data already fetched by `inventory.getEnhanced` API endpoint
- `InventoryPilotRow` type already includes `unitPrice` and `marginPercent` fields
- Margin calculation performed server-side using `marginCalculationService`
- Used `formatCurrency` for Price and COGS columns
- Custom formatter for Margin column to show percentage with 1 decimal place

## Testing
Manual testing recommended:
1. Navigate to Inventory workspace
2. Verify Price, COGS, and Margin columns appear in the grid
3. Verify null values show "-" instead of errors
4. Test sorting by each new column
5. Export to CSV and verify new columns are included

Related: TER-1047