### PR TITLE
fix(inventory): human-readable Stock Status labels - TER-1251

### DIFF
--- a/client/src/components/inventory/StockStatusBadge.tsx
+++ b/client/src/components/inventory/StockStatusBadge.tsx
@@ -65,3 +65,32 @@ export function StockStatusBadge({
     </Badge>
   );
 }
+
+/**
+ * TER-1251: Human-readable labels for stock status enum values.
+ * Use this in grid column formatters, inspector fields, and CSV exports
+ * instead of rendering the raw enum string.
+ */
+export const STOCK_STATUS_LABELS: Record<StockStatus, string> = {
+  CRITICAL: statusConfig.CRITICAL.label,
+  LOW: statusConfig.LOW.label,
+  OPTIMAL: statusConfig.OPTIMAL.label,
+  OUT_OF_STOCK: statusConfig.OUT_OF_STOCK.label,
+};
+
+/**
+ * Resolve a human-readable label for a raw stock status enum value.
+ * Falls back to a title-cased form of the raw value when the enum is
+ * unrecognized, to avoid ever surfacing SCREAMING_SNAKE_CASE to users.
+ */
+export function getStockStatusLabel(
+  status: string | null | undefined
+): string {
+  if (!status) return "";
+  const known = STOCK_STATUS_LABELS[status as StockStatus];
+  if (known) return known;
+  return status
+    .toLowerCase()
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, c => c.toUpperCase());
+}

--- a/client/src/components/inventory/index.ts
+++ b/client/src/components/inventory/index.ts
@@ -6,7 +6,12 @@
 
 export { BatchMediaUpload } from "./BatchMediaUpload";
 // Sprint 4 Track A exports
-export { StockStatusBadge, type StockStatus } from "./StockStatusBadge";
+export {
+  StockStatusBadge,
+  STOCK_STATUS_LABELS,
+  getStockStatusLabel,
+  type StockStatus,
+} from "./StockStatusBadge";
 export {
   AgingBadge,
   getAgeBracket,

--- a/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
+++ b/client/src/components/spreadsheet-native/InventoryManagementSurface.tsx
@@ -68,6 +68,11 @@ import {
   getGradeClass,
 } from "@/lib/statusTokens";
 import {
+  StockStatusBadge,
+  getStockStatusLabel,
+  type StockStatus,
+} from "@/components/inventory/StockStatusBadge";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -192,7 +197,7 @@ const EXPORT_COLUMNS: ExportColumn<InventoryPilotRow>[] = [
   {
     key: "stockStatus",
     label: "Stock Status",
-    formatter: v => String(v ?? ""),
+    formatter: v => getStockStatusLabel(v as string | null | undefined),
   },
 ];
 
@@ -807,10 +812,21 @@ export function InventoryManagementSurface() {
       },
       {
         field: "stockStatus",
-        headerName: "Stock",
-        minWidth: 90,
-        maxWidth: 110,
+        headerName: "Stock Status",
+        minWidth: 120,
+        maxWidth: 150,
         cellClass: "powersheet-cell--locked",
+        valueFormatter: params =>
+          getStockStatusLabel(params.value as string | null | undefined),
+        cellRenderer: (params: { value: string | null | undefined }) => {
+          if (!params.value) return null;
+          return (
+            <StockStatusBadge
+              status={params.value as StockStatus}
+              showIcon={false}
+            />
+          );
+        },
       },
       {
         headerName: "",
@@ -1535,7 +1551,11 @@ export function InventoryManagementSurface() {
                   <p>{formatQuantity(selectedRow?.availableQty ?? 0)}</p>
                 </InspectorField>
                 <InspectorField label="Stock Status">
-                  <p>{selectedRow?.stockStatus ?? "Unknown"}</p>
+                  <p>
+                    {selectedRow?.stockStatus
+                      ? getStockStatusLabel(selectedRow.stockStatus)
+                      : "Unknown"}
+                  </p>
                 </InspectorField>
                 <InspectorField label="Age">
                   <p>{selectedRow?.ageLabel ?? "-"}</p>

--- a/client/src/components/spreadsheet-native/InventorySheetPilotSurface.tsx
+++ b/client/src/components/spreadsheet-native/InventorySheetPilotSurface.tsx
@@ -53,6 +53,7 @@ import {
   type InventoryBatchStatus,
   mod,
 } from "./inventoryConstants";
+import { getStockStatusLabel } from "@/components/inventory/StockStatusBadge";
 
 // ============================================================================
 // Constants
@@ -120,7 +121,7 @@ const EXPORT_COLUMNS: ExportColumn<InventoryPilotRow>[] = [
   {
     key: "stockStatus",
     label: "Stock Status",
-    formatter: v => String(v ?? ""),
+    formatter: v => getStockStatusLabel(v as string | null | undefined),
   },
 ];
 
@@ -920,7 +921,11 @@ export function InventorySheetPilotSurface({
                 <p>{String(detailSummary?.auditLogCount ?? 0)}</p>
               </InspectorField>
               <InspectorField label="Stock Status">
-                <p>{selectedRow?.stockStatus ?? "Unknown"}</p>
+                <p>
+                  {selectedRow?.stockStatus
+                    ? getStockStatusLabel(selectedRow.stockStatus)
+                    : "Unknown"}
+                </p>
               </InspectorField>
               <InspectorField label="Age">
                 <p>{selectedRow?.ageLabel ?? "-"}</p>

--- a/client/src/components/spreadsheet-native/ProductBrowserGrid.tsx
+++ b/client/src/components/spreadsheet-native/ProductBrowserGrid.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import InlineRowAddControls from "./InlineRowAddControls";
 import { PowersheetGrid } from "./PowersheetGrid";
+import { getStockStatusLabel } from "@/components/inventory/StockStatusBadge";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -207,7 +208,7 @@ export function ProductBrowserGrid({
           item.availableQty !== null && item.availableQty !== undefined
             ? String(item.availableQty)
             : "0",
-        col4: item.stockStatus ?? "",
+        col4: getStockStatusLabel(item.stockStatus),
       }));
     }
 

--- a/docs/sessions/active/TER-1251-session.md
+++ b/docs/sessions/active/TER-1251-session.md
@@ -1,0 +1,7 @@
+# TER-1251 Agent Session
+
+- **Ticket:** TER-1251
+- **Branch:** `fix/ter-1251-stock-status-enum-labels`
+- **Status:** In Progress
+- **Started:** 2026-04-22T18:23:43Z
+- **Agent:** Factory Droid

--- a/docs/sessions/active/TER-1251-session.md
+++ b/docs/sessions/active/TER-1251-session.md
@@ -3,5 +3,5 @@
 - **Ticket:** TER-1251
 - **Branch:** `fix/ter-1251-stock-status-enum-labels`
 - **Status:** In Progress
-- **Started:** 2026-04-22T18:23:43Z
+- **Started:** 2026-04-22T18:36:04Z
 - **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

The Stock Status column in the spreadsheet-native inventory grid was rendering raw SCREAMING_SNAKE_CASE enum values (e.g. `CRITICAL`, `LOW`, `OPTIMAL`, `OUT_OF_STOCK`) instead of human-readable labels.

## Changes

Applies the existing enum humanization pattern (already used elsewhere in the codebase via `getBatchStatusLabel`, `VENDOR_SUPPLY_STATUS_LABELS`, etc.) to stock status values.

- **`StockStatusBadge.tsx`** — export `STOCK_STATUS_LABELS` and `getStockStatusLabel()` helper; reuses the label strings already configured in `statusConfig`.
- **`InventoryManagementSurface.tsx`** — render the `stockStatus` grid column via `<StockStatusBadge>` (matching the classic `InventoryWorkSurface` and gallery view patterns) and humanize the inspector panel field + CSV export formatter. Column header renamed from `Stock` to `Stock Status` and slightly widened for the badge.
- **`InventorySheetPilotSurface.tsx`** — humanize the inspector panel field and CSV export formatter for `stockStatus`.
- **`ProductBrowserGrid.tsx`** — humanize the low-stock tab's stock-status cell.

## Before / After

| Before | After |
| --- | --- |
| `CRITICAL` | Critical |
| `LOW` | Low Stock |
| `OPTIMAL` | Optimal |
| `OUT_OF_STOCK` | Out of Stock |

Unknown enum values fall back to title-cased form (e.g. `FOO_BAR` → `Foo Bar`) so raw SCREAMING_SNAKE_CASE never leaks to users.

## Acceptance Criteria

- [x] Stock Status column shows readable labels (e.g. "Live", "Depleted") not raw enum strings.

## Test plan

- `pnpm tsc --noEmit` — no new TypeScript errors introduced by this change. (Pre-existing errors in `client/src/pages/CalendarPage.tsx` from TER-1232 are unrelated.)
- `npx eslint` on all 5 touched files — clean.
- Visual check: the `Stock Status` column now renders `<StockStatusBadge>` chips identical to the ones already shown in the classic inventory view and gallery.

## Linear

- TER-1251

---

🤖 Generated with Droid