### PR TITLE
fix(sales-sheet): preserve basePrice=0 on sheet item load — TER-1011

### DIFF
--- a/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
+++ b/client/src/components/spreadsheet-native/SalesOrderSurface.tsx
@@ -152,7 +152,9 @@ const getInventoryCogsPerUnit = (item: PricedInventoryItem) =>
   item.effectiveCogs ?? item.basePrice ?? item.unitCogs ?? 0;
 
 const getInventoryRetailPrice = (item: PricedInventoryItem) =>
-  roundToCents(item.retailPrice || item.basePrice || 0);
+  // TER-1011: preserve explicit 0 (intentionally free). Use `??` instead of
+  // `||` so a saved retailPrice of 0 isn't replaced by the catalogue default.
+  roundToCents(item.retailPrice ?? item.basePrice ?? 0);
 
 const buildDefaultInventoryRowControls = (
   row: InventoryBrowserRow

--- a/client/src/hooks/useOrderDraft.ts
+++ b/client/src/hooks/useOrderDraft.ts
@@ -715,7 +715,10 @@ export function useOrderDraft({
       return validItems.map(item => {
         const cogsPerUnit =
           item.effectiveCogs ?? item.basePrice ?? item.unitCogs ?? 0;
-        const retailPrice = item.retailPrice || item.basePrice || 0;
+        // TER-1011: preserve explicit 0 (intentionally free). Use `??` instead
+        // of `||` so a saved retailPrice of 0 isn't replaced by the catalogue
+        // default (basePrice).
+        const retailPrice = item.retailPrice ?? item.basePrice ?? 0;
         const availableUnits = Math.max(1, Math.floor(item.quantity ?? 1));
         const quantity =
           normalizePositiveIntegerWithin(

--- a/client/src/pages/OrderCreatorPage.tsx
+++ b/client/src/pages/OrderCreatorPage.tsx
@@ -1509,7 +1509,10 @@ export default function OrderCreatorPageV2({
         // Calculate margin percent from basePrice and retailPrice
         const cogsPerUnit =
           item.effectiveCogs ?? item.basePrice ?? item.unitCogs ?? 0;
-        const retailPrice = item.retailPrice || item.basePrice || 0;
+        // TER-1011: preserve explicit 0 (intentionally free). Use `??` instead
+        // of `||` so a saved retailPrice of 0 isn't replaced by the catalogue
+        // default (basePrice).
+        const retailPrice = item.retailPrice ?? item.basePrice ?? 0;
 
         const availableUnits = Math.max(1, Math.floor(item.quantity ?? 1));
         const quantity =

--- a/docs/sessions/active/TER-1011-session.md
+++ b/docs/sessions/active/TER-1011-session.md
@@ -1,0 +1,7 @@
+# TER-1011 Agent Session
+
+- **Ticket:** TER-1011
+- **Branch:** `fix/ter-1011-baseprice-zero-preserve`
+- **Status:** In Progress
+- **Started:** 2026-04-23T18:07:20Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

Fixes **TER-1011**: loading a saved Sales Catalogue sheet item with an intentionally-free price (`retailPrice = 0`) silently replaces it with the catalogue default (`basePrice`), losing the operator's explicit $0.

## Root cause

Three duplicated inventory→line-item conversion sites used a truthy fallback chain:

```ts
const retailPrice = item.retailPrice || item.basePrice || 0;
```

Because `0` is falsy in JavaScript, a saved `retailPrice = 0` is treated the same as `undefined` and falls back to `item.basePrice` (the catalogue default price that came back from the inventory fetch).

## Fix

Swap `||` for `??` so the fallback only triggers on `null`/`undefined` — an explicit `0` is preserved.

```ts
const retailPrice = item.retailPrice ?? item.basePrice ?? 0;
```

Applied to all three call sites:

- `client/src/components/spreadsheet-native/SalesOrderSurface.tsx` (`getInventoryRetailPrice`)
- `client/src/hooks/useOrderDraft.ts` (`convertInventoryToLineItems`)
- `client/src/pages/OrderCreatorPage.tsx` (`convertInventoryToLineItems`)

## Acceptance criteria

- [x] Saved sheet item with `retailPrice`/`basePrice` = 0 loads back with 0, not the catalogue default.
- [x] Saved sheet item with no explicit price (`null`/`undefined`) still falls back to the catalogue default.
- [x] `pnpm check` passes (zero TS errors).
- [x] `pnpm lint` — no new ESLint errors introduced by this change (pre-existing repo lint debt remains).

## Tier

STRICT — UI/business-logic change to the order pricing conversion path.