### PR TITLE
fix(routing): redirect /sell/orders to /sales - TER-1252

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -571,6 +571,19 @@ function Router() {
                   path="/orders"
                   component={RedirectWithTab("/orders", "/sales", "orders")}
                 />
+                {/* TER-1252: Redirect legacy /sell/orders path to /sales?tab=orders */}
+                <Route
+                  path="/sell/orders"
+                  component={RedirectWithTab(
+                    "/sell/orders",
+                    "/sales",
+                    "orders"
+                  )}
+                />
+                <Route
+                  path="/sell"
+                  component={RedirectWithSearch("/sell", "/sales")}
+                />
                 <Route
                   path="/pick-pack"
                   component={RedirectToOperationsTab("/pick-pack", "shipping")}

--- a/docs/sessions/active/TER-1252-session.md
+++ b/docs/sessions/active/TER-1252-session.md
@@ -1,0 +1,7 @@
+# TER-1252 Agent Session
+
+- **Ticket:** TER-1252
+- **Branch:** `fix/ter-1252-orders-url-redirect`
+- **Status:** In Progress
+- **Started:** 2026-04-22T18:23:45Z
+- **Agent:** Factory Droid

--- a/docs/sessions/active/TER-1252-session.md
+++ b/docs/sessions/active/TER-1252-session.md
@@ -3,5 +3,5 @@
 - **Ticket:** TER-1252
 - **Branch:** `fix/ter-1252-orders-url-redirect`
 - **Status:** In Progress
-- **Started:** 2026-04-22T18:23:45Z
+- **Started:** 2026-04-22T18:36:04Z
 - **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Fixes TER-1252: navigating to `/sell/orders` returned a 404 because the current orders surface lives under `/sales?tab=orders`.

Adds redirect routes for the legacy `/sell/orders` (→ `/sales?tab=orders`) and `/sell` (→ `/sales`) paths using the existing `RedirectWithTab` / `RedirectWithSearch` helpers already used for other legacy route consolidations in `client/src/App.tsx`.

## Changes

- `client/src/App.tsx` — two new `<Route>` entries for `/sell/orders` and `/sell`.

## Verification

- Searched `client/src` for any hardcoded `/sell/orders` or `/sell/` references — none found, so no nav link updates were required.
- TypeScript check: the only `tsc --noEmit` errors in the tree are pre-existing in `client/src/pages/CalendarPage.tsx` and are unrelated to this change (they reproduce on `main` / before the patch).

## Acceptance Criteria

- [x] `/sell/orders` no longer 404s; it redirects to `/sales?tab=orders` preserving any query params.
- [x] No broken nav links — no code referenced `/sell/orders` previously.

TER-1252