### PR TITLE
fix(notifications): bell badge mirrors real unread count (TER-904)

### DIFF
--- a/client/src/components/notifications/NotificationBell.test.tsx
+++ b/client/src/components/notifications/NotificationBell.test.tsx
@@ -7,55 +7,70 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationBell } from "./NotificationBell";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 
-const mockSetLocation = vi.fn();
-const mockMarkRead = vi.fn();
-const mockMarkAllRead = vi.fn();
-const mockInvalidate = vi.fn();
+const {
+  mockGetUnreadCountQuery,
+  mockListQuery,
+  mockMarkRead,
+  mockMarkAllRead,
+  mockInvalidate,
+  sampleNotifications,
+} = vi.hoisted(() => {
+  const sampleNotifications = [
+    {
+      id: 1,
+      title: "New Order",
+      message: "Order #123 created",
+      type: "info",
+      link: "/orders/123",
+      metadata: { entityType: "order", entityId: 123 },
+      channel: "in_app",
+      read: false,
+      createdAt: new Date(),
+    },
+    {
+      id: 2,
+      title: "Reminder",
+      message: "Appointment tomorrow",
+      type: "warning",
+      link: null,
+      channel: "in_app",
+      read: true,
+      createdAt: new Date(),
+    },
+  ];
 
-const sampleNotifications = [
-  {
-    id: 1,
-    title: "New Order",
-    message: "Order #123 created",
-    type: "info",
-    link: "/orders/123",
-    metadata: { entityType: "order", entityId: 123 },
-    channel: "in_app",
-    read: false,
-    createdAt: new Date(),
-  },
-  {
-    id: 2,
-    title: "Reminder",
-    message: "Appointment tomorrow",
-    type: "warning",
-    link: null,
-    channel: "in_app",
-    read: true,
-    createdAt: new Date(),
-  },
-];
+  return {
+    mockGetUnreadCountQuery: vi.fn(() => ({
+      data: { unread: 1 },
+      isLoading: false,
+    })),
+    mockListQuery: vi.fn(() => ({
+      data: {
+        items: sampleNotifications,
+        total: sampleNotifications.length,
+        unread: 1,
+        pagination: { limit: 5, offset: 0 },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    })),
+    mockMarkRead: vi.fn(),
+    mockMarkAllRead: vi.fn(),
+    mockInvalidate: vi.fn(),
+    sampleNotifications,
+  };
+});
+
+const mockSetLocation = vi.fn();
 
 vi.mock("@/lib/trpc", () => ({
   trpc: {
     notifications: {
       getUnreadCount: {
-        useQuery: vi.fn(() => ({
-          data: { unread: 1 },
-          isLoading: false,
-        })),
+        useQuery: mockGetUnreadCountQuery,
       },
       list: {
-        useQuery: vi.fn(() => ({
-          data: {
-            items: sampleNotifications,
-            total: sampleNotifications.length,
-            unread: 1,
-            pagination: { limit: 5, offset: 0 },
-          },
-          isLoading: false,
-          refetch: vi.fn(),
-        })),
+        useQuery: mockListQuery,
       },
       markRead: {
         useMutation: vi.fn(() => ({
@@ -86,6 +101,23 @@ vi.mock("wouter", () => ({
 describe("NotificationBell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    
+    // Reset to default mock values
+    mockGetUnreadCountQuery.mockReturnValue({
+      data: { unread: 1 },
+      isLoading: false,
+    });
+    
+    mockListQuery.mockReturnValue({
+      data: {
+        items: sampleNotifications,
+        total: sampleNotifications.length,
+        unread: 1,
+        pagination: { limit: 5, offset: 0 },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
   });
 
   const renderBell = () =>
@@ -101,9 +133,42 @@ describe("NotificationBell", () => {
     fireEvent.click(trigger);
   };
 
-  it("renders unread badge from query data", () => {
+  it("renders unread badge from getUnreadCount query", () => {
     renderBell();
     expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("hides badge when unread count is 0", () => {
+    mockGetUnreadCountQuery.mockReturnValue({
+      data: { unread: 0 },
+      isLoading: false,
+    });
+
+    renderBell();
+    
+    const bell = screen.getByRole("button", { name: /notifications/i });
+    expect(bell).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows numeric count when count is 5", () => {
+    mockGetUnreadCountQuery.mockReturnValue({
+      data: { unread: 5 },
+      isLoading: false,
+    });
+
+    renderBell();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("shows '9+' when count is 15", () => {
+    mockGetUnreadCountQuery.mockReturnValue({
+      data: { unread: 15 },
+      isLoading: false,
+    });
+
+    renderBell();
+    expect(screen.getByText("9+")).toBeInTheDocument();
   });
 
   it("opens dropdown and lists notifications", async () => {

--- a/client/src/components/notifications/NotificationBell.tsx
+++ b/client/src/components/notifications/NotificationBell.tsx
@@ -35,6 +35,10 @@ export const NotificationBell = React.memo(function NotificationBell({
     }
   );
 
+  const { data: unreadData } = trpc.notifications.getUnreadCount.useQuery(undefined, {
+    refetchInterval: 30000, // Poll every 30 seconds
+  });
+
   const markRead = trpc.notifications.markRead.useMutation({
     onSuccess: async () => {
       await Promise.all([
@@ -54,7 +58,7 @@ export const NotificationBell = React.memo(function NotificationBell({
   });
 
   const notifications = listData?.items ?? [];
-  const unreadCount = listData?.unread ?? 0;
+  const unreadCount = unreadData?.unread ?? 0;
 
   const handleViewAll = useCallback(() => {
     setLocation("/notifications");

--- a/docs/sessions/active/TER-904-session.md
+++ b/docs/sessions/active/TER-904-session.md
@@ -1,0 +1,6 @@
+# TER-904 Agent Session
+- Ticket: TER-904
+- Branch: `fix/ter-904-notification-bell-badge`
+- Status: In Progress
+- Started: 2026-04-23T16:30:07Z
+- Agent: Factory Droid (isolated worktree)


### PR DESCRIPTION
## Summary
Fixes the notification bell badge to accurately reflect the actual number of unread notifications by using the dedicated `getUnreadCount` query as the single source of truth.

## Problem
The bell badge was showing a stale/hardcoded value ("9+") while the inbox showed only 1 unread notification. The component was using the `unread` field from the paginated `list` query instead of the dedicated `getUnreadCount` endpoint.

## Solution
- Added a dedicated `getUnreadCount` query with the same 30-second polling interval
- Changed badge to use `unreadData?.unread` instead of `listData?.unread`
- Badge now shares the same canonical unread count as the Notifications page
- Query invalidation on read ensures the badge updates immediately when notifications are marked as read

## Testing
- ✅ Added test: badge is hidden when count = 0
- ✅ Added test: shows numeric count ("5") when count = 5
- ✅ Added test: shows "9+" when count = 15
- ✅ All 7 tests passing
- ✅ Badge updates when marking notifications as read (via query invalidation)

## Verification Commands
```bash
pnpm test -- NotificationBell  # All tests pass
```

Closes TER-904