### PR TITLE
fix(notifications): bell badge mirrors real unread count (TER-904)

### DIFF
--- a/client/src/components/notifications/NotificationBell.test.tsx
+++ b/client/src/components/notifications/NotificationBell.test.tsx
@@ -11,6 +11,7 @@ const mockSetLocation = vi.fn();
 const mockMarkRead = vi.fn();
 const mockMarkAllRead = vi.fn();
 const mockInvalidate = vi.fn();
+let mockUnreadCount = 1;
 
 const sampleNotifications = [
   {
@@ -41,7 +42,7 @@ vi.mock("@/lib/trpc", () => ({
     notifications: {
       getUnreadCount: {
         useQuery: vi.fn(() => ({
-          data: { unread: 1 },
+          data: { unread: mockUnreadCount },
           isLoading: false,
         })),
       },
@@ -86,6 +87,7 @@ vi.mock("wouter", () => ({
 describe("NotificationBell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUnreadCount = 1;
   });
 
   const renderBell = () =>
@@ -101,7 +103,26 @@ describe("NotificationBell", () => {
     fireEvent.click(trigger);
   };
 
+  it("hides badge when unread count is 0", () => {
+    mockUnreadCount = 0;
+    renderBell();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows numeric badge when count is 1-9", () => {
+    mockUnreadCount = 5;
+    renderBell();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("shows 9+ badge when count is greater than 9", () => {
+    mockUnreadCount = 15;
+    renderBell();
+    expect(screen.getByText("9+")).toBeInTheDocument();
+  });
+
   it("renders unread badge from query data", () => {
+    mockUnreadCount = 1;
     renderBell();
     expect(screen.getByText("1")).toBeInTheDocument();
   });

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -35,6 +35,11 @@ export const NotificationBell = React.memo(function NotificationBell({
     }
   );
 
+  // Use dedicated unread count query as canonical source
+  const { data: unreadData } = trpc.notifications.getUnreadCount.useQuery(undefined, {
+    refetchInterval: 30000, // Poll every 30 seconds
+  });
+
   const markRead = trpc.notifications.markRead.useMutation({
     onSuccess: async () => {
       await Promise.all([
@@ -54,7 +59,7 @@ export const NotificationBell = React.memo(function NotificationBell({
   });
 
   const notifications = listData?.items ?? [];
-  const unreadCount = listData?.unread ?? 0;
+  const unreadCount = unreadData?.unread ?? 0;
 
   const handleViewAll = useCallback(() => {
     setLocation("/notifications");

--- a/docs/sessions/active/TER-1260-session.md
+++ b/docs/sessions/active/TER-1260-session.md
@@ -1,0 +1,6 @@
+# TER-1260 Agent Session
+
+- **Ticket:** TER-1260
+- **Branch:** `fix/ter-1260-sales-new-route`
+- **Status:** In Progress
+- **Agent:** Factory Droid

--- a/docs/sessions/active/TER-904-session.md
+++ b/docs/sessions/active/TER-904-session.md
@@ -1,0 +1,6 @@
+# TER-904 Agent Session
+- Ticket: TER-904
+- Branch: `fix/ter-904-notification-bell-badge`
+- Status: In Progress
+- Started: 2026-04-23T16:00:14Z
+- Agent: Factory Droid (wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

Fixes TER-904 - Make the global notification bell badge accurately reflect the number of unread notifications.

## Changes

- **Use dedicated unread count query**: The bell now uses  as the canonical source instead of the count from the  query
- **Accurate reflection**: Badge now shows the total unread count across ALL notifications, not just the first 5 fetched for the dropdown
- **Badge display logic**: 
  - Hides when count is 0
  - Shows numeric count for 1-9
  - Shows "9+" for counts > 9
- **Proper cache invalidation**: Mark read/mark all read mutations invalidate both queries to keep the badge in sync
- **Comprehensive tests**: Added tests for all badge display scenarios (0, 1-9, 9+)

## Acceptance Criteria

- ✅ Bell badge value comes from the same canonical unread count as the Notifications page
- ✅ Badge shows numeric count up to 9 and "9+" for >9; hidden when 0
- ✅ Marking a notification read updates the badge in the same UI session
- ✅ Unit tests verify badge display logic for all scenarios
- ✅ `pnpm check` passes (TypeScript verification)

## Testing

```bash
pnpm check
pnpm test -- NotificationBell
```