### PR TITLE
fix(demand-supply): render supplier name (or fallback) on supply cards (TER-973)

### DIFF
--- a/client/src/pages/MatchmakingServicePage.test.tsx
+++ b/client/src/pages/MatchmakingServicePage.test.tsx
@@ -269,6 +269,27 @@ describe("MatchmakingServicePage - Button Navigation", () => {
     expect(screen.getAllByText(/5 lbs available/i).length).toBeGreaterThan(0);
   });
 
+  it("shows real supplier name when vendorName is provided (TER-973)", () => {
+    // Update mock to include a real vendor name
+    mockSupplyItems = [
+      {
+        id: 88,
+        vendorName: "Green Valley Farms",
+        category: "Flower",
+        grade: "A+",
+        productName: "Wedding Cake",
+        buyerCount: 2,
+        quantityAvailable: "10",
+        unitPrice: "1500",
+      },
+    ];
+
+    render(<MatchmakingServicePage />);
+
+    expect(screen.getByText("Supplier: Green Valley Farms")).toBeInTheDocument();
+    expect(screen.queryByText("Supplier: Unknown supplier")).not.toBeInTheDocument();
+  });
+
   it("disables Reserve when no active buyer needs exist", () => {
     render(<MatchmakingServicePage />);
 

--- a/docs/sessions/active/TER-973-session.md
+++ b/docs/sessions/active/TER-973-session.md
@@ -1,0 +1,6 @@
+# TER-973 Agent Session
+- Ticket: TER-973
+- Branch: `fix/ter-973-supply-card-blank-supplier`
+- Status: In Progress
+- Started: 2026-04-23T16:30:17Z
+- Agent: Factory Droid (isolated worktree)

--- a/server/vendorSupplyDb.ts
+++ b/server/vendorSupplyDb.ts
@@ -1,6 +1,6 @@
 import { eq, and, desc, sql, isNull } from "drizzle-orm";
 import { getDb } from "./db";
-import { vendorSupply } from "../drizzle/schema";
+import { vendorSupply, vendors } from "../drizzle/schema";
 import { logger } from "./_core/logger";
 import type { VendorSupply, InsertVendorSupply } from "../drizzle/schema";
 
@@ -246,17 +246,60 @@ export async function deleteVendorSupply(id: number): Promise<boolean> {
 /**
  * Get vendor supply with match indicators
  * @param filters - Optional filters
- * @returns Array of vendor supply items with buyer counts
+ * @returns Array of vendor supply items with buyer counts and vendor names
  */
 export async function getVendorSupplyWithMatches(filters?: {
   status?: "AVAILABLE" | "RESERVED" | "PURCHASED" | "EXPIRED";
   vendorId?: number;
-}): Promise<Array<VendorSupply & { buyerCount: number }>> {
+}): Promise<Array<VendorSupply & { buyerCount: number; vendorName?: string }>> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
 
   try {
-    const supplies = await getVendorSupply(filters);
+    // TER-973: Join with vendors table to get supplier names
+    // PARTY-004: Exclude soft-deleted records from both tables
+    const conditions = [isNull(vendorSupply.deletedAt)];
+    if (filters?.status) {
+      conditions.push(eq(vendorSupply.status, filters.status));
+    }
+    if (filters?.vendorId) {
+      conditions.push(eq(vendorSupply.vendorId, filters.vendorId));
+    }
+
+    const supplies = await db
+      .select({
+        // Spread all vendorSupply fields
+        id: vendorSupply.id,
+        vendorId: vendorSupply.vendorId,
+        strain: vendorSupply.strain,
+        productName: vendorSupply.productName,
+        strainType: vendorSupply.strainType,
+        category: vendorSupply.category,
+        subcategory: vendorSupply.subcategory,
+        grade: vendorSupply.grade,
+        quantityAvailable: vendorSupply.quantityAvailable,
+        unitPrice: vendorSupply.unitPrice,
+        status: vendorSupply.status,
+        availableUntil: vendorSupply.availableUntil,
+        reservedAt: vendorSupply.reservedAt,
+        purchasedAt: vendorSupply.purchasedAt,
+        notes: vendorSupply.notes,
+        internalNotes: vendorSupply.internalNotes,
+        createdBy: vendorSupply.createdBy,
+        createdByClientId: vendorSupply.createdByClientId,
+        createdAt: vendorSupply.createdAt,
+        updatedAt: vendorSupply.updatedAt,
+        deletedAt: vendorSupply.deletedAt,
+        // Join vendor name
+        vendorName: vendors.name,
+      })
+      .from(vendorSupply)
+      .leftJoin(
+        vendors,
+        and(eq(vendorSupply.vendorId, vendors.id), isNull(vendors.deletedAt))
+      )
+      .where(and(...conditions))
+      .orderBy(desc(vendorSupply.createdAt));
 
     // TER-1198: the previous implementation called
     // `findBuyersForVendorSupply(supply.id)` per row, which issued several

--- a/server/vendorSupplyDb.ts
+++ b/server/vendorSupplyDb.ts
@@ -251,7 +251,7 @@ export async function deleteVendorSupply(id: number): Promise<boolean> {
 export async function getVendorSupplyWithMatches(filters?: {
   status?: "AVAILABLE" | "RESERVED" | "PURCHASED" | "EXPIRED";
   vendorId?: number;
-}): Promise<Array<VendorSupply & { buyerCount: number; vendorName?: string }>> {
+}): Promise<Array<VendorSupply & { buyerCount: number; vendorName: string | null }>> {
   const db = await getDb();
   if (!db) throw new Error("Database not available");
 


### PR DESCRIPTION
## Summary
Fixes TER-973: Supply cards on the Demand & Supply matchmaking page now display supplier names instead of blank values.

## Changes
- Updated `vendorSupplyDb.getVendorSupplyWithMatches` to join with the `vendors` table and include supplier names in the query result
- Added `vendorName` field to the return type
- UI already had fallback logic (`|| "Unknown supplier"`) for missing names
- Added test case verifying real supplier names are displayed
- Existing test already verified the fallback "Unknown supplier" text

## Testing
- Unit tests pass: `npx vitest run MatchmakingServicePage` (9/9 tests passing)
- Test coverage includes:
  - Supply card with real vendor name displays correctly
  - Supply card with missing vendor name shows "Unknown supplier" fallback

## Acceptance Criteria
- [x] Supply cards render a non-empty supplier label for every row that has a linked seller
- [x] Rows where the supplier link is genuinely missing render "Unknown supplier" rather than an empty string
- [x] Server query updated to include supplier name (joined from vendors table)
- [x] Tests verify both real supplier name and missing supplier fallback
- [x] Tests pass