### PR TITLE
fix(clients): exclude QA/test fixtures from client picker — TER-1259

### DIFF
--- a/docs/sessions/active/TER-1259-session.md
+++ b/docs/sessions/active/TER-1259-session.md
@@ -1,0 +1,6 @@
+# TER-1259 Agent Session
+
+- **Ticket:** TER-1259
+- **Branch:** `fix/ter-1259-qa-client-filter`
+- **Status:** In Progress
+- **Agent:** Factory Droid

--- a/server/clientsDb.ts
+++ b/server/clientsDb.ts
@@ -22,6 +22,29 @@ import {
 // ============================================================================
 
 /**
+ * TER-1259: QA / test-client exclusion
+ *
+ * Excludes test fixtures from client list / picker results so they
+ * never appear in the New Order flow or any client-facing combobox.
+ * This is a filter-only change — rows remain in the database and are
+ * still reachable by direct ID lookups / admin tooling.
+ *
+ * Patterns (name + email, OR-combined at the row level is AND-excluded here):
+ * - name LIKE 'QA Write-Path%'   → legacy QA fixture prefix
+ * - name LIKE 'ZZZ%'             → manual placeholder / sort-to-bottom
+ * - name = 'wer werwe'           → specific stray fixture
+ * - email = 'qa-edited@example.com' → QA automation mailbox
+ */
+function qaTestClientExclusionConditions(): SQL<unknown>[] {
+  return [
+    sql`${clients.name} NOT LIKE 'QA Write-Path%'`,
+    sql`${clients.name} NOT LIKE 'ZZZ%'`,
+    sql`(${clients.name} IS NULL OR ${clients.name} <> 'wer werwe')`,
+    sql`(${clients.email} IS NULL OR ${clients.email} <> 'qa-edited@example.com')`,
+  ];
+}
+
+/**
  * Get all clients (with pagination and filters)
  */
 export async function getClients(options: {
@@ -106,6 +129,9 @@ export async function getClients(options: {
 
   // FIX: Always filter out soft-deleted clients unless explicitly requested
   conditions.push(sql`${clients.deletedAt} IS NULL`);
+
+  // TER-1259: Always filter out QA / test-client fixtures
+  conditions.push(...qaTestClientExclusionConditions());
 
   // Enhanced multi-field search (TERI code, name, email, phone, address)
   if (search) {
@@ -238,6 +264,9 @@ export async function getClientCount(options: {
 
   // FIX: Always filter out soft-deleted clients
   conditions.push(sql`${clients.deletedAt} IS NULL`);
+
+  // TER-1259: Always filter out QA / test-client fixtures
+  conditions.push(...qaTestClientExclusionConditions());
 
   // Enhanced multi-field search (same as getClients)
   if (search) {


### PR DESCRIPTION
## Summary

Excludes QA/test client fixtures from the client picker combobox in the New Order flow and every other `clients.list` consumer.

## Ticket

TER-1259

## Problem

Clients named `QA Write-Path*`, `ZZZ*`, or `wer werwe`, or those using the `qa-edited@example.com` mailbox, were leaking into the client picker and polluting real operator flows.

## Fix

Applied a filter-only exclusion centrally in `server/clientsDb.ts` (`getClients` and `getClientCount`):

```ts
function qaTestClientExclusionConditions(): SQL<unknown>[] {
  return [
    sql`${clients.name} NOT LIKE 'QA Write-Path%'`,
    sql`${clients.name} NOT LIKE 'ZZZ%'`,
    sql`(${clients.name} IS NULL OR ${clients.name} <> 'wer werwe')`,
    sql`(${clients.email} IS NULL OR ${clients.email} <> 'qa-edited@example.com')`,
  ];
}
```

Because `trpc.clients.list` powers all client pickers (including the New Order flow via `useClientsData`), a single-site change flows through to every combobox.

## Acceptance Criteria

- [x] Clients matching `QA Write-Path*`, `ZZZ*`, or `wer werwe` do NOT appear in client picker results
- [x] Clients with email `qa-edited@example.com` are also excluded (future-proofing)
- [x] Real clients are unaffected — only four narrow patterns are filtered
- [x] No hard deletes — filter only; rows remain in DB, direct ID lookups still work
- [x] No new database columns — name/email patterns only
- [x] No changes to client creation, client detail pages, auth, or unrelated routers

## Verification

- `pnpm check` (tsc --noEmit): ✅ zero errors
- `npx eslint server/clientsDb.ts`: ✅ clean
- `npx vitest run server/routers/clients.test.ts`: ✅ 28/28 passing