### PR TITLE
fix(sales-sheet): loud error handling for share/open/print actions — TER-1012

### DIFF
--- a/client/src/components/spreadsheet-native/SalesCatalogueSurface.test.tsx
+++ b/client/src/components/spreadsheet-native/SalesCatalogueSurface.test.tsx
@@ -609,6 +609,72 @@ describe("SalesCatalogueSurface", () => {
     expect(draftState.resetDraft).toHaveBeenCalled();
   });
 
+  it("shows a loud error when pop-ups are blocked on Print", async () => {
+    const windowOpen = vi.spyOn(window, "open").mockReturnValue(null);
+
+    render(<SalesCatalogueSurface />);
+    fireEvent.click(screen.getByText("Select Client 1"));
+    fireEvent.click(screen.getByTestId("grid-Inventory"));
+    fireEvent.click(screen.getByRole("button", { name: "Add Row" }));
+    fireEvent.click(screen.getByRole("button", { name: /Print/i }));
+
+    expect(windowOpen).toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "Allow pop-ups to print the catalogue"
+    );
+    expect(toastSuccess).not.toHaveBeenCalledWith("Print dialog opened");
+
+    windowOpen.mockRestore();
+  });
+
+  it("shows a success toast when Print opens successfully", async () => {
+    const writeMock = vi.fn();
+    const closeMock = vi.fn();
+    const mockWindow = {
+      document: { write: writeMock, close: closeMock },
+      close: vi.fn(),
+    } as unknown as ReturnType<typeof window.open>;
+    const windowOpen = vi.spyOn(window, "open").mockReturnValue(mockWindow);
+
+    render(<SalesCatalogueSurface />);
+    fireEvent.click(screen.getByText("Select Client 1"));
+    fireEvent.click(screen.getByTestId("grid-Inventory"));
+    fireEvent.click(screen.getByRole("button", { name: "Add Row" }));
+    fireEvent.click(screen.getByRole("button", { name: /Print/i }));
+
+    expect(writeMock).toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalledWith("Print dialog opened");
+
+    windowOpen.mockRestore();
+  });
+
+  it("shows a loud error when Print fails to write the document", async () => {
+    const mockWindow = {
+      document: {
+        write: vi.fn(() => {
+          throw new Error("write denied");
+        }),
+        close: vi.fn(),
+      },
+      close: vi.fn(),
+    } as unknown as ReturnType<typeof window.open>;
+    const windowOpen = vi.spyOn(window, "open").mockReturnValue(mockWindow);
+
+    render(<SalesCatalogueSurface />);
+    fireEvent.click(screen.getByText("Select Client 1"));
+    fireEvent.click(screen.getByTestId("grid-Inventory"));
+    fireEvent.click(screen.getByRole("button", { name: "Add Row" }));
+    fireEvent.click(screen.getByRole("button", { name: /Print/i }));
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Failed to prepare print dialog: write denied"
+    );
+    expect(toastSuccess).not.toHaveBeenCalledWith("Print dialog opened");
+
+    windowOpen.mockRestore();
+  });
+
   it("wires draft deletion from the dialog to the hook", () => {
     draftState.drafts = [
       {

--- a/client/src/hooks/useCatalogueDraft.test.ts
+++ b/client/src/hooks/useCatalogueDraft.test.ts
@@ -301,4 +301,148 @@ describe("useCatalogueDraft", () => {
     );
     expect(toastSuccess).toHaveBeenCalledWith("Share link copied to clipboard");
   });
+
+  it("surfaces a loud error when share is requested without a finalized sheet", async () => {
+    const { result } = renderHook(() =>
+      useCatalogueDraft({
+        clientId: 1,
+        items: [{ id: 1 }] as never[],
+      })
+    );
+
+    let shareUrl: string | null = "initial" as string | null;
+    await act(async () => {
+      shareUrl = await result.current.generateShareLink();
+    });
+
+    expect(shareUrl).toBeNull();
+    expect(toastError).toHaveBeenCalledWith(
+      "Save the catalogue before generating a share link"
+    );
+    expect(shareLinkMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a loud error when share is requested with unsaved changes", async () => {
+    const item = {
+      id: 1,
+      name: "Blue Dream",
+      basePrice: 10,
+      retailPrice: 20,
+      quantity: 2,
+      priceMarkup: 0,
+      appliedRules: [],
+    } as never;
+
+    const { result, rerender } = renderHook(
+      ({ items }) => useCatalogueDraft({ clientId: 1, items }),
+      { initialProps: { items: [item] as never[] } }
+    );
+
+    await act(async () => {
+      await result.current.saveSheet();
+    });
+
+    await waitFor(() => {
+      expect(result.current.lastSavedSheetId).toBe(202);
+    });
+
+    // Dirty the catalogue with new items
+    rerender({
+      items: [item, { ...item, id: 2 }] as never[],
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+
+    shareLinkMutateAsync.mockClear();
+    toastError.mockClear();
+
+    let shareUrl: string | null = "initial" as string | null;
+    await act(async () => {
+      shareUrl = await result.current.generateShareLink();
+    });
+
+    expect(shareUrl).toBeNull();
+    expect(toastError).toHaveBeenCalledWith(
+      "Save your latest changes before generating a share link"
+    );
+    expect(shareLinkMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a loud error when the share-link server call fails", async () => {
+    const item = {
+      id: 1,
+      name: "Blue Dream",
+      basePrice: 10,
+      retailPrice: 20,
+      quantity: 2,
+      priceMarkup: 0,
+      appliedRules: [],
+    } as never;
+
+    const { result } = renderHook(
+      ({ items }) => useCatalogueDraft({ clientId: 1, items }),
+      { initialProps: { items: [item] as never[] } }
+    );
+
+    await act(async () => {
+      await result.current.saveSheet();
+    });
+
+    await waitFor(() => {
+      expect(result.current.lastSavedSheetId).toBe(202);
+    });
+
+    shareLinkMutateAsync.mockRejectedValueOnce(
+      new Error("network unavailable")
+    );
+    toastError.mockClear();
+
+    let shareUrl: string | null = "initial" as string | null;
+    await act(async () => {
+      shareUrl = await result.current.generateShareLink();
+    });
+
+    expect(shareUrl).toBeNull();
+    expect(toastError).toHaveBeenCalledWith(
+      "Failed to generate share link: network unavailable"
+    );
+  });
+
+  it("surfaces a loud error when the share-link response has no URL", async () => {
+    const item = {
+      id: 1,
+      name: "Blue Dream",
+      basePrice: 10,
+      retailPrice: 20,
+      quantity: 2,
+      priceMarkup: 0,
+      appliedRules: [],
+    } as never;
+
+    const { result } = renderHook(
+      ({ items }) => useCatalogueDraft({ clientId: 1, items }),
+      { initialProps: { items: [item] as never[] } }
+    );
+
+    await act(async () => {
+      await result.current.saveSheet();
+    });
+
+    await waitFor(() => {
+      expect(result.current.lastSavedSheetId).toBe(202);
+    });
+
+    shareLinkMutateAsync.mockResolvedValueOnce({});
+    toastError.mockClear();
+
+    let shareUrl: string | null = "initial" as string | null;
+    await act(async () => {
+      shareUrl = await result.current.generateShareLink();
+    });
+
+    expect(shareUrl).toBeNull();
+    expect(toastError).toHaveBeenCalledWith(
+      "Share link could not be generated — the server returned no URL"
+    );
+  });
 });

--- a/client/src/hooks/useCatalogueDraft.ts
+++ b/client/src/hooks/useCatalogueDraft.ts
@@ -481,26 +481,49 @@ export function useCatalogueDraft({
   const generateShareLink = useCallback(async () => {
     // Share link requires a finalized sheet ID, not a draft ID.
     // salesSheets.generateShareLink operates on the salesSheetHistory table.
-    if (!lastSavedSheetId || hasUnsavedChanges) return null;
+    if (!lastSavedSheetId) {
+      toast.error("Save the catalogue before generating a share link");
+      return null;
+    }
+    if (hasUnsavedChanges) {
+      toast.error("Save your latest changes before generating a share link");
+      return null;
+    }
     try {
       const result = await shareLinkMutateAsyncRef.current({
         sheetId: lastSavedSheetId,
         expiresInDays: 7,
       });
-      if (result?.shareUrl) {
-        const absoluteShareUrl = toAbsoluteShareUrl(result.shareUrl);
-        setLastShareUrl(absoluteShareUrl);
-        if (navigator.clipboard?.writeText) {
+      if (!result?.shareUrl) {
+        toast.error(
+          "Share link could not be generated — the server returned no URL"
+        );
+        return null;
+      }
+      const absoluteShareUrl = toAbsoluteShareUrl(result.shareUrl);
+      setLastShareUrl(absoluteShareUrl);
+      if (navigator.clipboard?.writeText) {
+        try {
           await navigator.clipboard.writeText(absoluteShareUrl);
           toast.success("Share link copied to clipboard");
-        } else {
-          toast.success("Share link ready");
+        } catch (clipboardError) {
+          console.error(
+            "Failed to copy share link to clipboard",
+            clipboardError
+          );
+          toast.error(
+            "Share link ready, but copying to clipboard failed — use 'Open Shared View' instead"
+          );
         }
-        return absoluteShareUrl;
+      } else {
+        toast.success("Share link ready");
       }
-      return null;
-    } catch {
-      toast.error("Failed to generate share link");
+      return absoluteShareUrl;
+    } catch (error) {
+      console.error("Failed to generate share link", error);
+      const message =
+        error instanceof Error ? error.message : "Unknown error";
+      toast.error("Failed to generate share link: " + message);
       return null;
     }
   }, [lastSavedSheetId, hasUnsavedChanges]);

--- a/docs/sessions/active/TER-1012-session.md
+++ b/docs/sessions/active/TER-1012-session.md
@@ -1,0 +1,7 @@
+# TER-1012 Agent Session
+
+- **Ticket:** TER-1012
+- **Branch:** `fix/ter-1012-catalogue-action-errors`
+- **Status:** In Progress
+- **Started:** 2026-04-23T18:07:22Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

Fixes **TER-1012** — Sales Catalogue Share / Open / Print actions fail loudly instead of silently or falsely succeeding.

Previously these three actions on the Sales Catalogue could appear to succeed (no error) while actually failing, or simply do nothing with no feedback to the user.

## Changes

### `client/src/hooks/useCatalogueDraft.ts` — `generateShareLink`
- **Before:** bare `} catch { }` swallowed the server error message; guard (`!lastSavedSheetId || hasUnsavedChanges`) returned `null` silently; a missing `result.shareUrl` returned `null` silently; clipboard failure bubbled to the generic outer catch and reported "Failed to generate share link" even though the link *was* generated.
- **After:** every failure path shows an actionable `toast.error` with the underlying message. Clipboard failure is caught separately so users still know the link is ready. Unknown errors include the thrown message.

### `client/src/components/spreadsheet-native/SalesCatalogueSurface.tsx`
- **Print (`handlePrintCatalogue`)**: wraps `printWindow.document.write` in a `try/catch`; shows a `toast.error` with the error message on failure and closes the dead window; shows `toast.success("Print dialog opened")` on success.
- **PDF export (`handleExportPdf`)**: no longer falsely toasts success when the print window failed to open. Only toasts "Print dialog opened. Use 'Save as PDF' to export." when the underlying print window actually opened.
- **Open Shared View (`handleOpenSharePreview`)**: detects pop-up blocking (`window.open` returns `null`) and shows `toast.error("Allow pop-ups to open the shared view")`; toasts success on a successful new-tab open; surfaces its own toast when a cached but unusable share URL needs regeneration.

### Tests
- `useCatalogueDraft.test.ts`: four new cases cover the no-finalized-sheet guard, unsaved-changes guard, server error (mutateAsync throws), and missing-shareUrl response — all confirm a loud `toast.error`.
- `SalesCatalogueSurface.test.tsx`: three new cases cover pop-up-blocked Print, successful Print, and document.write failure.

## Acceptance Criteria

- [x] Share/Open/Print each show a user-visible error toast if the action fails
- [x] Success path shows a confirmation
- [x] No silent catch blocks — all caught errors are either surfaced or rethrown
- [x] Error messages are actionable (server message / 'Allow pop-ups' / 'Save first')
- [x] `pnpm check` passes
- [x] `pnpm lint` is clean for all files touched in this PR (pre-existing repo-wide lint errors are unrelated)

## Test evidence

```
$ pnpm check
> tsc --noEmit  ✓ (0 errors)

$ npx eslint client/src/components/spreadsheet-native/SalesCatalogueSurface.tsx \
              client/src/hooks/useCatalogueDraft.ts \
              client/src/components/spreadsheet-native/SalesCatalogueSurface.test.tsx \
              client/src/hooks/useCatalogueDraft.test.ts
  ✓ (0 errors)

$ npx vitest run client/src/hooks/useCatalogueDraft.test.ts \
                 client/src/components/spreadsheet-native/SalesCatalogueSurface.test.tsx
  Test Files  2 passed (2)
       Tests  32 passed | 3 skipped (35)
```

Tier: **STRICT**