### PR TITLE
feat(design): Tranche D System 2 — Radius discipline (TER-1243)

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -111,12 +111,12 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
           onSubmit={handleSearch}
           className="flex min-w-0 flex-1 items-center xl:max-w-4xl"
         >
-          <div className="relative flex w-full items-center rounded-2xl border border-border/70 bg-card/90 shadow-sm">
+          <div className="relative flex w-full items-center rounded-[var(--radius)] border border-border/70 bg-card/90 shadow-sm">
             <Search className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
               placeholder="Search, jump, or run a command..."
-              className="h-10 w-full rounded-2xl border-0 bg-transparent pl-10 pr-[5.5rem] text-sm shadow-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="h-10 w-full rounded-[var(--radius)] border-0 bg-transparent pl-10 pr-[5.5rem] text-sm shadow-none focus-visible:ring-1 focus-visible:ring-ring"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -133,7 +133,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
           </div>
         </form>
 
-        <div className="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 bg-card/90 p-1 shadow-sm">
+        <div className="ml-auto flex shrink-0 items-center gap-1 rounded-[var(--radius)] border border-border/70 bg-card/90 p-1 shadow-sm">
           <NotificationBell className="relative flex h-11 w-11 items-center justify-center sm:h-9 sm:w-9" />
           <Button
             variant="ghost"

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-[var(--radius)] border py-6",
         className
       )}
       {...props}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -101,7 +101,7 @@
   --chart-3: oklch(0.42 0.15 25);
   --chart-4: oklch(0.58 0.07 40);
   --chart-5: oklch(0.31 0.09 55);
-  --radius: 0.15rem;
+  --radius: 0.375rem;
   --background: oklch(0.979 0.007 76);
   --foreground: oklch(0.135 0.01 60);
   --card: oklch(1 0 0);
@@ -224,7 +224,7 @@
     gap: 0;
     border: 1px solid color-mix(in oklab, var(--border) 86%, transparent);
     border-left: 2px solid oklch(0.53 0.13 44 / 0.22);
-    border-radius: 16px;
+    border-radius: var(--radius);
     background: var(--card);
     overflow: hidden;
   }
@@ -254,7 +254,7 @@
     gap: 0.45rem;
     min-width: 0;
     width: fit-content;
-    border-radius: 999px;
+    border-radius: var(--radius);
     border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
     background: color-mix(in oklab, var(--muted) 42%, transparent);
     padding: 0.22rem 0.6rem;
@@ -329,7 +329,7 @@
     gap: 0.4rem;
     min-height: 30px;
     max-width: min(100%, 320px);
-    border-radius: 999px;
+    border-radius: var(--radius);
     border: 1px solid color-mix(in oklab, var(--border) 82%, transparent);
     background: color-mix(in oklab, var(--muted) 38%, transparent);
     padding: 0.3rem 0.78rem;
@@ -427,7 +427,7 @@
     gap: 0.34rem;
     height: 34px;
     min-width: max-content;
-    border-radius: 999px;
+    border-radius: var(--radius);
     padding: 4px;
     border: 1px solid color-mix(in oklab, var(--border) 84%, transparent);
     background: color-mix(in oklab, var(--muted) 48%, transparent);
@@ -713,7 +713,7 @@
     }
 
     .linear-workspace-shell {
-      border-radius: 10px;
+      border-radius: var(--radius);
     }
 
     .linear-workspace-header,

--- a/docs/sessions/active/TER-1243-session.md
+++ b/docs/sessions/active/TER-1243-session.md
@@ -1,0 +1,6 @@
+# TER-1243 Agent Session
+
+- Ticket: TER-1243
+- Branch: `feat/tranche-d-design-system`
+- Status: In Progress
+- Agent: Factory Droid


### PR DESCRIPTION
## TER-1243 — [D System 2] Radius discipline — single --radius token (5 fixes)

**Linear:** https://linear.app/terpcorp/issue/TER-1243/d-system-2-radius-discipline-single-radius-token-5-fixes
**Parent:** TER-1144 (Tranche D — Design system)

Systems 1 (TER-1240), 3 (TER-1238), and 4 (TER-1241) are already merged to main. This PR implements System 2.

---

@droid

TERP AGENT ONBOARDING — DO THIS FIRST, IN ORDER:
1. cd /home/factory/repos/TERP
2. git stash --include-untracked 2>/dev/null; git checkout feat/tranche-d-design-system && git pull --ff-only
3. Read docs/agent-context/START_HERE.md
4. Verify docs/sessions/active/TER-1243-session.md exists (it should — already committed to this branch)

Commit rules: conventional commits only. No any, no ctx.user?.id || 1, no db.delete().
Push to feat/tranche-d-design-system. Do NOT merge PR.

---

GOAL: Implement Tranche D System 2 — enforce a single --radius CSS token across all UI primitives (5 atomic fixes).

SCOPE: client/src/index.css, client/src/components/ui/card.tsx, client/src/layout/AppHeader.tsx

ACCEPTANCE CRITERIA:
  - Single --radius: 0.375rem (6px) defined in index.css :root
  - card.tsx: rounded-xl replaced with rounded-[var(--radius)]
  - AppHeader.tsx search input: rounded-2xl replaced with token
  - Kill rounded-full on non-interactive containers (meta pills, eyebrow pill, tabs list) in index.css
  - Audit: interactive elements use radius token; layout containers use 0 or token
  - pnpm check passes (TypeScript + lint)

TEST COMMAND: pnpm check
BRANCH: feat/tranche-d-design-system (already exists — push to it)
DO NOT TOUCH: server/, db/, migrations/, auth/
CONTEXT: TER-1243 (Linear), Tranche D System 2. Parent: TER-1144.