### PR TITLE
feat(notifications): Merge Inbox and Todo into unified NotificationsHub - TER-1233

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,7 +49,6 @@ import ShrinkageReportPage from "@/pages/ShrinkageReportPage"; // NAV-018: Shrin
 import ImpersonatePage from "@/pages/vip-portal/auth/ImpersonatePage";
 import SessionEndedPage from "@/pages/vip-portal/SessionEndedPage";
 import AccountPage from "@/pages/AccountPage";
-import { TodoListsPage } from "@/pages/TodoListsPage";
 import { TodoListDetailPage } from "@/pages/TodoListDetailPage";
 import { NotificationsPage } from "@/pages/NotificationsPage";
 // MEET-049 FIX: Use lazy loading to isolate CalendarPage import
@@ -838,14 +837,22 @@ function Router() {
                   path="/clients/:clientId/vip-portal-config"
                   component={withErrorBoundary(VIPPortalConfigPage)}
                 />
-                {/* Todo Lists - support both /todo and /todos */}
+                {/* Todo Lists - redirect to notifications with todos tab */}
                 <Route
                   path="/todo"
-                  component={withErrorBoundary(TodoListsPage)}
+                  component={RedirectWithTab(
+                    "/todo",
+                    "/notifications",
+                    "todos"
+                  )}
                 />
                 <Route
                   path="/todos"
-                  component={withErrorBoundary(TodoListsPage)}
+                  component={RedirectWithTab(
+                    "/todos",
+                    "/notifications",
+                    "todos"
+                  )}
                 />
                 <Route
                   path="/todos/:listId"
@@ -963,7 +970,11 @@ function Router() {
                 />
                 <Route
                   path="/todo-lists"
-                  component={RedirectWithSearch("/todo-lists", "/todos")}
+                  component={RedirectWithTab(
+                    "/todo-lists",
+                    "/notifications",
+                    "todos"
+                  )}
                 />
 
                 {/* TER-859: Dead route redirects */}

--- a/client/src/components/notifications/NotificationsHub.tsx
+++ b/client/src/components/notifications/NotificationsHub.tsx
@@ -1,10 +1,22 @@
-import { useMemo } from "react";
-import { Bell } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Bell, Plus } from "lucide-react";
 import { useLocation, useSearch } from "wouter";
 import { BackButton } from "@/components/common/BackButton";
 import { AlertsPanel } from "@/components/alerts/AlertsPanel";
 import { InlineNotificationPanel } from "@/components/notifications/InlineNotificationPanel";
 import { normalizeNotificationLink } from "@/lib/navigation/notificationLinks";
+import { TodoListCard } from "@/components/todos/TodoListCard";
+import { TodoListForm } from "@/components/todos/TodoListForm";
+import { QuickAddTaskModal } from "@/components/todos/QuickAddTaskModal";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc";
+import {
+  EmptyState,
+  ErrorState,
+  emptyStateConfigs,
+} from "@/components/ui/empty-state";
+import { LoadingState } from "@/components/ui/loading-state";
 import {
   Card,
   CardContent,
@@ -14,16 +26,21 @@ import {
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-type NotificationsHubTab = "system" | "alerts";
+type NotificationsHubTab = "system" | "alerts" | "todos";
 
 function getTabFromSearch(search: string): NotificationsHubTab {
   const value = new URLSearchParams(search).get("tab");
-  return value === "alerts" ? "alerts" : "system";
+  if (value === "alerts") return "alerts";
+  if (value === "todos") return "todos";
+  return "system";
 }
 
 export function NotificationsHub() {
   const search = useSearch();
   const [, setLocation] = useLocation();
+  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
+  const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
+  const [deleteListId, setDeleteListId] = useState<number | null>(null);
 
   const activeTab = useMemo<NotificationsHubTab>(
     () => getTabFromSearch(search),
@@ -35,12 +52,45 @@ export function NotificationsHub() {
 
     if (nextTab === "alerts") {
       params.set("tab", "alerts");
+    } else if (nextTab === "todos") {
+      params.set("tab", "todos");
     } else {
       params.delete("tab");
     }
 
     const query = params.toString();
     setLocation(`/notifications${query ? `?${query}` : ""}`);
+  };
+
+  // Todo Lists data and mutations
+  const {
+    data: listsData,
+    isLoading: listsLoading,
+    error: listsError,
+    isError: listsIsError,
+    refetch: refetchLists,
+  } = trpc.todoLists.getMyLists.useQuery();
+  const lists = Array.isArray(listsData)
+    ? listsData
+    : (listsData?.items ?? []);
+
+  const utils = trpc.useContext();
+
+  const deleteList = trpc.todoLists.delete.useMutation({
+    onSuccess: () => {
+      utils.todoLists.getMyLists.invalidate();
+      setDeleteListId(null);
+    },
+  });
+
+  const handleDeleteList = (listId: number) => {
+    setDeleteListId(listId);
+  };
+
+  const confirmDeleteList = () => {
+    if (deleteListId) {
+      deleteList.mutate({ listId: deleteListId });
+    }
   };
 
   return (
@@ -63,9 +113,10 @@ export function NotificationsHub() {
         onValueChange={handleTabChange}
         className="space-y-4"
       >
-        <TabsList className="grid w-full max-w-md grid-cols-2">
+        <TabsList className="grid w-full max-w-2xl grid-cols-3">
           <TabsTrigger value="system">System Notifications</TabsTrigger>
           <TabsTrigger value="alerts">Alerts</TabsTrigger>
+          <TabsTrigger value="todos">Todo Lists</TabsTrigger>
         </TabsList>
 
         <TabsContent value="system">
@@ -101,7 +152,97 @@ export function NotificationsHub() {
         <TabsContent value="alerts">
           <AlertsPanel variant="full" maxHeight="calc(100vh - 240px)" />
         </TabsContent>
+
+        <TabsContent value="todos">
+          <Card className="overflow-hidden">
+            <CardHeader className="pb-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Todo Lists</CardTitle>
+                  <CardDescription>
+                    Organize your tasks with lists
+                  </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsCreateFormOpen(true)}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    New List
+                  </Button>
+                  <Button
+                    onClick={() => setIsQuickAddOpen(true)}
+                    data-testid="create-todo"
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    New Todo
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {listsLoading ? (
+                <LoadingState message="Loading your lists..." />
+              ) : listsIsError ? (
+                <ErrorState
+                  title="Failed to load todo lists"
+                  description={
+                    listsError?.message ||
+                    "An error occurred while loading your todo lists."
+                  }
+                  onRetry={() => refetchLists()}
+                />
+              ) : lists.length === 0 ? (
+                <EmptyState
+                  {...emptyStateConfigs.todos}
+                  action={{
+                    label: "Create Your First List",
+                    onClick: () => setIsCreateFormOpen(true),
+                  }}
+                />
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {lists.map(list => (
+                    <TodoListCard
+                      key={list.id}
+                      list={list}
+                      onClick={() => setLocation(`/todos/${list.id}`)}
+                      onDelete={() => handleDeleteList(list.id)}
+                    />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
       </Tabs>
+
+      {/* Todo List Forms */}
+      <TodoListForm
+        isOpen={isCreateFormOpen}
+        onClose={() => setIsCreateFormOpen(false)}
+      />
+
+      <QuickAddTaskModal
+        isOpen={isQuickAddOpen}
+        onClose={() => setIsQuickAddOpen(false)}
+        onCreated={createdListId => {
+          setIsQuickAddOpen(false);
+          setLocation(`/todos/${createdListId}`);
+        }}
+      />
+
+      <ConfirmDialog
+        open={!!deleteListId}
+        onOpenChange={open => !open && setDeleteListId(null)}
+        title="Delete Todo List"
+        description="Are you sure you want to delete this list? All tasks will be deleted."
+        confirmLabel="Delete"
+        variant="destructive"
+        onConfirm={confirmDeleteList}
+        isLoading={deleteList.isPending}
+      />
     </div>
   );
 }

--- a/docs/sessions/active/TER-1233-session.md
+++ b/docs/sessions/active/TER-1233-session.md
@@ -1,0 +1,7 @@
+# TER-1233 Agent Session
+
+- **Ticket:** TER-1233
+- **Branch:** `feat/ter-1233-inbox-todo-merge`
+- **Status:** In Progress
+- **Started:** 2026-04-21T23:43:11Z
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary
Merges the Inbox and Todo surfaces into a single unified NotificationsHub with three tabs: System Notifications, Alerts, and Todo Lists.

## Changes
- Added 'Todo Lists' tab to NotificationsHub alongside existing System Notifications and Alerts tabs
- Updated NotificationsHub with full todo list management (create list, quick add task, delete list)
- Redirected /todos and /todo routes to /notifications?tab=todos
- Kept /todos/:listId route for individual todo list detail pages
- Updated TabsList grid from 2 to 3 columns to accommodate new tab
- Removed unused TodoListsPage import from App.tsx

## Testing
- ✅ TypeScript compilation: clean
- ✅ ESLint: clean (no new errors)
- All existing functionality preserved in both Inbox and Todo surfaces
- Navigation updated to use single entry point

Closes TER-1233