### PR TITLE
fix(orders): Standard View shows 0 orders - TER-1257

### DIFF
--- a/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
+++ b/client/src/components/work-surface/OrdersWorkSurface.query.test.ts
@@ -13,25 +13,25 @@ import {
 } from "./OrdersWorkSurface";
 
 describe("buildDraftQueryInput", () => {
-  it("keeps the orders draft tab constrained to sales drafts", () => {
+  // TER-1257: Standard View must mirror the Spreadsheet View queue, which does
+  // not constrain by orderType. The previous `orderType: "SALE"` filter caused
+  // Standard View to return zero orders when data was visible in Spreadsheet.
+  it("requests all draft orders without constraining orderType", () => {
     expect(buildDraftQueryInput()).toEqual({
-      orderType: "SALE",
       isDraft: true,
     });
   });
 });
 
 describe("buildConfirmedQueryInput", () => {
-  it("always constrains confirmed orders to sales", () => {
+  it("requests all confirmed orders without constraining orderType", () => {
     expect(buildConfirmedQueryInput()).toEqual({
-      orderType: "SALE",
       isDraft: false,
     });
   });
 
-  it("preserves the selected fulfillment filter for sales only", () => {
+  it("preserves the selected fulfillment filter", () => {
     expect(buildConfirmedQueryInput("SHIPPED")).toEqual({
-      orderType: "SALE",
       isDraft: false,
       fulfillmentStatus: "SHIPPED",
     });

--- a/client/src/components/work-surface/OrdersWorkSurface.tsx
+++ b/client/src/components/work-surface/OrdersWorkSurface.tsx
@@ -334,22 +334,23 @@ const extractItems = <T,>(data: unknown): T[] => {
   return [];
 };
 
+// TER-1257: Drop the `orderType: "SALE"` constraint so Standard View mirrors
+// the Spreadsheet View queue. The SALE-only filter caused Standard View to
+// return 0 orders while Spreadsheet View rendered data correctly — the
+// divergence was this over-narrow filter, not the data itself.
 export const buildConfirmedQueryInput = (
   fulfillmentStatus?: string
 ): {
-  orderType: "SALE";
   isDraft: boolean;
   fulfillmentStatus?: string;
 } =>
   fulfillmentStatus && fulfillmentStatus !== "ALL"
-    ? { orderType: "SALE", isDraft: false, fulfillmentStatus }
-    : { orderType: "SALE", isDraft: false };
+    ? { isDraft: false, fulfillmentStatus }
+    : { isDraft: false };
 
 export const buildDraftQueryInput = (): {
-  orderType: "SALE";
   isDraft: boolean;
 } => ({
-  orderType: "SALE",
   isDraft: true,
 });
 

--- a/docs/sessions/active/TER-1257-session.md
+++ b/docs/sessions/active/TER-1257-session.md
@@ -1,0 +1,7 @@
+# TER-1257 Agent Session
+
+- **Ticket:** TER-1257
+- **Branch:** `fix/ter-1257-standard-view-zero-orders`
+- **Status:** In Progress
+- **Started:** 2026-04-22T18:23:41Z
+- **Agent:** Factory Droid

--- a/docs/sessions/active/TER-1257-session.md
+++ b/docs/sessions/active/TER-1257-session.md
@@ -3,5 +3,5 @@
 - **Ticket:** TER-1257
 - **Branch:** `fix/ter-1257-standard-view-zero-orders`
 - **Status:** In Progress
-- **Started:** 2026-04-22T18:23:41Z
+- **Started:** 2026-04-22T18:36:04Z
 - **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Standard View on the Sales Orders tab rendered zero rows while Spreadsheet View (same tab, same data) showed the expected orders. The divergence was in the tRPC query input: Standard View asked for orders with `orderType: 'SALE'` in addition to `isDraft`, while Spreadsheet View queried only `{ isDraft }`. With the SALE-only constraint, Standard View returned nothing whenever the visible data set contained orders not strictly typed 'SALE', even though those same rows rendered fine in Spreadsheet View.

This PR drops the `orderType` constraint from the Standard View queue query helpers so both surfaces pull the same set of orders.

## Changes

- `client/src/components/work-surface/OrdersWorkSurface.tsx`
  - Remove `orderType: 'SALE'` from `buildConfirmedQueryInput` and `buildDraftQueryInput` return types and payloads
- `client/src/components/work-surface/OrdersWorkSurface.query.test.ts`
  - Update query-builder expectations to reflect the new, SALE-agnostic input shape

## Acceptance Criteria

- Standard View and Spreadsheet View show the same orders ✓ (both now issue `{ isDraft }`-only queries against `trpc.orders.getAll`)

## Test plan

- `pnpm tsc --noEmit` — no new TypeScript errors from this change (pre-existing CalendarPage.tsx parse errors already on `main` are unrelated)
- `pnpm vitest run client/src/components/work-surface/OrdersWorkSurface.query.test.ts` — passes with updated expectations

## Out of scope / preserved

- Server routers, migrations, and schema untouched
- `OrdersWorkSurface` rendering, keyboard, and inspector logic preserved exactly

Ticket: TER-1257