### PR TITLE
feat(design): Tranche D System 5 — Header + sidebar consolidation (TER-1242)

### DIFF
--- a/client/src/components/layout/LinearWorkspaceShell.tsx
+++ b/client/src/components/layout/LinearWorkspaceShell.tsx
@@ -16,17 +16,13 @@ export interface LinearWorkspaceTab<T extends string = string> {
 
 interface LinearWorkspaceShellProps<T extends string> {
   title: string;
-  description: string;
   activeTab: T;
   tabs: readonly LinearWorkspaceTab<T>[];
   onTabChange: (tab: T) => void;
-  meta?: Array<{ label: string; value: ReactNode }>;
   commandStrip?: ReactNode;
   children: ReactNode;
   className?: string;
   density?: "default" | "compact";
-  /** Navigation section label (e.g. "Sell", "Buy", "Finance") shown as a hierarchy cue */
-  section?: string;
 }
 
 const TRANSITION_SKELETON_MS = 180;
@@ -63,19 +59,15 @@ function LinearWorkspaceTransitionSkeleton() {
 
 export function LinearWorkspaceShell<T extends string>({
   title,
-  description,
   activeTab,
   tabs,
   onTabChange,
-  meta = [],
   commandStrip,
   children,
   className,
   density = "default",
-  section,
 }: LinearWorkspaceShellProps<T>) {
-  const showHeader = Boolean(title || description || section);
-  const showMeta = meta.length > 0;
+  const showHeader = Boolean(title);
   const showTabs = tabs.length > 1;
   const showTabRow = showTabs || Boolean(commandStrip);
   const tabsScrollRef = useRef<HTMLDivElement>(null);
@@ -133,44 +125,10 @@ export function LinearWorkspaceShell<T extends string>({
       {showHeader && (
         <header className="linear-workspace-header">
           <div className="linear-workspace-title-wrap">
-            <p className="linear-workspace-eyebrow">
-              {section ? (
-                <>
-                  <span className="linear-workspace-eyebrow-section">
-                    {section}
-                  </span>
-                  <span className="linear-workspace-eyebrow-sep" aria-hidden>
-                    {" "}
-                    /{" "}
-                  </span>
-                </>
-              ) : null}
-              Workspace
-            </p>
             <div>
               <h1 className="linear-workspace-title">{title}</h1>
-              {description ? (
-                <p className="linear-workspace-description">{description}</p>
-              ) : null}
             </div>
           </div>
-          {showMeta && (
-            <div
-              className="linear-workspace-meta"
-              aria-label="Workspace metadata"
-            >
-              {meta.map(item => (
-                <div key={item.label} className="linear-workspace-meta-item">
-                  <span className="linear-workspace-meta-label">
-                    {item.label}
-                  </span>
-                  <span className="linear-workspace-meta-value">
-                    {item.value}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
         </header>
       )}
 

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -282,7 +282,7 @@ export const Sidebar = React.memo(function Sidebar({
                     className={cn(
                       "flex items-center gap-3 rounded-md text-sm transition-colors max-md:min-h-11 px-3 py-2",
                       isActivePath("/sales?tab=create-order")
-                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                         : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                     )}
                     aria-current={
@@ -303,7 +303,7 @@ export const Sidebar = React.memo(function Sidebar({
                     className={cn(
                       "flex items-center gap-3 rounded-md text-sm transition-colors max-md:min-h-11 px-3 py-2",
                       isActivePath("/sales?tab=orders")
-                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                         : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                     )}
                     aria-current={
@@ -322,7 +322,7 @@ export const Sidebar = React.memo(function Sidebar({
                     className={cn(
                       "flex items-center gap-3 rounded-md text-sm transition-colors max-md:min-h-11 px-3 py-2",
                       isActivePath("/sales?tab=sales-sheets")
-                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                         : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                     )}
                     aria-current={
@@ -343,7 +343,7 @@ export const Sidebar = React.memo(function Sidebar({
                     className={cn(
                       "flex items-center gap-3 rounded-md text-sm transition-colors max-md:min-h-11 px-3 py-2",
                       isActivePath("/relationships?tab=clients")
-                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                         : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                     )}
                     aria-current={
@@ -364,7 +364,7 @@ export const Sidebar = React.memo(function Sidebar({
                     className={cn(
                       "flex items-center gap-3 rounded-md text-sm transition-colors max-md:min-h-11 px-3 py-2",
                       isActivePath("/inventory?tab=shipping")
-                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                        ? "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                         : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                     )}
                     aria-current={
@@ -391,7 +391,7 @@ export const Sidebar = React.memo(function Sidebar({
                 key={group.key}
                 className={cn(
                   "rounded-lg border border-transparent transition-colors",
-                  hasActiveItem && "border-white/10 bg-white/5"
+                  false
                 )}
               >
                 {!collapsed && (
@@ -408,12 +408,6 @@ export const Sidebar = React.memo(function Sidebar({
                     data-testid="nav-group-label"
                   >
                     <span className="flex items-center gap-1.5">
-                      {hasActiveItem && (
-                        <span
-                          className="inline-block h-1.5 w-1.5 rounded-full bg-[oklch(0.78_0.18_130)] flex-shrink-0"
-                          aria-hidden
-                        />
-                      )}
                       {group.label}
                     </span>
                     {isOpen ? (
@@ -451,7 +445,7 @@ export const Sidebar = React.memo(function Sidebar({
                                   : "px-3 py-2",
                                 isActive
                                   ? cn(
-                                      "border-l-[3px] border-[oklch(0.78_0.18_130)] bg-white/10 text-white font-semibold"
+                                      "border-l-[3px] border-[oklch(0.78_0.18_130)] text-white"
                                     )
                                   : "border-l-[3px] border-transparent font-normal text-white/65 hover:bg-white/8 hover:text-white/90"
                               )}
@@ -483,18 +477,7 @@ export const Sidebar = React.memo(function Sidebar({
 
         {/* TER-599: Simplified footer — user info + logout only */}
         <div className="border-t border-white/10 p-3">
-          {!collapsed && (
-            <div className="flex items-center gap-2 mb-2">
-              <Avatar className="h-7 w-7">
-                <AvatarFallback className="text-xs bg-white/10 text-white/70">
-                  <UserCircle2 className="h-4 w-4" />
-                </AvatarFallback>
-              </Avatar>
-              <p className="text-xs text-white/70 truncate">
-                {currentUser?.name || currentUser?.email || "TERP Operator"}
-              </p>
-            </div>
-          )}
+          
           <Button
             variant="ghost"
             size="sm"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -248,36 +248,10 @@
     gap: 0.35rem;
   }
 
-  .linear-workspace-eyebrow {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.45rem;
-    min-width: 0;
-    width: fit-content;
-    border-radius: var(--radius);
-    border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
-    background: color-mix(in oklab, var(--muted) 42%, transparent);
-    padding: 0.22rem 0.6rem;
-    font-size: 0.61rem;
-    line-height: 1;
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    font-weight: 700;
-    color: color-mix(in oklab, var(--muted-foreground) 86%, transparent);
-  }
-
-  .linear-workspace-eyebrow-section {
-    color: oklch(0.53 0.13 44);
-  }
-
-  .linear-workspace-eyebrow-sep {
-    color: color-mix(in oklab, var(--muted-foreground) 72%, transparent);
-  }
-
   .linear-workspace-title {
-    font-size: clamp(1.75rem, 2.4vw, 2.5rem);
+    font-size: 1.125rem;
     line-height: 1.1;
-    font-weight: 700;
+    font-weight: 600;
     letter-spacing: -0.03em;
     min-width: 0;
   }
@@ -309,13 +283,10 @@
     gap: 0.2rem;
   }
 
-  .linear-workspace-shell[data-density="compact"] .linear-workspace-eyebrow {
-    font-size: 0.57rem;
-    letter-spacing: 0.1em;
-  }
+  .linear-workspace-shell[data-density="compact"]
 
   .linear-workspace-shell[data-density="compact"] .linear-workspace-title {
-    font-size: clamp(1.35rem, 2vw, 1.75rem);
+    font-size: 1.125rem;
   }
 
   .linear-workspace-shell[data-density="compact"]
@@ -424,13 +395,14 @@
   .linear-workspace-tabs-list {
     display: inline-flex;
     align-items: center;
-    gap: 0.34rem;
+    gap: 0;
     height: 34px;
     min-width: max-content;
-    border-radius: var(--radius);
-    padding: 4px;
-    border: 1px solid color-mix(in oklab, var(--border) 84%, transparent);
-    background: color-mix(in oklab, var(--muted) 48%, transparent);
+    border-radius: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 76%, transparent);
   }
 
   .linear-workspace-shell[data-density="compact"] .linear-workspace-tabs-list {
@@ -443,9 +415,14 @@
     padding-inline: 0.98rem;
     white-space: nowrap;
     font-size: 0.73rem;
-    font-weight: 600;
+    font-weight: 500;
     letter-spacing: 0.01em;
-    border-radius: 999px;
+    border-radius: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: var(--muted-foreground);
+    height: 100%;
+    transition: color 0.15s, border-color 0.15s;
   }
 
   .linear-workspace-shell[data-density="compact"]
@@ -461,8 +438,10 @@
   }
 
   .linear-workspace-tabs-trigger[data-state="active"] {
-    background: var(--background);
+    background: transparent;
     color: var(--foreground);
+    border-bottom-color: var(--foreground);
+    font-weight: 600;
   }
 
   .linear-workspace-command-strip {

--- a/client/src/pages/AccountingWorkspacePage.tsx
+++ b/client/src/pages/AccountingWorkspacePage.tsx
@@ -54,25 +54,9 @@ export default function AccountingWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title={ACCOUNTING_WORKSPACE.title}
-      description="Keep invoices, bills, payments, and ledger work in one queue-first finance workspace."
-      section="Finance"
       activeTab={activeTab}
       tabs={ACCOUNTING_WORKSPACE.tabs}
       onTabChange={setActiveTab}
-      meta={[
-        {
-          label: "Cash in",
-          value: "Select an invoice, then record payment",
-        },
-        {
-          label: "Cash out",
-          value: "Pay suppliers, then confirm the ledger",
-        },
-        {
-          label: "Ledger flow",
-          value: "Invoice -> Payment -> General Ledger",
-        },
-      ]}
     >
       <LinearWorkspacePanel value="dashboard">
         <AccountingDashboard embedded />

--- a/client/src/pages/ClientProfilePage.tsx
+++ b/client/src/pages/ClientProfilePage.tsx
@@ -486,12 +486,9 @@ export default function ClientProfilePage() {
 
       <LinearWorkspaceShell
         title={shell.name}
-        description="Unified customer and supplier workspace with money, pricing, inventory, and activity in one place."
-        section="Relationships"
         activeTab={activeSection}
         tabs={PROFILE_TABS}
         onTabChange={handleSectionChange}
-        meta={meta}
         commandStrip={commandStrip}
       >
         <LinearWorkspacePanel value="overview">

--- a/client/src/pages/CreditsWorkspacePage.tsx
+++ b/client/src/pages/CreditsWorkspacePage.tsx
@@ -201,21 +201,9 @@ export default function CreditsWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title={CREDITS_WORKSPACE.title}
-      description={CREDITS_WORKSPACE.description}
-      section="Finance"
       activeTab={activeTab}
       tabs={CREDITS_WORKSPACE.tabs}
       onTabChange={tab => setActiveTab(tab)}
-      meta={[
-        {
-          label: "Capacity",
-          value: "Client limits, exposure, and order guardrails",
-        },
-        {
-          label: "Adjustments",
-          value: "Issued adjustments that can be applied back to invoices",
-        },
-      ]}
       commandStrip={
         <>
           <Button

--- a/client/src/pages/DemandSupplyWorkspacePage.tsx
+++ b/client/src/pages/DemandSupplyWorkspacePage.tsx
@@ -26,20 +26,9 @@ export default function DemandSupplyWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title={DEMAND_SUPPLY_WORKSPACE.title}
-      description={DEMAND_SUPPLY_WORKSPACE.description}
-      section="Sell"
       activeTab={activeTab}
       tabs={DEMAND_SUPPLY_WORKSPACE.tabs}
       onTabChange={tab => setActiveTab(tab)}
-      meta={[
-        { label: "Primary", value: "Matching supply with demand" },
-        {
-          label: "Current view",
-          value:
-            DEMAND_SUPPLY_WORKSPACE.tabs.find(tab => tab.value === activeTab)
-              ?.label ?? activeTab,
-        },
-      ]}
       commandStrip={
         <>
           <Button

--- a/client/src/pages/InventoryWorkspacePage.tsx
+++ b/client/src/pages/InventoryWorkspacePage.tsx
@@ -119,15 +119,9 @@ export default function InventoryWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title={INVENTORY_WORKSPACE.title}
-      description="Inventory, intake, receiving, shipping, photography, and samples share one operational frame."
-      section="Operations"
       activeTab={activeTab}
       tabs={INVENTORY_TABS_CONFIG}
       onTabChange={tab => setActiveTab(tab)}
-      meta={[
-        { label: "Primary", value: "Inventory and intake" },
-        { label: "Handoffs", value: "Receiving and shipping" },
-      ]}
       data-testid="inventory-header"
       commandStrip={
         activeTab === "intake" ? (

--- a/client/src/pages/ProcurementWorkspacePage.tsx
+++ b/client/src/pages/ProcurementWorkspacePage.tsx
@@ -71,15 +71,9 @@ export default function ProcurementWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title="Buying"
-      description="Create and manage purchase orders, track supplier intake, and walk POs from draft to received."
-      section="Operations"
       activeTab={activeTab}
       tabs={PROCUREMENT_TABS}
       onTabChange={setActiveTab}
-      meta={[
-        { label: "Primary", value: "Purchase orders" },
-        { label: "Next handoff", value: "Receiving" },
-      ]}
       commandStrip={
         // TER-1060: Quick-nav shortcut into the "Expected Deliveries Today" filtered view
         <Button

--- a/client/src/pages/RelationshipsWorkspacePage.tsx
+++ b/client/src/pages/RelationshipsWorkspacePage.tsx
@@ -23,15 +23,9 @@ export default function RelationshipsWorkspacePage() {
   return (
     <LinearWorkspaceShell
       title={RELATIONSHIPS_WORKSPACE.title}
-      description="Move between buyers and suppliers with the two-way context operators actually need."
-      section="Relationships"
       activeTab={activeTab}
       tabs={RELATIONSHIPS_WORKSPACE.tabs}
       onTabChange={tab => setActiveTab(tab)}
-      meta={[
-        { label: "Buyer view", value: "Clients" },
-        { label: "Supplier view", value: "Suppliers" },
-      ]}
     >
       <LinearWorkspacePanel value="clients">
         <ClientsWorkSurface />

--- a/client/src/pages/SalesWorkspacePage.tsx
+++ b/client/src/pages/SalesWorkspacePage.tsx
@@ -307,16 +307,10 @@ export default function SalesWorkspacePage() {
     <>
       <LinearWorkspaceShell
         title={SALES_WORKSPACE.title}
-        description="Keep queue, catalogue, quote, and order work in one place with fewer context switches."
-        section="Sell"
         density="compact"
         activeTab={activeTab}
         tabs={SALES_TABS_CONFIG}
         onTabChange={tab => setActiveTab(tab)}
-        meta={[
-          { label: "Primary", value: "Orders and quotes" },
-          { label: "Sheet-native", value: "Catalogue and order draft" },
-        ]}
         commandStrip={
           activeTab === "orders" ? (
             <SheetModeToggle

--- a/docs/sessions/active/TER-1242-session.md
+++ b/docs/sessions/active/TER-1242-session.md
@@ -1,6 +1,6 @@
 # TER-1242 Agent Session
 
 - Ticket: TER-1242
-- Branch: feat/ter-1242-d-system-5-header-sidebar
+- Branch: `feat/ter-1242-d-system-5-header-sidebar`
 - Status: In Progress
 - Agent: Manus PM Agent

--- a/docs/sessions/active/TER-1242-session.md
+++ b/docs/sessions/active/TER-1242-session.md
@@ -3,4 +3,4 @@
 - Ticket: TER-1242
 - Branch: feat/ter-1242-d-system-5-header-sidebar
 - Status: In Progress
-- Agent: Factory Droid (pending dispatch)
+- Agent: Manus PM Agent

--- a/docs/sessions/active/TER-1242-session.md
+++ b/docs/sessions/active/TER-1242-session.md
@@ -1,0 +1,6 @@
+# TER-1242 Agent Session
+
+- Ticket: TER-1242
+- Branch: feat/ter-1242-d-system-5-header-sidebar
+- Status: In Progress
+- Agent: Factory Droid (pending dispatch)


### PR DESCRIPTION
## Summary

Tranche D System 5 — Header + sidebar consolidation (10 atomic fixes).

## Scope

**Workspace pages (8 files):**
- Drop `description`, `section`, `meta` props from all workspace pages
- Update `LinearWorkspaceShell` interface to remove these props

**index.css:**
- Shrink `.linear-workspace-title` to `1.125rem/600`
- Delete `.linear-workspace-eyebrow` and related classes
- Convert tabs from pill container to flat-with-underline

**Sidebar.tsx:**
- Remove nested group-card wrapping when `hasActiveItem`
- Remove green-dot bullet on active group label
- Delete sidebar footer user block (already in AppHeader dropdown)
- Reduce sidebar active state from 3 signals (border + bg + bold) to 1 (border only)

## Acceptance

- `pnpm check` passes (TypeScript clean) ✓
- All 10 atomic fixes implemented

Linear: TER-1242