### PR TITLE
style(design): Tranche D System 2 — enforce --radius token (TER-1243)

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -116,7 +116,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
             <Input
               type="search"
               placeholder="Search, jump, or run a command..."
-              className="h-10 w-full rounded-2xl border-0 bg-transparent pl-10 pr-[5.5rem] text-sm shadow-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="h-10 w-full rounded-[var(--radius)] border-0 bg-transparent pl-10 pr-[5.5rem] text-sm shadow-none focus-visible:ring-1 focus-visible:ring-ring"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-[var(--radius)] border py-6",
         className
       )}
       {...props}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -101,7 +101,7 @@
   --chart-3: oklch(0.42 0.15 25);
   --chart-4: oklch(0.58 0.07 40);
   --chart-5: oklch(0.31 0.09 55);
-  --radius: 0.15rem;
+  --radius: 0.375rem; /* 6px — Tranche D System 2 */
   --background: oklch(0.979 0.007 76);
   --foreground: oklch(0.135 0.01 60);
   --card: oklch(1 0 0);
@@ -224,7 +224,7 @@
     gap: 0;
     border: 1px solid color-mix(in oklab, var(--border) 86%, transparent);
     border-left: 2px solid oklch(0.53 0.13 44 / 0.22);
-    border-radius: 16px;
+    border-radius: var(--radius);
     background: var(--card);
     overflow: hidden;
   }
@@ -254,7 +254,7 @@
     gap: 0.45rem;
     min-width: 0;
     width: fit-content;
-    border-radius: 999px;
+    border-radius: var(--radius);
     border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
     background: color-mix(in oklab, var(--muted) 42%, transparent);
     padding: 0.22rem 0.6rem;
@@ -329,7 +329,7 @@
     gap: 0.4rem;
     min-height: 30px;
     max-width: min(100%, 320px);
-    border-radius: 999px;
+    border-radius: var(--radius);
     border: 1px solid color-mix(in oklab, var(--border) 82%, transparent);
     background: color-mix(in oklab, var(--muted) 38%, transparent);
     padding: 0.3rem 0.78rem;
@@ -427,7 +427,7 @@
     gap: 0.34rem;
     height: 34px;
     min-width: max-content;
-    border-radius: 999px;
+    border-radius: var(--radius);
     padding: 4px;
     border: 1px solid color-mix(in oklab, var(--border) 84%, transparent);
     background: color-mix(in oklab, var(--muted) 48%, transparent);

--- a/docs/sessions/active/TER-1243-session.md
+++ b/docs/sessions/active/TER-1243-session.md
@@ -1,0 +1,6 @@
+# TER-1243 Agent Session
+
+- Ticket: TER-1243
+- Branch: feat/ter-1243-d-system-2-radius-discipline
+- Status: In Progress
+- Agent: Manus PM

--- a/docs/sessions/active/TER-1243-session.md
+++ b/docs/sessions/active/TER-1243-session.md
@@ -1,6 +1,7 @@
 # TER-1243 Agent Session
 
 - Ticket: TER-1243
-- Branch: feat/ter-1243-d-system-2-radius-discipline
+- Branch: `feat/ter-1243-d-system-2-radius-discipline`
 - Status: In Progress
 - Agent: Manus PM
+- Started: 2026-04-23


### PR DESCRIPTION
## Summary

Tranche D System 2 — enforce a single `--radius` CSS token across all UI primitives.

## Changes

### `client/src/index.css`
- Updated `--radius` value from `0.15rem` to `0.375rem` (6px) per Tranche D System 2 spec
- Replaced `border-radius: 16px` on `.linear-workspace-shell` with `var(--radius)` (layout container)
- Replaced `border-radius: 999px` on `.linear-workspace-eyebrow` with `var(--radius)` (decorative non-interactive label)
- Replaced `border-radius: 999px` on `.linear-workspace-meta-item` with `var(--radius)` (non-interactive metadata display)
- Replaced `border-radius: 999px` on `.linear-workspace-tabs-list` with `var(--radius)` (non-interactive container)
- **Kept** `border-radius: 999px` on `.linear-workspace-tabs-trigger` — interactive element, pill shape intentional

### `client/src/components/ui/card.tsx`
- Replaced `rounded-xl` with `rounded-[var(--radius)]` — uses the CSS token directly

### `client/src/layout/AppHeader.tsx`
- Replaced `rounded-2xl` on search input with `rounded-[var(--radius)]`

## Acceptance Criteria

- [x] Single `--radius: 0.375rem` (6px) defined in `index.css :root`
- [x] `card.tsx`: `rounded-xl` replaced with token
- [x] `AppHeader.tsx` search input: `rounded-2xl` replaced with token
- [x] Non-interactive containers (eyebrow pill, meta items, tabs list) use token instead of `999px`
- [x] Interactive elements (`tabs-trigger`) keep their pill shape

Closes TER-1243