### PR TITLE
feat(ux): Mobile back navigation for detail pages - TER-1213

### DIFF
--- a/client/src/pages/ClientProfilePage.tsx
+++ b/client/src/pages/ClientProfilePage.tsx
@@ -474,7 +474,7 @@ export default function ClientProfilePage() {
   if (!shell) {
     return (
       <div className="space-y-4 p-4 md:p-6">
-        <BackButton />
+        <BackButton className="block xl:hidden" />
         <EmptyCard message="This relationship profile could not be loaded." />
       </div>
     );
@@ -482,7 +482,7 @@ export default function ClientProfilePage() {
 
   return (
     <div className="space-y-4 px-4 py-4 md:px-6">
-      <BackButton />
+      <BackButton className="block xl:hidden" />
 
       <LinearWorkspaceShell
         title={shell.name}

--- a/client/src/pages/TodoListDetailPage.tsx
+++ b/client/src/pages/TodoListDetailPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useParams } from "wouter";
 import { useLocation } from "wouter";
-import { Plus, MoreVertical, ArrowLeft } from "lucide-react";
+import { Plus, MoreVertical } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { BackButton } from "@/components/common/BackButton";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -133,14 +134,11 @@ export function TodoListDetailPage() {
     <div className="container mx-auto py-8 px-4">
       {/* Header */}
       <div className="mb-8">
-        <Button
-          variant="ghost"
-          onClick={() => setLocation("/todos")}
-          className="mb-4"
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Lists
-        </Button>
+        <BackButton
+          label="Back to Lists"
+          to="/todos"
+          className="mb-4 block xl:hidden"
+        />
 
         <div className="flex items-start justify-between">
           <div className="flex-1">

--- a/client/src/pages/VIPPortalConfigPage.tsx
+++ b/client/src/pages/VIPPortalConfigPage.tsx
@@ -257,7 +257,7 @@ export default function VIPPortalConfigPage() {
     <div className="p-4 md:p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <BackButton size="icon" />
+          <BackButton size="icon" className="block xl:hidden" />
           <div>
             <h1 className="text-2xl md:text-3xl font-bold">
               VIP Portal Configuration

--- a/docs/sessions/active/TER-1213-session.md
+++ b/docs/sessions/active/TER-1213-session.md
@@ -1,0 +1,11 @@
+# TER-1213 Agent Session
+
+- **Ticket:** TER-1213
+- **Branch:** `feature/ter-1213-mobile-back-nav`
+- **Status:** In Progress
+- **Started:** 2026-04-21
+- **Agent:** Factory Droid
+
+## Summary
+Implementation of TER-1213 as part of TERP Tranche B parallel wave execution.
+


### PR DESCRIPTION
## Summary
Implements TER-1213: Add in-app back navigation that appears on mobile/tablet viewports (below xl breakpoint) for detail pages.

## Changes
- **ClientProfilePage**: Add `xl:hidden` class to BackButton to show only on mobile/tablet
- **VIPPortalConfigPage**: Add `xl:hidden` class to BackButton to show only on mobile/tablet
- **TodoListDetailPage**: Replace custom back button implementation with BackButton component + `xl:hidden` class

## Behavior
- **Mobile/tablet (below 1280px)**: Back button is visible and navigates to parent/list view
- **Desktop (xl+ / 1280px and above)**: Back button is hidden

## Testing
- Verify back button appears on mobile viewport (<1280px) on client profile, VIP portal config, and todo list detail pages
- Verify back button is hidden on desktop viewport (>=1280px)
- Verify back button navigates correctly

## Notes
Order detail, inventory batch detail, and product detail pages mentioned in the ticket do not have dedicated route pages — they are handled as inspector panels/modals within workspace pages.