### PR TITLE
fix(orders): remove finalize order confirmation theater - TER-1222

### DIFF
--- a/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
+++ b/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
@@ -333,7 +333,6 @@ export function SalesOrderSurface({
   const [inventoryRowControls, setInventoryRowControls] = useState<
     Record<number, InventoryRowControls>
   >({});
-  const [showFinalizeConfirm, setShowFinalizeConfirm] = useState(false);
   const [showCreditWarning, setShowCreditWarning] = useState(false);
   const [creditCheckResult, setCreditCheckResult] =
     useState<CreditCheckResult | null>(null);
@@ -1090,9 +1089,13 @@ export function SalesOrderSurface({
       }
     }
 
-    setShowFinalizeConfirm(true);
+    // TER-1222: Remove confirmation theater - finalize directly
+    confirmFinalizeDraft({
+      overrideReason: undefined,
+    });
   }, [
     calculationState.isValid,
+    confirmFinalizeDraft,
     creditCheckMutation,
     draft.clientId,
     draft.orderType,
@@ -1102,24 +1105,19 @@ export function SalesOrderSurface({
   ]);
 
   const handleCreditProceed = useCallback((overrideReason?: string) => {
-    setPendingCreditOverrideReason(overrideReason);
     setShowCreditWarning(false);
-    setShowFinalizeConfirm(true);
-  }, []);
+    setCreditCheckResult(null);
+    // TER-1222: Remove confirmation theater - finalize directly after credit override
+    confirmFinalizeDraft({
+      overrideReason: overrideReason?.trim() || undefined,
+    });
+  }, [confirmFinalizeDraft]);
 
   const handleCreditCancel = useCallback(() => {
     setShowCreditWarning(false);
     setCreditCheckResult(null);
     setPendingCreditOverrideReason(undefined);
   }, []);
-
-  const handleConfirmFinalize = useCallback(() => {
-    setShowFinalizeConfirm(false);
-    confirmFinalizeDraft({
-      overrideReason: pendingCreditOverrideReason?.trim() || undefined,
-    });
-    setPendingCreditOverrideReason(undefined);
-  }, [confirmFinalizeDraft, pendingCreditOverrideReason]);
 
   const keyboard = useWorkSurfaceKeyboard({
     gridMode: false,
@@ -1600,29 +1598,7 @@ export function SalesOrderSurface({
         onCancel={handleCreditCancel}
       />
 
-      <ConfirmDialog
-        open={showFinalizeConfirm}
-        onOpenChange={open => {
-          setShowFinalizeConfirm(open);
-          if (!open) {
-            setPendingCreditOverrideReason(undefined);
-          }
-        }}
-        title={
-          draft.orderType === "QUOTE" ? "Confirm quote?" : "Confirm order?"
-        }
-        description={
-          draft.orderType === "QUOTE"
-            ? "This will save the current draft and finalize it as a quote."
-            : "This will save the current draft and finalize it as a sales order."
-        }
-        confirmLabel={
-          draft.orderType === "QUOTE" ? "Confirm Quote" : "Confirm Order"
-        }
-        onConfirm={handleConfirmFinalize}
-        isLoading={draft.isFinalizingDraft}
-      />
-
+      {/* TER-1222: Removed finalize confirmation dialog (confirmation theater) */}
       <draft.ConfirmNavigationDialog />
     </div>
   );

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -1472,7 +1472,6 @@ export default function OrderCreatorPageV2({
   }, [setLocation]);
 
   const confirmFinalize = () => {
-    setShowFinalizeConfirm(false);
 
     if (!clientId) return;
 

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -461,7 +461,6 @@ export default function OrderCreatorPageV2({
   const [showAdjustmentOnDocument, setShowAdjustmentOnDocument] =
     useState(true);
   const [orderType, setOrderType] = useState<"QUOTE" | "SALE">("SALE");
-  const [showFinalizeConfirm, setShowFinalizeConfirm] = useState(false);
   const [customerDrawerOpen, setCustomerDrawerOpen] = useState(false);
   const [customerDrawerSection, setCustomerDrawerSection] =
     useState<CustomerDrawerSection>("money");
@@ -1407,15 +1406,15 @@ export default function OrderCreatorPageV2({
       }
     }
 
-    // Show confirmation dialog for finalize
-    setShowFinalizeConfirm(true);
+    // TER-1222: Remove confirmation theater - finalize directly
+    confirmFinalize();
   };
 
   const handleCreditProceed = (overrideReason?: string) => {
     setShowCreditWarning(false);
     setPendingOverrideReason(overrideReason);
-    // Show finalize confirmation
-    setShowFinalizeConfirm(true);
+    // TER-1222: Remove confirmation theater - finalize directly after credit override
+    confirmFinalize();
   };
 
   const handleRequestCreditOverride = useCallback(
@@ -2292,16 +2291,7 @@ export default function OrderCreatorPageV2({
           onCancel={handleCreditCancel}
         />
 
-        {/* Finalize Confirmation Dialog */}
-        <ConfirmDialog
-          open={showFinalizeConfirm}
-          onOpenChange={setShowFinalizeConfirm}
-          title={`Finalize ${orderType === "QUOTE" ? "Quote" : "Sales Order"}?`}
-          description={`Are you sure you want to finalize this ${orderType.toLowerCase()}? Total: $${totals.total.toFixed(2)}. This will create the order and cannot be undone.`}
-          confirmLabel="Finalize"
-          variant="default"
-          onConfirm={confirmFinalize}
-        />
+        {/* TER-1222: Removed finalize confirmation dialog (confirmation theater) */}
 
         {/* CHAOS-007: Unsaved Changes Navigation Dialog */}
         <ConfirmNavigationDialog />

--- a/docs/sessions/active/TER-1222-session.md
+++ b/docs/sessions/active/TER-1222-session.md
@@ -1,0 +1,6 @@
+# TER-1222 Agent Session
+
+- **Ticket:** TER-1222
+- **Branch:** `ter-1222-remove-finalize-confirmation`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary
Removes confirmation dialogs that appear when finalizing orders. These dialogs ask "Are you sure?" without providing meaningful additional information, adding friction to a decision the user has already made.

## Changes
- ✅ Remove confirmation dialog from SalesOrderSurface (sales/quote finalization)
- ✅ Remove confirmation dialog from OrderCreatorPage (order finalization)
- ✅ Wire finalize buttons to call mutations directly
- ✅ Preserve credit check warnings (these provide meaningful decision support)

## Rationale
The user has already decided to finalize by:
1. Building the order
2. Adding line items
3. Reviewing totals and margin
4. Clicking the "Confirm Order" or "Finalize" button

Asking "Are you sure?" again adds no safety benefit—it's pure confirmation theater.

## Testing
- TypeScript: Will be verified by CI (environment lacks node/pnpm)
- ESLint: Will be verified by CI
- Manual testing recommended: Click "Confirm Order" in SalesOrderSurface and verify it finalizes immediately

## Related
Closes TER-1222 — [B12] Remove Finalize Order confirmation theater