### PR TITLE
feat(orders): horizontal resize divider between order tables and controls (TER-1281)

### DIFF
--- a/client/src/components/spreadsheet-native/SalesOrderSurface.test.tsx
+++ b/client/src/components/spreadsheet-native/SalesOrderSurface.test.tsx
@@ -472,15 +472,45 @@ describe("SalesOrderSurface", () => {
     ).not.toBeInTheDocument();
 
     const panels = container.querySelectorAll("[data-panel]");
-    expect(panels).toHaveLength(2);
+    // TER-1281: Nested vertical splits — outer splits tables area vs. controls
+    // band, inner splits inventory vs. document grid.
+    expect(panels).toHaveLength(4);
+    // Outer primary panel hosts the nested inventory/document split.
     expect(
-      within(panels[1] as HTMLElement).getByTestId("document-grid")
+      within(panels[0] as HTMLElement).getByTestId("grid-inventory")
     ).toBeInTheDocument();
     expect(
-      within(panels[1] as HTMLElement).queryByTestId("invoice-bottom")
+      within(panels[0] as HTMLElement).getByTestId("document-grid")
+    ).toBeInTheDocument();
+    expect(
+      within(panels[0] as HTMLElement).queryByTestId("invoice-bottom")
+    ).not.toBeInTheDocument();
+    // Inner primary panel renders the inventory grid only.
+    expect(
+      within(panels[1] as HTMLElement).getByTestId("grid-inventory")
+    ).toBeInTheDocument();
+    expect(
+      within(panels[1] as HTMLElement).queryByTestId("document-grid")
+    ).not.toBeInTheDocument();
+    // Inner secondary panel renders the order line-items grid only.
+    expect(
+      within(panels[2] as HTMLElement).getByTestId("document-grid")
+    ).toBeInTheDocument();
+    expect(
+      within(panels[2] as HTMLElement).queryByTestId("invoice-bottom")
     ).not.toBeInTheDocument();
     expect(
-      within(panels[1] as HTMLElement).queryByTestId("order-adjustments")
+      within(panels[2] as HTMLElement).queryByTestId("order-adjustments")
+    ).not.toBeInTheDocument();
+    // Outer secondary panel hosts the fixed line-item controls band.
+    expect(
+      within(panels[3] as HTMLElement).getByTestId("invoice-bottom")
+    ).toBeInTheDocument();
+    expect(
+      within(panels[3] as HTMLElement).getByTestId("order-adjustments")
+    ).toBeInTheDocument();
+    expect(
+      within(panels[3] as HTMLElement).queryByTestId("grid-inventory")
     ).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Save Draft" })).toHaveLength(
       1

--- a/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
+++ b/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
@@ -1527,20 +1527,34 @@ export function SalesOrderSurface({
             </div>
           </div>
         ) : (
-          <div className="flex flex-1 flex-col gap-1 px-1">
+          <div className="flex min-h-0 flex-1 flex-col gap-1 px-1">
             <AdaptiveSplitLayout
-              primary={inventoryPanel}
-              secondary={documentPanel}
-              autoSaveId="sales-order-surface-layout-v2"
+              primary={
+                <AdaptiveSplitLayout
+                  primary={inventoryPanel}
+                  secondary={documentPanel}
+                  autoSaveId="sales-order-surface-layout-v2"
+                  direction="vertical"
+                  primaryDefaultSize={55}
+                  primaryMinSize={20}
+                  secondaryMinSize={20}
+                  desktopClassName="h-full"
+                  primaryPanelClassName="min-h-0"
+                  secondaryPanelClassName="min-h-0"
+                />
+              }
+              secondary={documentControlsBand}
+              autoSaveId="sales-order-surface-tables-controls-v1"
               direction="vertical"
-              primaryDefaultSize={55}
-              primaryMinSize={20}
-              secondaryMinSize={20}
+              primaryDefaultSize={72}
+              primaryMinSize={35}
+              secondaryDefaultSize={28}
+              secondaryMinSize={18}
               desktopClassName="min-h-[720px] flex-1"
-              primaryPanelClassName="min-h-0"
-              secondaryPanelClassName="min-h-0"
+              primaryPanelClassName="min-h-0 h-full"
+              secondaryPanelClassName="min-h-0 overflow-y-auto"
+              mobileClassName="space-y-1"
             />
-            {documentControlsBand}
           </div>
         )
       ) : (

--- a/docs/sessions/active/TER-1281-session.md
+++ b/docs/sessions/active/TER-1281-session.md
@@ -1,0 +1,6 @@
+# TER-1281 Agent Session
+
+- **Ticket:** TER-1281
+- **Branch:** `feat/ter-1281-horizontal-order-divider`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Adds a horizontal drag handle **between the two order tables area and the item entry / totals controls band** on the sheet-native Sales Order document view. Users can now resize how much vertical space the tables get vs. the fixed controls band. Closes TER-1281.

**Page**: `/sales?tab=orders&surface=sheet-native&ordersView=document`

## Approach

The existing TER-1266 vertical split (inventory grid vs. order line-items grid) is now wrapped in an **outer** `AdaptiveSplitLayout` with `direction="vertical"`:

- **Outer primary** → nested TER-1266 tables split (inventory + document grids)
- **Outer secondary** → line-item controls band (InvoiceBottom + OrderAdjustmentsBar + availability/consignment warnings)
- Outer handle is full-width with the same grip styling as TER-1266 for visual consistency
- New `autoSaveId="sales-order-surface-tables-controls-v1"` persists the outer split position per-user in localStorage via `react-resizable-panels`
- Inner split uses `desktopClassName="h-full"` so it fills the outer primary panel instead of forcing its own min height
- Mobile fallback (< 1024px) stacks naturally — the controls band still sits below the tables

## Acceptance Criteria

- [x] A horizontal drag handle appears between the two order tables area and the item entry controls
- [x] Dragging it resizes the table area height (top) / controls area height (bottom)
- [x] The controls (input, Clear, Mode, Discount, Unit, etc.) do NOT scroll away with the tables — they live in their own panel now
- [x] Works on `/sales?tab=orders&surface=sheet-native&ordersView=document`
- [x] Looks visually consistent with the existing vertical resize handle from TER-1266

## Verification

```
pnpm exec tsc --noEmit                                        # ✅ passes (0 errors)
pnpm exec vitest run SalesOrderSurface.test.tsx               # ✅ 24/24 tests pass
pnpm exec eslint SalesOrderSurface.tsx SalesOrderSurface.test.tsx  # ✅ no new errors
```

Pre-existing lint errors (`ConfirmDialog` / `pendingCreditOverrideReason` unused) are not introduced by this PR.

## Test Update

Updated `SalesOrderSurface.test.tsx` to assert the new 4-panel nested structure:
- Outer primary contains both grids
- Inner primary contains inventory only
- Inner secondary contains the order document grid only
- Outer secondary contains the controls band (invoice-bottom + order-adjustments)

## Out of Scope

No changes to order logic, pricing, server, or auth.