### PR TITLE
fix(csp): remove hardcoded mac-mini agentation endpoint from staging - TER-1254

### DIFF
--- a/.do/app-staging.yaml
+++ b/.do/app-staging.yaml
@@ -94,9 +94,6 @@ services:
       - key: VITE_APP_ID
         value: terp-staging
         scope: RUN_AND_BUILD_TIME
-      - key: VITE_AGENTATION_ENDPOINT
-        value: https://evans-mac-mini.tailbe55dd.ts.net
-        scope: RUN_AND_BUILD_TIME
       - key: VITE_AG_GRID_LICENSE_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET

--- a/docs/sessions/active/TER-1254-session.md
+++ b/docs/sessions/active/TER-1254-session.md
@@ -1,0 +1,7 @@
+# TER-1254 Agent Session
+
+- **Ticket:** TER-1254
+- **Branch:** `fix/ter-1254-agentation-mac-mini-calls`
+- **Status:** In Progress
+- **Started:** 2026-04-22T19:23:07Z
+- **Agent:** Factory Droid (wave launcher)

--- a/server/_core/securityHeaders.test.ts
+++ b/server/_core/securityHeaders.test.ts
@@ -46,7 +46,7 @@ describe("getHelmetConfig", () => {
       getHelmetConfig(
         "production",
         "terp-staging",
-        "https://evans-mac-mini.tailbe55dd.ts.net"
+        "https://agentation.example.com"
       )
     ).toMatchObject({
       contentSecurityPolicy: {
@@ -57,8 +57,8 @@ describe("getHelmetConfig", () => {
             "http://127.0.0.1:4747",
             "ws://localhost:4747",
             "ws://127.0.0.1:4747",
-            "https://evans-mac-mini.tailbe55dd.ts.net",
-            "wss://evans-mac-mini.tailbe55dd.ts.net",
+            "https://agentation.example.com",
+            "wss://agentation.example.com",
           ]),
         },
       },


### PR DESCRIPTION
Removes the hardcoded evans-mac-mini.tailbe55dd.ts.net Tailscale URL from .do/app-staging.yaml. This URL is Evan personal Mac Mini, unreachable from staging, causing hundreds of CSP console errors on every page load. Falls back to localhost:4747 agentation defaults. securityHeaders.test.ts updated to use a generic example URL. TSC clean, vitest 4/4 pass. Fixes TER-1254.