### PR TITLE
feat(ux-v2): PowersheetGrid numeric defaults — right-align tabular-nums currency formatter [TER-1285]

### DIFF
--- a/client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx
+++ b/client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx
@@ -26,17 +26,131 @@ import type {
   RowClickedEvent,
   SendToClipboardParams,
   SelectionChangedEvent,
+  ValueFormatterParams,
 } from "ag-grid-community";
 import { themeAlpine } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingState } from "@/components/ui/loading-state";
+import { useOptionalFeatureFlag } from "@/contexts/FeatureFlagContext";
+import { FEATURE_FLAGS } from "@/lib/constants/featureFlags";
 import { cn } from "@/lib/utils";
 import type {
   PowersheetSelectionSet,
   PowersheetSelectionSummary,
 } from "@/lib/powersheet/contracts";
+
+/**
+ * Recognized numeric cell data types for which `SpreadsheetPilotGrid`
+ * auto-applies right-alignment, tabular-nums styling, and locale-aware
+ * value formatters when the {@link FEATURE_FLAGS.uxV2Grid} flag is
+ * enabled.
+ */
+const NUMERIC_CELL_DATA_TYPES = ["currency", "number", "percent"] as const;
+type NumericCellDataType = (typeof NUMERIC_CELL_DATA_TYPES)[number];
+
+function isNumericCellDataType(
+  value: ColDef["cellDataType"]
+): value is NumericCellDataType {
+  return (
+    typeof value === "string" &&
+    (NUMERIC_CELL_DATA_TYPES as readonly string[]).includes(value)
+  );
+}
+
+const USD_CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const PERCENT_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+function coerceToFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function formatCurrencyValue(params: ValueFormatterParams): string {
+  const num = coerceToFiniteNumber(params.value);
+  if (num === null) {
+    return params.value === null || params.value === undefined
+      ? ""
+      : String(params.value);
+  }
+  return USD_CURRENCY_FORMATTER.format(num);
+}
+
+function formatPercentValue(params: ValueFormatterParams): string {
+  const num = coerceToFiniteNumber(params.value);
+  if (num === null) {
+    return params.value === null || params.value === undefined
+      ? ""
+      : String(params.value);
+  }
+  return `${PERCENT_NUMBER_FORMATTER.format(num)}%`;
+}
+
+const NUMERIC_CELL_CLASS = "text-right font-mono tabular-nums";
+const NUMERIC_HEADER_CLASS = "text-right";
+
+/**
+ * Apply numeric column defaults (right-alignment, tabular-nums styling,
+ * and locale-aware value formatters) to any ColDef whose `cellDataType`
+ * is one of {@link NUMERIC_CELL_DATA_TYPES}.
+ *
+ * Existing explicit `cellClass` / `valueFormatter` on a ColDef are
+ * preserved — defaults are only applied where those fields are
+ * `undefined` on the incoming column definition.
+ */
+function applyNumericColumnDefaults<Row extends object>(
+  columnDefs: ColDef<Row>[]
+): ColDef<Row>[] {
+  let changed = false;
+  const nextDefs = columnDefs.map(colDef => {
+    if (!isNumericCellDataType(colDef.cellDataType)) {
+      return colDef;
+    }
+
+    const dataType: NumericCellDataType = colDef.cellDataType;
+    const next: ColDef<Row> = { ...colDef };
+    let mutated = false;
+
+    if (next.cellClass === undefined) {
+      next.cellClass = NUMERIC_CELL_CLASS;
+      mutated = true;
+    }
+    if (next.headerClass === undefined) {
+      next.headerClass = NUMERIC_HEADER_CLASS;
+      mutated = true;
+    }
+    if (next.valueFormatter === undefined) {
+      if (dataType === "currency") {
+        next.valueFormatter = formatCurrencyValue;
+        mutated = true;
+      } else if (dataType === "percent") {
+        next.valueFormatter = formatPercentValue;
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      changed = true;
+      return next;
+    }
+    return colDef;
+  });
+
+  return changed ? nextDefs : columnDefs;
+}
 
 export type SpreadsheetPilotGridSelectionMode = "single-row" | "cell-range";
 
@@ -398,6 +512,17 @@ export function SpreadsheetPilotGrid<Row extends object>({
     [allowColumnReorder, suppressKeyboardEvent]
   );
 
+  const numericDefaultsEnabled = useOptionalFeatureFlag(
+    FEATURE_FLAGS.uxV2Grid
+  );
+
+  const effectiveColumnDefs = useMemo<ColDef<Row>[]>(() => {
+    if (!numericDefaultsEnabled) {
+      return columnDefs;
+    }
+    return applyNumericColumnDefaults(columnDefs);
+  }, [columnDefs, numericDefaultsEnabled]);
+
   const emitSelectedRowChange = useCallback(
     (row: Row | null) => {
       const nextId = row ? getRowId(row) : null;
@@ -576,7 +701,7 @@ export function SpreadsheetPilotGrid<Row extends object>({
             <AgGridReact<Row>
               theme={themeAlpine}
               rowData={rows}
-              columnDefs={columnDefs}
+              columnDefs={effectiveColumnDefs}
               defaultColDef={defaultColDef}
               rowHeight={rowHeightProp ?? 28}
               headerHeight={32}

--- a/client/src/contexts/FeatureFlagContext.tsx
+++ b/client/src/contexts/FeatureFlagContext.tsx
@@ -133,3 +133,21 @@ export function useModuleEnabled(module: string): {
 } {
   return useFeatureFlag(module);
 }
+
+/**
+ * Safely check if a feature flag is enabled without requiring
+ * {@link FeatureFlagProvider} to be present in the React tree.
+ *
+ * Unlike {@link useFeatureFlag}, this hook returns `false` (disabled) when
+ * there is no {@link FeatureFlagContext} above the caller. This is useful
+ * for low-level/shared components that can be rendered both inside the
+ * authenticated app shell (where the provider is mounted) and inside
+ * isolated unit-test harnesses (where it typically is not).
+ *
+ * @param key - The feature flag key to check
+ * @returns `true` when the flag is enabled, `false` otherwise
+ */
+export function useOptionalFeatureFlag(key: string): boolean {
+  const context = useContext(FeatureFlagContext);
+  return context?.flags[key] ?? false;
+}

--- a/client/src/lib/constants/featureFlags.ts
+++ b/client/src/lib/constants/featureFlags.ts
@@ -5,4 +5,17 @@ export const FEATURE_FLAGS = {
    * (OperationalStateSurface) for data-bearing components.
    */
   uxV2States: "ux.v2.states",
+  /**
+   * UX v2 grid numeric defaults.
+   *
+   * When enabled, `SpreadsheetPilotGrid` auto-applies right-alignment,
+   * tabular-nums styling, and locale-aware value formatters to column
+   * definitions whose `cellDataType` is "currency", "number", or "percent".
+   * Explicit `cellClass` / `valueFormatter` overrides on a ColDef are
+   * preserved (no clobbering).
+   *
+   * See: docs/ux-review/02-Implementation_Strategy.md §4.2
+   * Linear: TER-1285
+   */
+  uxV2Grid: "ux.v2.grid",
 } as const;

--- a/docs/sessions/active/TER-1285-session.md
+++ b/docs/sessions/active/TER-1285-session.md
@@ -1,0 +1,7 @@
+# TER-1285 Agent Session
+
+- **Ticket:** TER-1285
+- **Branch:** `feat/ter-1285-powersheet-grid-numeric-defaults`
+- **Status:** In Progress
+- **Started:** 2026-04-23T18:35:00Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
Implements TER-1285: PowersheetGrid numeric defaults.

## Summary

`SpreadsheetPilotGrid` — the internal implementation that every `PowersheetGrid` consumer renders through — now auto-applies numeric column defaults when the `ux.v2.grid` feature flag is enabled.

Part of epic **TER-1283** (April 23 frontend UX v2 work).
Source: `docs/ux-review/02-Implementation_Strategy.md` §4.2.

## What changed

### `client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx`

- Intercepts `columnDefs` before passing them to AG Grid and applies defaults based on `cellDataType`:
  - `"currency"` → `cellClass: "text-right font-mono tabular-nums"`, `headerClass: "text-right"`, USD `Intl.NumberFormat` formatter rendering `"$1,234.56"`
  - `"number"` → `cellClass: "text-right font-mono tabular-nums"`, `headerClass: "text-right"` (numbers render as-authored)
  - `"percent"` → `cellClass: "text-right font-mono tabular-nums"`, `headerClass: "text-right"`, `Intl.NumberFormat` formatter rendering `"12.3%"`
- **Explicit `cellClass` / `valueFormatter` on a ColDef are preserved.** Defaults only fill in `undefined` fields; per-column overrides are never clobbered.
- Interception is gated behind the `ux.v2.grid` feature flag.
- `Intl.NumberFormat` instances are module-scoped singletons so formatter allocation stays O(1) per grid render.

### `client/src/lib/constants/featureFlags.ts`

- Adds `uxV2Grid: "ux.v2.grid"` to `FEATURE_FLAGS`.

### `client/src/contexts/FeatureFlagContext.tsx`

- Adds `useOptionalFeatureFlag(key)` — returns `false` when no `FeatureFlagProvider` is mounted (rather than throwing), so shared low-level components can opt into flag-driven behavior without breaking unit-test harnesses.

## Acceptance criteria

- [x] `SpreadsheetPilotGrid` intercepts `columnDefs` and applies numeric defaults for `currency` / `number` / `percent` `cellDataType`
- [x] Explicit `cellClass` or `valueFormatter` on a ColDef override the defaults (no clobbering)
- [x] Currency formatter renders `"$1,234.56"` (USD, locale-aware via `Intl.NumberFormat`)
- [x] Percent formatter renders `"12.3%"`
- [x] `ux.v2.grid` feature flag defined and gates the auto-apply logic
- [x] `pnpm check` passes (zero TypeScript errors)
- [x] `pnpm lint` is clean on all files touched by this change

## Out of scope

- `server/` tRPC routers / database — untouched (per task spec)
- Migrating existing surfaces off ad-hoc `cellClass: "text-right font-mono"` — surfaces can adopt `cellDataType` declarations as they roll through the flag; existing explicit styling continues to render while the flag is off or when a surface keeps its override.
- The `PowersheetGrid` consumer lint rule (tracked separately).

Linear: TER-1285
Epic: TER-1283

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>