### PR TITLE
fix(returns): show user name instead of raw 'User #N' in Processed By column (TER-921)

### DIFF
--- a/client/src/components/spreadsheet-native/ReturnsPilotSurface.tsx
+++ b/client/src/components/spreadsheet-native/ReturnsPilotSurface.tsx
@@ -136,6 +136,7 @@ interface ReturnQueueRow {
   returnNumber: string;
   returnReason: string;
   processedBy: number;
+  processedByName?: string | null;
   processedAt: string;
   notes: string | null;
   derivedStatus:
@@ -238,6 +239,7 @@ interface ReturnListItem {
   returnReason: string;
   status: string; // DISC-RET-002: dedicated column
   processedBy: number;
+  processedByName?: string | null;
   processedAt: string | Date;
   notes: string | null;
 }
@@ -250,6 +252,7 @@ function mapReturnsToQueueRows(items: ReturnListItem[]): ReturnQueueRow[] {
     returnNumber: `RET-${item.id}`,
     returnReason: item.returnReason,
     processedBy: item.processedBy,
+    processedByName: item.processedByName,
     processedAt:
       item.processedAt instanceof Date
         ? item.processedAt.toISOString()
@@ -789,10 +792,13 @@ export function ReturnsPilotSurface({
       {
         field: "processedBy",
         headerName: "By",
-        minWidth: 80,
-        maxWidth: 100,
+        minWidth: 120,
+        maxWidth: 180,
         cellClass: "powersheet-cell--locked",
-        valueFormatter: params => `#${String(params.value ?? "")}`,
+        valueGetter: params => {
+          const row = params.data as ReturnQueueRow;
+          return row.processedByName || `User #${row.processedBy}`;
+        },
       },
     ],
     []

--- a/docs/sessions/active/TER-921-session.md
+++ b/docs/sessions/active/TER-921-session.md
@@ -1,0 +1,6 @@
+# TER-921 Agent Session
+- Ticket: TER-921
+- Branch: `fix/ter-921-returns-processed-by-username`
+- Status: In Progress
+- Started: 2026-04-23T16:29:46Z
+- Agent: Factory Droid (isolated worktree)

--- a/server/routers/returns.ts
+++ b/server/routers/returns.ts
@@ -292,9 +292,11 @@ export const returnsRouter = router({
           status: returns.status,
           notes: returns.notes,
           processedBy: returns.processedBy,
+          processedByName: users.name,
           processedAt: returns.processedAt,
         })
-        .from(returns);
+        .from(returns)
+        .leftJoin(users, eq(returns.processedBy, users.id));
 
       if (conditions.length > 0) {
         query = query.where(and(...conditions)) as typeof query;


### PR DESCRIPTION
## Summary

Fixes TER-921 - Replace raw "User #2" placeholder with actual user display name in the Returns "Processed By" column.

## Changes

### Server ()
- Added  field to the  endpoint query
- Added  to join the users table
- This brings  endpoint in line with  endpoint which already had the join

### Client ()
- Added  to  interface
- Added  to  interface  
- Updated mapping function to include the field
- Changed column definition from displaying raw ID to displaying user name with fallback:
  - Primary: User's full name from 
  - Fallback: "User #${id}" if name is not available
- Increased column width from 80-100 to 120-180 to accommodate names

## Testing

- ReturnsPage already uses  endpoint which had the proper join, so it was unaffected
- ReturnsPilotSurface now uses the same pattern
- Both surfaces will display user names instead of IDs

## Acceptance Criteria

✅ 1. Find every place that renders "User #${id}" for Processed By and replace with user's display name  
✅ 2. Extended the API query to include user's name field (leftJoin on users table)  
✅ 3. Fallback pattern: full name → "User #${id}" if missing (no email fallback since users table has name field)  

## Related

- Linear: TER-921
- Surface: Sales / Returns
- Found in: UX/QA audit 2026-03-26