### PR TITLE
fix(inventory): use human-readable status labels - TER-1048

### DIFF
--- a/client/src/components/spreadsheet-native/inventoryConstants.ts
+++ b/client/src/components/spreadsheet-native/inventoryConstants.ts
@@ -14,10 +14,10 @@ export const STATUS_OPTIONS = [
 export type InventoryBatchStatus = (typeof STATUS_OPTIONS)[number];
 
 export const STATUS_LABELS: Record<InventoryBatchStatus, string> = {
-  AWAITING_INTAKE: "Incoming",
-  LIVE: "Available",
+  AWAITING_INTAKE: "Awaiting Intake",
+  LIVE: "Live",
   ON_HOLD: "On Hold",
-  QUARANTINED: "Quality Hold",
+  QUARANTINED: "Quarantined",
   SOLD_OUT: "Sold Out",
   CLOSED: "Closed",
 };

--- a/client/src/lib/statusTokens.ts
+++ b/client/src/lib/statusTokens.ts
@@ -208,9 +208,9 @@ export function getPaymentTermLabel(term: string): string {
 
 export const BATCH_STATUS_LABELS: Record<string, string> = {
   AWAITING_INTAKE: "Awaiting Intake",
-  LIVE: "Available",
+  LIVE: "Live",
   ON_HOLD: "On Hold",
-  QUARANTINED: "Quality Hold",
+  QUARANTINED: "Quarantined",
   SOLD_OUT: "Sold Out",
   CLOSED: "Closed",
 };


### PR DESCRIPTION
## Changes

- Updated inventory batch status labels to be more literal and human-readable
- **LIVE**: "Available" → "Live"
- **AWAITING_INTAKE**: "Incoming" → "Awaiting Intake"
- **QUARANTINED**: "Quality Hold" → "Quarantined"
- Applied consistent labels in both `inventoryConstants.ts` and `statusTokens.ts`

## Default Filter

- The default filter is already set to `LIVE` status in `createDefaultInventoryFilters()`
- Users can still clear the filter to see all statuses
- Filter state preserves when switching between tabs within the inventory workspace

## Testing

- ✅ TypeScript check passed (`pnpm check` on modified files)
- ✅ Lint check passed (`pnpm lint`)
- ✅ Build successful (`pnpm build`)

## Acceptance Criteria

- [x] Inventory grid defaults to showing only LIVE status items on load
- [x] Status labels display human-readable text everywhere
- [x] User can still clear filter to see all statuses
- [x] Status filter preserves selection across workspace tab navigation
- [x] TypeScript clean
- [x] Lint clean

Closes TER-1048