### PR TITLE
feat(design): Tranche D System 3 — Shadow rationalization (TER-1238)

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -87,7 +87,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
   };
 
   return (
-    <header className="border-b border-border/70 bg-background/90 shadow-[0_1px_0_rgba(0,0,0,0.03)] backdrop-blur-md">
+    <header className="border-b border-border/70 bg-background/90 backdrop-blur-md">
       <div className="mx-auto flex min-h-[56px] w-full max-w-[1800px] items-center gap-2 px-3 py-2 md:px-4">
         <Button
           variant="ghost"

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6",
         className
       )}
       {...props}

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -55,7 +55,7 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -242,7 +242,6 @@
         color-mix(in oklab, var(--card) 99%, transparent),
         color-mix(in oklab, var(--background) 94%, transparent)
       );
-    box-shadow: 0 20px 45px -34px rgb(15 23 42 / 0.22);
     overflow: hidden;
   }
 
@@ -357,7 +356,6 @@
     padding: 0.3rem 0.78rem;
     font-size: 0.7rem;
     line-height: 1.15;
-    box-shadow: inset 0 1px 0 color-mix(in oklab, var(--background) 65%, transparent);
   }
 
   .linear-workspace-meta-label {
@@ -454,9 +452,6 @@
     padding: 4px;
     border: 1px solid color-mix(in oklab, var(--border) 84%, transparent);
     background: color-mix(in oklab, var(--muted) 48%, transparent);
-    box-shadow:
-      inset 0 1px 0 color-mix(in oklab, var(--background) 72%, transparent),
-      0 1px 0 color-mix(in oklab, var(--foreground) 3%, transparent);
   }
 
   .linear-workspace-shell[data-density="compact"] .linear-workspace-tabs-list {
@@ -489,9 +484,6 @@
   .linear-workspace-tabs-trigger[data-state="active"] {
     background: var(--background);
     color: var(--foreground);
-    box-shadow:
-      0 1px 1px rgb(15 23 42 / 0.08),
-      0 8px 22px -16px rgb(15 23 42 / 0.3);
   }
 
   .linear-workspace-command-strip {

--- a/docs/sessions/active/TER-1238-session.md
+++ b/docs/sessions/active/TER-1238-session.md
@@ -1,0 +1,6 @@
+# TER-1238 Agent Session
+
+- Ticket: TER-1238
+- Branch: `feat/tranche-d-design-system`
+- Status: In Progress
+- Agent: Factory Droid


### PR DESCRIPTION
## Summary
Implements TER-1238: Shadow rationalization — restricts shadows to 5 overlay surfaces only.

## Changes (8 fixes)
- **Fix 11** — `card.tsx`: Remove `shadow-sm` from Card component
- **Fix 12** — `input.tsx`: Remove `shadow-xs` from Input component
- **Fix 13** — `AppHeader.tsx`: Remove custom `shadow-[0_1px_0_rgba(0,0,0,0.03)]` from header element
- **Fix 14** — `index.css`: Remove `box-shadow` from `.linear-workspace-shell`
- **Fix 15** — `index.css`: Remove `box-shadow` from `.linear-workspace-tabs-list`
- **Fix 16** — `index.css`: Remove `box-shadow` from `.linear-workspace-tabs-trigger[data-state=active]`
- **Fix 17** — `index.css`: Remove `box-shadow` from `.linear-workspace-meta-item`
- **Fix 18** — Design rule: Shadows retained ONLY on overlay surfaces (Dropdown, Popover, Dialog, Sheet, Command menu)

## Linear
Closes TER-1238