### PR TITLE
feat(inventory): Kanban board view for batch status pipeline - TER-1224

### DIFF
--- a/client/src/components/inventory/InventoryBatchCard.tsx
+++ b/client/src/components/inventory/InventoryBatchCard.tsx
@@ -1,0 +1,80 @@
+/**
+ * InventoryBatchCard
+ *
+ * Card component for displaying batch information in kanban board view.
+ * Shows: strain name, supplier, quantity, price.
+ */
+
+import { memo } from "react";
+import { Card } from "@/components/ui/card";
+import { MonoId } from "@/components/ui/mono-id";
+
+interface InventoryBatchCardProps {
+  batch: {
+    batchId: number;
+    sku: string;
+    productName: string;
+    vendorName: string;
+    brandName?: string;
+    onHandQty: number;
+    unitPrice: number | null;
+    status: string;
+  };
+  onClick?: () => void;
+}
+
+const formatCurrency = (value: number | null) =>
+  value === null
+    ? "-"
+    : new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(value);
+
+const formatQuantity = (value: number) =>
+  value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+
+export const InventoryBatchCard = memo(function InventoryBatchCard({
+  batch,
+  onClick,
+}: InventoryBatchCardProps) {
+  return (
+    <Card
+      className="p-3 hover:shadow-md transition-shadow cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="space-y-2">
+        {/* SKU */}
+        <div className="flex items-center justify-between">
+          <MonoId value={batch.sku} className="text-xs" />
+        </div>
+
+        {/* Product Name */}
+        <div className="font-medium text-sm leading-tight">
+          {batch.productName}
+        </div>
+
+        {/* Supplier / Brand */}
+        <div className="text-xs text-muted-foreground">
+          {[
+            batch.vendorName !== "-" ? batch.vendorName : null,
+            batch.brandName && batch.brandName !== "-" ? batch.brandName : null,
+          ]
+            .filter(Boolean)
+            .join(" / ") || "No supplier"}
+        </div>
+
+        {/* Quantity and Price */}
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">
+            Qty: <span className="font-medium">{formatQuantity(batch.onHandQty)}</span>
+          </span>
+          <span className="font-medium">{formatCurrency(batch.unitPrice)}</span>
+        </div>
+      </div>
+    </Card>
+  );
+});

--- a/client/src/components/inventory/InventoryKanbanBoard.tsx
+++ b/client/src/components/inventory/InventoryKanbanBoard.tsx
@@ -1,0 +1,67 @@
+/**
+ * InventoryKanbanBoard
+ *
+ * Kanban-style board for inventory management.
+ * Organizes batches by status: Awaiting Intake → Live → On Hold → Quarantined → Sold Out → Closed
+ */
+
+import { useMemo } from "react";
+import { InventoryKanbanColumn } from "./InventoryKanbanColumn";
+import { BATCH_STATUSES } from "../../../../server/constants/batchStatuses";
+import type { BatchStatus } from "../../../../server/constants/batchStatuses";
+
+interface InventoryKanbanBatch {
+  batchId: number;
+  sku: string;
+  productName: string;
+  vendorName: string;
+  brandName?: string;
+  onHandQty: number;
+  unitPrice: number | null;
+  status: string;
+}
+
+interface InventoryKanbanBoardProps {
+  batches: InventoryKanbanBatch[];
+  onBatchClick?: (batchId: number) => void;
+}
+
+export function InventoryKanbanBoard({
+  batches,
+  onBatchClick,
+}: InventoryKanbanBoardProps) {
+  // Group batches by status
+  const batchesByStatus = useMemo(() => {
+    const grouped = new Map<BatchStatus, InventoryKanbanBatch[]>();
+
+    // Initialize all statuses with empty arrays
+    BATCH_STATUSES.forEach(status => {
+      grouped.set(status, []);
+    });
+
+    // Group batches by their status
+    batches.forEach(batch => {
+      const status = batch.status as BatchStatus;
+      if (grouped.has(status)) {
+        grouped.get(status)!.push(batch);
+      }
+    });
+
+    return grouped;
+  }, [batches]);
+
+  return (
+    <div className="h-full max-w-full overflow-x-auto -webkit-overflow-scrolling-touch">
+      <div className="flex flex-col md:flex-row gap-4 p-4 md:p-6 h-full md:min-w-max">
+        {BATCH_STATUSES.map(status => (
+          <InventoryKanbanColumn
+            key={status}
+            status={status}
+            batches={batchesByStatus.get(status) ?? []}
+            onBatchClick={onBatchClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/inventory/InventoryKanbanColumn.tsx
+++ b/client/src/components/inventory/InventoryKanbanColumn.tsx
@@ -1,0 +1,74 @@
+/**
+ * InventoryKanbanColumn
+ *
+ * Represents a single status column in the Inventory Kanban board.
+ * Displays batches grouped by their status.
+ */
+
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { InventoryBatchCard } from "./InventoryBatchCard";
+import { BATCH_STATUS_LABELS, BATCH_STATUS_COLORS } from "../../../../server/constants/batchStatuses";
+import type { BatchStatus } from "../../../../server/constants/batchStatuses";
+
+interface InventoryKanbanBatch {
+  batchId: number;
+  sku: string;
+  productName: string;
+  vendorName: string;
+  brandName?: string;
+  onHandQty: number;
+  unitPrice: number | null;
+  status: string;
+}
+
+interface InventoryKanbanColumnProps {
+  status: BatchStatus;
+  batches: InventoryKanbanBatch[];
+  onBatchClick?: (batchId: number) => void;
+}
+
+export function InventoryKanbanColumn({
+  status,
+  batches,
+  onBatchClick,
+}: InventoryKanbanColumnProps) {
+  const statusLabel = BATCH_STATUS_LABELS[status];
+  const statusColors = BATCH_STATUS_COLORS[status];
+
+  return (
+    <div className="flex-shrink-0 w-full md:w-80">
+      <Card className="h-full flex flex-col">
+        {/* Column Header */}
+        <div className="p-4 border-b border-border">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-semibold text-sm">{statusLabel}</h3>
+            <Badge
+              variant="outline"
+              className={`${statusColors.bg} ${statusColors.text}`}
+            >
+              {batches.length}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Batches List */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {batches.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              No batches
+            </div>
+          ) : (
+            batches.map(batch => (
+              <InventoryBatchCard
+                key={batch.batchId}
+                batch={batch}
+                onClick={() => onBatchClick?.(batch.batchId)}
+              />
+            ))
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
+++ b/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
@@ -14,6 +14,7 @@ import { useLocation } from "wouter";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { CellValueChangedEvent, ColDef } from "ag-grid-community";
 import {
+  Columns3,
   Download,
   Filter,
   Grid3X3,
@@ -96,6 +97,7 @@ import {
   type InventoryFilterState,
 } from "./InventoryAdvancedFilters";
 import { InventoryGalleryView } from "./InventoryGalleryView";
+import { InventoryKanbanBoard } from "../inventory/InventoryKanbanBoard";
 import {
   STATUS_OPTIONS,
   STATUS_LABELS,
@@ -216,7 +218,7 @@ const formatQuantity = (value: number) =>
 // Types
 // ============================================================================
 
-type ViewMode = "grid" | "gallery";
+type ViewMode = "board" | "grid" | "gallery";
 
 interface AdjustDrawerState {
   isOpen: boolean;
@@ -249,8 +251,14 @@ export function InventoryManagementSurface() {
   const { selectedId: selectedBatchId, setSelectedId: setSelectedBatchId } =
     useSpreadsheetSelectionParam("batchId");
 
-  // View & filter state
-  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  // View & filter state - default to board, persist in localStorage
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const stored = localStorage.getItem("inventory-view-mode");
+    if (stored === "board" || stored === "grid" || stored === "gallery") {
+      return stored;
+    }
+    return "board";
+  });
   const [filters, setFilters] = useState<InventoryFilterState>(
     createDefaultInventoryFilters
   );
@@ -293,6 +301,11 @@ export function InventoryManagementSurface() {
   useEffect(() => {
     setLoadedWindowCount(1);
   }, [filters]);
+
+  // Persist viewMode to localStorage
+  useEffect(() => {
+    localStorage.setItem("inventory-view-mode", viewMode);
+  }, [viewMode]);
 
   const loadedRowTarget = PAGE_SIZE * loadedWindowCount;
 
@@ -1097,6 +1110,15 @@ export function InventoryManagementSurface() {
           <div className="ml-auto flex flex-wrap items-center gap-1.5">
             <Button
               size="sm"
+              variant={viewMode === "board" ? "default" : "outline"}
+              className="h-7 px-2"
+              onClick={() => setViewMode("board")}
+              aria-label="Board view"
+            >
+              <Columns3 className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              size="sm"
               variant={viewMode === "grid" ? "default" : "outline"}
               className="h-7 px-2"
               onClick={() => setViewMode("grid")}
@@ -1312,8 +1334,24 @@ export function InventoryManagementSurface() {
           gradeOptions={gradeOptions}
         />
 
-        {/* ── 4. Main Content (Grid / Gallery) ── */}
-        {viewMode === "grid" ? (
+        {/* ── 4. Main Content (Board / Grid / Gallery) ── */}
+        {viewMode === "board" ? (
+          <div className={`${surfacePanelClass} flex-1 min-h-[500px]`}>
+            <InventoryKanbanBoard
+              batches={rows.map(row => ({
+                batchId: row.batchId,
+                sku: row.sku,
+                productName: row.productName,
+                vendorName: row.vendorName,
+                brandName: row.brandName,
+                onHandQty: row.onHandQty,
+                unitPrice: row.unitPrice,
+                status: row.status,
+              }))}
+              onBatchClick={setSelectedBatchId}
+            />
+          </div>
+        ) : viewMode === "grid" ? (
           <PowersheetGrid
             surfaceId="inventory-management"
             requirementIds={[

--- a/docs/sessions/active/TER-1224-session.md
+++ b/docs/sessions/active/TER-1224-session.md
@@ -1,0 +1,7 @@
+# TER-1224 Agent Session
+
+- **Ticket:** TER-1224
+- **Branch:** `feat/ter-1224-inventory-kanban`
+- **Status:** In Progress
+- **Started:** 2026-04-21T23:42:09Z
+- **Agent:** Factory Droid


### PR DESCRIPTION
**Closes TER-1224**

## Summary
Added a kanban-style board view to the Inventory landing page, organized by batch status (Awaiting Intake → Live → On Hold → Quarantined → Sold Out → Closed).

## Changes
- ✅ Added  component with status columns
- ✅ Added  component for each batch status
- ✅ Added  component displaying: strain name, supplier, quantity, price
- ✅ Added board/grid/gallery view toggle in InventoryManagementSurface
- ✅ Default to board view, persist preference in localStorage
- ✅ Click card opens inspector panel for batch details

## Acceptance Criteria Met
- [x] Board renders all batches grouped by status
- [x] Toggle switches between board, grid, and gallery views
- [x] View preference persisted in localStorage
- [x] Default to board view
- [x] TypeScript clean (client UI only)
- [x] Lint clean

## Testing
TIER: STRICT — Client UI only
Manual testing recommended for view switching and card interactions.