### PR TITLE
feat(design): Tranche D Systems 6+7 — Primitives cleanup + single max-width (TER-1244, TER-1239)

### DIFF
--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -111,7 +111,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
           onSubmit={handleSearch}
           className="flex min-w-0 flex-1 items-center xl:max-w-4xl"
         >
-          <div className="relative flex w-full items-center rounded-2xl border border-border/70 bg-card/90 shadow-sm">
+          <div className="relative flex w-full items-center rounded-md border border-border/70 bg-card/90">
             <Search className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
@@ -133,7 +133,7 @@ export function AppHeader({ onMenuClick }: AppHeaderProps) {
           </div>
         </form>
 
-        <div className="ml-auto flex shrink-0 items-center gap-1 rounded-full border border-border/70 bg-card/90 p-1 shadow-sm">
+        <div className="ml-auto flex shrink-0 items-center gap-1 rounded-md border border-border/70 bg-card/90 p-1">
           <NotificationBell className="relative flex h-11 w-11 items-center justify-center sm:h-9 sm:w-9" />
           <Button
             variant="ghost"

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   // CHAOS-011: Added touch-manipulation for better mobile touch handling
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:cursor-not-allowed disabled:opacity-45 disabled:saturate-50 disabled:shadow-none [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive touch-manipulation",
   {
     variants: {
       variant: {

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-[var(--radius)] border py-6",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-md border py-4",
         className
       )}
       {...props}

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -56,7 +56,7 @@ function Input({
       data-slot="input"
       className={cn(
         "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,21 +2,9 @@
 @import "tw-animate-css";
 @import "./styles/print.css";
 
-@font-face {
-  font-family: "Fraunces";
-  src: url("/fonts/Fraunces-Light.woff2") format("woff2");
-  font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-}
 
-@font-face {
-  font-family: "Fraunces";
-  src: url("/fonts/Fraunces-Regular.woff2") format("woff2");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
+
+
 
 @font-face {
   font-family: "DM Mono";
@@ -92,6 +80,13 @@
 }
 
 :root {
+  /* TER-1244: Typography lockdown — 6-step scale */
+  --text-xs: 0.6875rem;   /* 11px */
+  --text-sm: 0.75rem;     /* 12px */
+  --text-base: 0.8125rem; /* 13px */
+  --text-md: 0.875rem;    /* 14px */
+  --text-lg: 1.125rem;    /* 18px */
+  --text-xl: 1.5rem;      /* 24px */
   --primary: oklch(0.53 0.13 44);
   --primary-foreground: oklch(0.98 0.003 76);
   --sidebar-primary: oklch(0.53 0.13 44);
@@ -183,7 +178,7 @@
     font-family: "Instrument Sans", system-ui, sans-serif;
   }
   .font-display {
-    font-family: "Fraunces", Georgia, serif;
+    font-family: "Instrument Sans", system-ui, sans-serif;
     font-weight: 300;
     letter-spacing: -0.015em;
   }
@@ -210,7 +205,7 @@
   }
 
   .terp-main-shell {
-    max-width: 1800px;
+    max-width: 1280px; /* TER-1239: unified with .container */
     margin: 0 auto;
     width: 100%;
     min-width: 0;

--- a/docs/sessions/active/TER-1239-session.md
+++ b/docs/sessions/active/TER-1239-session.md
@@ -1,0 +1,6 @@
+# TER-1239 Agent Session
+
+- Ticket: TER-1239
+- Branch: `feat/ter-1244-d-system-6-primitives-cleanup`
+- Status: In Progress
+- Agent: Manus PM Agent

--- a/docs/sessions/active/TER-1244-session.md
+++ b/docs/sessions/active/TER-1244-session.md
@@ -1,0 +1,6 @@
+# TER-1244 Agent Session
+
+- Ticket: TER-1244
+- Branch: `feat/ter-1244-d-system-6-primitives-cleanup`
+- Status: In Progress
+- Agent: Manus PM Agent


### PR DESCRIPTION
## Summary

Implements Tranche D Systems 6 and 7 together (sequential, single commit).

### TER-1244: System 6 — Primitives cleanup (7 fixes)

- **Fix 35**: Input — change focus ring from `ring-[3px]` to `ring-[2px]`
- **Fix 36**: Button — simplify disabled to `pointer-events-none opacity-50` only (removed `saturate-50`, `shadow-none`, `cursor-not-allowed`)
- **Fix 37**: Card — `rounded-md border py-4` (from `rounded-[var(--radius)] border py-6`)
- **Fix 38**: AppHeader search — flatten container (remove `rounded-2xl`, `shadow-sm`)
- **Fix 39**: AppHeader account chip — flatten (remove `rounded-full`, `shadow-sm`)
- **Fix 40**: Typography lockdown — add 6-step scale CSS vars (11/12/13/14/18/24px) to `:root`
- **Fix 41**: Drop Fraunces `@font-face` declarations; keep Instrument Sans only

### TER-1239: System 7 — Single content max-width (1 fix)

- **Fix 42**: Unify `.terp-main-shell` to `1280px` (matching `.container` standard width, removing the competing `1800px` value)

## Acceptance

- TypeScript: ✅ `pnpm check` passes with zero errors
- One font family (Instrument Sans)
- One max-width (1280px)
- Primitives simplified across input/button/card/header

Closes TER-1244, TER-1239