### PR TITLE
feat(design): Tranche D System 4 — Kill decorative backgrounds (TER-1241)

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -87,7 +87,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
   };
 
   return (
-    <header className="border-b border-border/70 bg-background/90 backdrop-blur-md">
+    <header className="border-b border-border/70 bg-background">
       <div className="mx-auto flex min-h-[56px] w-full max-w-[1800px] items-center gap-2 px-3 py-2 md:px-4">
         <Button
           variant="ghost"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -206,18 +206,7 @@
 
 @layer components {
   .terp-shell-root {
-    background:
-      radial-gradient(
-        circle at 10% -10%,
-        color-mix(in oklab, var(--primary) 12%, transparent),
-        transparent 38%
-      ),
-      radial-gradient(
-        circle at 100% 0%,
-        color-mix(in oklab, var(--foreground) 4%, transparent),
-        transparent 42%
-      ),
-      var(--background);
+    background: var(--background);
   }
 
   .terp-main-shell {
@@ -236,12 +225,7 @@
     border: 1px solid color-mix(in oklab, var(--border) 86%, transparent);
     border-left: 2px solid oklch(0.53 0.13 44 / 0.22);
     border-radius: 16px;
-    background:
-      linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--card) 99%, transparent),
-        color-mix(in oklab, var(--background) 94%, transparent)
-      );
+    background: var(--card);
     overflow: hidden;
   }
 
@@ -252,12 +236,7 @@
     justify-content: space-between;
     gap: 1rem;
     border-bottom: 1px solid color-mix(in oklab, var(--border) 82%, transparent);
-    background:
-      linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--background) 84%, var(--card)),
-        color-mix(in oklab, var(--card) 98%, transparent)
-      );
+    background: transparent;
     padding: 0.95rem 1rem 0.85rem;
   }
 
@@ -390,7 +369,7 @@
     padding: 0.65rem 1rem 0.72rem;
     min-height: 46px;
     border-bottom: 1px solid color-mix(in oklab, var(--border) 76%, transparent);
-    background: color-mix(in oklab, var(--background) 90%, var(--card));
+    background: var(--card);
   }
 
   .linear-workspace-shell[data-density="compact"] .linear-workspace-tab-row {
@@ -521,12 +500,7 @@
     display: flex;
     flex-direction: column;
     padding: 0.5rem;
-    background:
-      linear-gradient(
-        180deg,
-        color-mix(in oklab, var(--background) 94%, transparent),
-        color-mix(in oklab, var(--card) 96%, transparent)
-      );
+    background: transparent;
   }
 
   .linear-workspace-shell[data-single-tab="true"] .linear-workspace-content {

--- a/docs/sessions/active/TER-1241-session.md
+++ b/docs/sessions/active/TER-1241-session.md
@@ -1,0 +1,6 @@
+# TER-1241 Agent Session
+
+- Ticket: TER-1241
+- Branch: `feat/tranche-d-design-system`
+- Status: In Progress
+- Agent: Factory Droid


### PR DESCRIPTION
## Summary

Tranche D System 4 — Remove all decorative gradients and backdrop-blur from shell/header components.

## Scope
- `.terp-shell-root`: remove both radial gradients (`index.css`)
- `.linear-workspace-shell`: remove gradient; use `transparent` or `var(--card)`
- `.linear-workspace-header`: remove gradient
- `.linear-workspace-content`: remove gradient
- `.linear-workspace-tab-row`: remove color-mix background
- `AppHeader`: remove `backdrop-blur-md` + `bg-background/90`

## Acceptance
Zero decorative gradients in `index.css`.

Linear: TER-1241