### PR TITLE
fix(routing): redirect /sales/new to sales new order tab (TER-1260)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -379,6 +379,14 @@ function Router() {
                   component={withErrorBoundary(SalesWorkspacePage)}
                 />
                 <Route
+                  path="/sales/new"
+                  component={RedirectWithTab(
+                    "/sales/new",
+                    "/sales",
+                    "create-order"
+                  )}
+                />
+                <Route
                   path="/relationships"
                   component={withErrorBoundary(RelationshipsWorkspacePage)}
                 />

--- a/docs/sessions/active/TER-1260-session.md
+++ b/docs/sessions/active/TER-1260-session.md
@@ -1,0 +1,6 @@
+# TER-1260 Agent Session
+
+- **Ticket:** TER-1260
+- **Branch:** `fix/ter-1260-sales-new-route`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
Fixes /sales/new 404 by adding a redirect route to /sales?tab=create-order

**Changes:**
- Added route for /sales/new that redirects to /sales with create-order tab
- Uses existing RedirectWithTab pattern for consistency
- Prevents 404 error when navigating to /sales/new

**Testing:**
- Verified route follows same pattern as /orders/new redirect
- No new TypeScript or routing errors introduced

Fixes TER-1260