### PR TITLE
feat(ux-v2): ESLint rules no-bare-card-loading + no-inline-text-right + prefer-powersheet-grid [TER-1289/1290/1291]

### DIFF
--- a/docs/sessions/active/TER-1289-session.md
+++ b/docs/sessions/active/TER-1289-session.md
@@ -1,0 +1,7 @@
+# TER-1289 Agent Session
+
+- **Ticket:** TER-1289
+- **Branch:** `feat/ter-1289-eslint-rules-sprint1`
+- **Status:** In Progress
+- **Started:** 2026-04-23T18:35:02Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,28 @@
+/**
+ * eslint-plugin-terp — local custom rules for the TERP codebase.
+ *
+ * Rules shipped in Sprint 1 (TER-1289 / TER-1290 / TER-1291):
+ *   - terp/no-bare-card-loading         (TER-1289, warn)
+ *   - terp/no-inline-text-right-on-coldef (TER-1290, error)
+ *   - terp/prefer-powersheet-grid       (TER-1291, warn)
+ *
+ * Wired into `eslint.config.strict.js`. See each rule file for details.
+ */
+
+import noBareCardLoading from "./rules/no-bare-card-loading.js";
+import noInlineTextRightOnColdef from "./rules/no-inline-text-right-on-coldef.js";
+import preferPowersheetGrid from "./rules/prefer-powersheet-grid.js";
+
+const plugin = {
+  meta: {
+    name: "eslint-plugin-terp",
+    version: "0.1.0",
+  },
+  rules: {
+    "no-bare-card-loading": noBareCardLoading,
+    "no-inline-text-right-on-coldef": noInlineTextRightOnColdef,
+    "prefer-powersheet-grid": preferPowersheetGrid,
+  },
+};
+
+export default plugin;

--- a/eslint-rules/rules/no-bare-card-loading.js
+++ b/eslint-rules/rules/no-bare-card-loading.js
@@ -1,0 +1,81 @@
+/**
+ * TER-1289 — terp/no-bare-card-loading
+ *
+ * Flags `<Card>` / `<CardContent>` elements whose FIRST non-whitespace child
+ * is a bare `<Loader2 />` or `<Skeleton />`. Those loading surfaces should be
+ * wrapped in `<OperationalStateSurface>` so the `loading / empty / error /
+ * ready` contract is honored consistently.
+ *
+ * Does NOT fire on:
+ *   - `<Loader2 />` inside a `<Button>` (mutation-pending pattern)
+ *   - `<OperationalStateSurface>` itself
+ *
+ * Level: `warn` — will flip to `error` once the codemod cleans up existing
+ * usages.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Discourage bare <Loader2 /> or <Skeleton /> inside <Card>/<CardContent>. " +
+        "Wrap with <OperationalStateSurface> instead so loading/empty/error/ready states stay consistent.",
+    },
+    schema: [],
+    messages: {
+      bareLoading:
+        "Bare <{{child}} /> inside <{{parent}}> — wrap with <OperationalStateSurface> so loading/empty/error/ready stay consistent.",
+    },
+  },
+
+  create(context) {
+    const CARD_PARENTS = new Set(["Card", "CardContent"]);
+    const LOADING_CHILDREN = new Set(["Loader2", "Skeleton"]);
+
+    function getElementName(el) {
+      const name = el && el.openingElement && el.openingElement.name;
+      if (!name) return null;
+      // <Foo /> → JSXIdentifier
+      if (name.type === "JSXIdentifier") return name.name;
+      // <Foo.Bar /> → JSXMemberExpression (e.g. Card.Content)
+      if (name.type === "JSXMemberExpression" && name.property) {
+        return name.property.name;
+      }
+      return null;
+    }
+
+    return {
+      JSXElement(node) {
+        const parentName = getElementName(node);
+        if (!parentName || !CARD_PARENTS.has(parentName)) return;
+
+        // Find the first non-whitespace child.
+        const firstChild = node.children.find((child) => {
+          if (child.type === "JSXText") {
+            return child.value.trim().length > 0;
+          }
+          if (child.type === "JSXExpressionContainer") {
+            // Skip {/* comments */} only.
+            return child.expression && child.expression.type !== "JSXEmptyExpression";
+          }
+          return true;
+        });
+
+        if (!firstChild || firstChild.type !== "JSXElement") return;
+
+        const childName = getElementName(firstChild);
+        if (!childName || !LOADING_CHILDREN.has(childName)) return;
+
+        context.report({
+          node: firstChild,
+          messageId: "bareLoading",
+          data: { parent: parentName, child: childName },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/rules/no-inline-text-right-on-coldef.js
+++ b/eslint-rules/rules/no-inline-text-right-on-coldef.js
@@ -1,0 +1,94 @@
+/**
+ * TER-1290 — terp/no-inline-text-right-on-coldef
+ *
+ * Flags ColDef object literals that pin alignment inline via `cellClass`
+ * containing BOTH the `text-right` AND `font-mono` tokens. Numeric-cell
+ * alignment should be expressed through the shared PowerSheet primitives
+ * (e.g. `powersheet-cell--numeric`) instead of ad-hoc Tailwind strings.
+ *
+ * Scope: `client/src/**` only.
+ * Allow-list: `client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx`
+ * (the primitive itself is allowed to define the alignment contract).
+ *
+ * Level: `error` — the codemod runs before this rule lands in the strict
+ * config, so the tree stays clean.
+ */
+
+import path from "node:path";
+
+const ALLOW_LIST_SUFFIXES = [
+  "client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx",
+];
+
+function normalizeFilename(filename) {
+  if (!filename) return "";
+  return filename.split(path.sep).join("/");
+}
+
+function isAllowListed(filename) {
+  const normalized = normalizeFilename(filename);
+  return ALLOW_LIST_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+function isInClientSrc(filename) {
+  return normalizeFilename(filename).includes("/client/src/");
+}
+
+function extractStaticString(node) {
+  if (!node) return null;
+  if (node.type === "Literal" && typeof node.value === "string") {
+    return node.value;
+  }
+  if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
+    return node.quasis.map((q) => q.value.cooked).join("");
+  }
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid inline `text-right font-mono` on ColDef.cellClass. Use a PowerSheet alignment class instead.",
+    },
+    schema: [],
+    messages: {
+      inlineAlignment:
+        'Inline `text-right font-mono` on ColDef.cellClass is forbidden. ' +
+        'Use a PowerSheet alignment class (e.g. "powersheet-cell--numeric") instead.',
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename();
+
+    if (!isInClientSrc(filename)) return {};
+    if (isAllowListed(filename)) return {};
+
+    return {
+      Property(node) {
+        if (!node.key) return;
+        const keyName =
+          node.key.type === "Identifier"
+            ? node.key.name
+            : node.key.type === "Literal"
+              ? node.key.value
+              : null;
+        if (keyName !== "cellClass") return;
+
+        const staticValue = extractStaticString(node.value);
+        if (staticValue === null) return;
+
+        // Tokenize on whitespace so "font-mono-extra" doesn't match "font-mono".
+        const tokens = new Set(staticValue.split(/\s+/).filter(Boolean));
+        if (tokens.has("text-right") && tokens.has("font-mono")) {
+          context.report({ node, messageId: "inlineAlignment" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/rules/prefer-powersheet-grid.js
+++ b/eslint-rules/rules/prefer-powersheet-grid.js
@@ -1,0 +1,74 @@
+/**
+ * TER-1291 — terp/prefer-powersheet-grid
+ *
+ * Flags direct imports from `ag-grid-react` outside the hard-coded allow-list.
+ * New code should consume the PowerSheet primitive (`SpreadsheetPilotGrid`) or
+ * the shared compat wrapper (`AgGridReactCompat`) rather than wiring AG Grid
+ * React directly into feature surfaces.
+ *
+ * Allow-list (hard-coded):
+ *   - client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx
+ *     (inner PowerSheet implementation)
+ *   - client/src/components/ag-grid/AgGridReactCompat.tsx
+ *     (shared compat layer)
+ *   - client/src/components/spreadsheet/ClientGrid.tsx         // sunset
+ *   - client/src/components/spreadsheet/InventoryGrid.tsx      // sunset
+ *   - client/src/components/spreadsheet/PickPackGrid.tsx       // sunset
+ *   - client/src/components/work-surface/DirectIntakeWorkSurface.tsx // sunset
+ *
+ * Level: `warn` — flips to `error` once the sunset grids migrate off AG Grid.
+ */
+
+import path from "node:path";
+
+const ALLOW_LIST_SUFFIXES = [
+  // PowerSheet primitive + compat layer
+  "client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx",
+  "client/src/components/ag-grid/AgGridReactCompat.tsx",
+  // Sprint-5 legacy — sunset
+  "client/src/components/spreadsheet/ClientGrid.tsx",
+  "client/src/components/spreadsheet/InventoryGrid.tsx",
+  "client/src/components/spreadsheet/PickPackGrid.tsx",
+  "client/src/components/work-surface/DirectIntakeWorkSurface.tsx",
+];
+
+function normalizeFilename(filename) {
+  if (!filename) return "";
+  return filename.split(path.sep).join("/");
+}
+
+function isAllowListed(filename) {
+  const normalized = normalizeFilename(filename);
+  return ALLOW_LIST_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Prefer SpreadsheetPilotGrid / AgGridReactCompat over direct `ag-grid-react` imports.",
+    },
+    schema: [],
+    messages: {
+      preferPowersheet:
+        "Do not import from 'ag-grid-react' directly. Use <SpreadsheetPilotGrid /> (or AgGridReactCompat for the compat layer) instead.",
+    },
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (isAllowListed(filename)) return {};
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source && node.source.value === "ag-grid-react") {
+          context.report({ node, messageId: "preferPowersheet" });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint.config.strict.js
+++ b/eslint.config.strict.js
@@ -15,6 +15,7 @@ import typescript from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import terp from './eslint-rules/index.js';
 
 export default [
   js.configs.recommended,
@@ -24,6 +25,7 @@ export default [
       '@typescript-eslint': typescript,
       'react': react,
       'react-hooks': reactHooks,
+      'terp': terp,
     },
     languageOptions: {
       parser: typescriptParser,
@@ -141,6 +143,23 @@ export default [
       'no-new-func': 'error',
       'no-return-await': 'error',
       'require-await': 'off', // Use TypeScript version
+
+      // ============================================================
+      // TERP Sprint 1 primitives — regression-prevention lint rules
+      // (TER-1289 / TER-1290 / TER-1291, Epic TER-1283)
+      // ============================================================
+
+      // TER-1289 — flag bare <Loader2 /> or <Skeleton /> directly inside
+      // <Card> / <CardContent>. Will flip to `error` after the codemod lands.
+      'terp/no-bare-card-loading': 'warn',
+
+      // TER-1290 — forbid inline `text-right font-mono` on ColDef.cellClass.
+      // Numeric alignment must come from PowerSheet cell classes.
+      'terp/no-inline-text-right-on-coldef': 'error',
+
+      // TER-1291 — prefer SpreadsheetPilotGrid / AgGridReactCompat over direct
+      // `ag-grid-react` imports. Will flip to `error` after sunset grids migrate.
+      'terp/prefer-powersheet-grid': 'warn',
     },
     settings: {
       react: {

--- a/tests/unit/eslint-rules/no-bare-card-loading.test.ts
+++ b/tests/unit/eslint-rules/no-bare-card-loading.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit test — terp/no-bare-card-loading (TER-1289).
+ *
+ * Covers:
+ *   - Card with bare <Loader2 /> as first child → fires
+ *   - CardContent with bare <Skeleton /> as first child → fires
+ *   - Button with <Loader2 /> (mutation-pending pattern) → does NOT fire
+ *   - Card wrapped with <OperationalStateSurface> → does NOT fire
+ *   - Card with meaningful content before Loader2 → does NOT fire
+ */
+
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+// @ts-expect-error — plain JS rule module (no bundled types)
+import rule from "../../../eslint-rules/rules/no-bare-card-loading.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run("terp/no-bare-card-loading", rule, {
+  valid: [
+    // Loader2 inside Button (mutation pending pattern) — allowed.
+    {
+      code: `<Button disabled><Loader2 /> Saving…</Button>`,
+    },
+    // Card wrapped via OperationalStateSurface — allowed.
+    {
+      code: `<OperationalStateSurface loading={isLoading}><Card><div>ready</div></Card></OperationalStateSurface>`,
+    },
+    // Card with real content — allowed.
+    {
+      code: `<Card><h2>Title</h2><div>body</div></Card>`,
+    },
+    // Card whose first child is a different element — allowed.
+    {
+      code: `<Card><div><Loader2 /></div></Card>`,
+    },
+    // OperationalStateSurface alone — not a Card/CardContent, so ignored.
+    {
+      code: `<OperationalStateSurface><Loader2 /></OperationalStateSurface>`,
+    },
+  ],
+  invalid: [
+    // <Card><Loader2/> → fires.
+    {
+      code: `<Card><Loader2 /></Card>`,
+      errors: [{ messageId: "bareLoading" }],
+    },
+    // <CardContent><Skeleton/> → fires.
+    {
+      code: `<CardContent><Skeleton className="h-4 w-full" /></CardContent>`,
+      errors: [{ messageId: "bareLoading" }],
+    },
+    // Whitespace before Loader2 should still fire (first meaningful child).
+    {
+      code: `<Card>\n  <Loader2 />\n</Card>`,
+      errors: [{ messageId: "bareLoading" }],
+    },
+  ],
+});

--- a/tests/unit/eslint-rules/no-inline-text-right-on-coldef.test.ts
+++ b/tests/unit/eslint-rules/no-inline-text-right-on-coldef.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit test — terp/no-inline-text-right-on-coldef (TER-1290).
+ *
+ * Covers:
+ *   - cellClass: "text-right font-mono" → fires
+ *   - cellClass: "powersheet-cell--locked font-mono text-right" → fires
+ *   - cellClass: "text-right" (no font-mono) → does NOT fire
+ *   - cellClass: params => ... (function) → does NOT fire (not a static string)
+ *   - SpreadsheetPilotGrid.tsx allow-list → does NOT fire
+ *   - Out-of-scope path (server/**) → does NOT fire
+ */
+
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+// @ts-expect-error — plain JS rule module (no bundled types)
+import rule from "../../../eslint-rules/rules/no-inline-text-right-on-coldef.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+const IN_SCOPE = "/repo/client/src/components/feature/Foo.tsx";
+const ALLOWED = "/repo/client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx";
+const OUT_OF_SCOPE = "/repo/server/routers/foo.ts";
+
+ruleTester.run("terp/no-inline-text-right-on-coldef", rule, {
+  valid: [
+    // Only text-right (no font-mono) — allowed.
+    {
+      code: `const col = { cellClass: "text-right" };`,
+      filename: IN_SCOPE,
+    },
+    // Only font-mono — allowed.
+    {
+      code: `const col = { cellClass: "font-mono" };`,
+      filename: IN_SCOPE,
+    },
+    // Function cellClass — not a static string, skip.
+    {
+      code: `const col = { cellClass: (params) => "text-right font-mono" };`,
+      filename: IN_SCOPE,
+    },
+    // Allow-list: SpreadsheetPilotGrid itself.
+    {
+      code: `const col = { cellClass: "text-right font-mono" };`,
+      filename: ALLOWED,
+    },
+    // Out-of-scope: not under client/src.
+    {
+      code: `const col = { cellClass: "text-right font-mono" };`,
+      filename: OUT_OF_SCOPE,
+    },
+    // PowerSheet alignment class — allowed.
+    {
+      code: `const col = { cellClass: "powersheet-cell--numeric" };`,
+      filename: IN_SCOPE,
+    },
+  ],
+  invalid: [
+    // Minimal: both tokens in a literal string.
+    {
+      code: `const col = { cellClass: "text-right font-mono" };`,
+      filename: IN_SCOPE,
+      errors: [{ messageId: "inlineAlignment" }],
+    },
+    // Real-world ordering with an extra class in between.
+    {
+      code: `const col = { cellClass: "powersheet-cell--locked font-mono text-right" };`,
+      filename: IN_SCOPE,
+      errors: [{ messageId: "inlineAlignment" }],
+    },
+    // Template literal with no interpolation.
+    {
+      code: "const col = { cellClass: `text-right font-mono` };",
+      filename: IN_SCOPE,
+      errors: [{ messageId: "inlineAlignment" }],
+    },
+  ],
+});

--- a/tests/unit/eslint-rules/prefer-powersheet-grid.test.ts
+++ b/tests/unit/eslint-rules/prefer-powersheet-grid.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit test — terp/prefer-powersheet-grid (TER-1291).
+ *
+ * Covers:
+ *   - Random feature file importing from 'ag-grid-react' → fires
+ *   - Importing from 'ag-grid-community' → does NOT fire (rule is
+ *     only about the `react` package)
+ *   - Allow-listed paths → do NOT fire
+ */
+
+import { RuleTester } from "eslint";
+import { describe, it } from "vitest";
+// @ts-expect-error — plain JS rule module (no bundled types)
+import rule from "../../../eslint-rules/rules/prefer-powersheet-grid.js";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+const FEATURE_FILE = "/repo/client/src/components/new-feature/Foo.tsx";
+
+// Allow-list paths that should NOT report.
+const ALLOW_LISTED = [
+  "/repo/client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx",
+  "/repo/client/src/components/ag-grid/AgGridReactCompat.tsx",
+  "/repo/client/src/components/spreadsheet/ClientGrid.tsx",
+  "/repo/client/src/components/spreadsheet/InventoryGrid.tsx",
+  "/repo/client/src/components/spreadsheet/PickPackGrid.tsx",
+  "/repo/client/src/components/work-surface/DirectIntakeWorkSurface.tsx",
+];
+
+ruleTester.run("terp/prefer-powersheet-grid", rule, {
+  valid: [
+    // Importing the community package is fine.
+    {
+      code: `import { AllCommunityModule } from "ag-grid-community";`,
+      filename: FEATURE_FILE,
+    },
+    // Allow-listed files may import ag-grid-react.
+    ...ALLOW_LISTED.map((filename) => ({
+      code: `import { AgGridReact } from "ag-grid-react";`,
+      filename,
+    })),
+  ],
+  invalid: [
+    // Default feature file importing ag-grid-react directly.
+    {
+      code: `import { AgGridReact } from "ag-grid-react";`,
+      filename: FEATURE_FILE,
+      errors: [{ messageId: "preferPowersheet" }],
+    },
+    // Namespace import still fires.
+    {
+      code: `import * as AgGrid from "ag-grid-react";`,
+      filename: FEATURE_FILE,
+      errors: [{ messageId: "preferPowersheet" }],
+    },
+    // Side-effect import still fires.
+    {
+      code: `import "ag-grid-react";`,
+      filename: FEATURE_FILE,
+      errors: [{ messageId: "preferPowersheet" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Implements the regression-prevention lint layer for Sprint 1 UX primitives (Epic **TER-1283**, April 23 frontend UX v2 work).

Three rules land in a new local plugin (`eslint-rules/`) and are wired into `eslint.config.strict.js` (pre-commit / staged-files pipeline).

| Rule | Ticket | Level | Purpose |
|------|--------|-------|---------|
| `terp/no-bare-card-loading` | TER-1289 | `warn` | Flag `<Card>`/`<CardContent>` whose first child is a bare `<Loader2 />` or `<Skeleton />` — suggests `<OperationalStateSurface>`. |
| `terp/no-inline-text-right-on-coldef` | TER-1290 | `error` | Forbid inline `text-right font-mono` on `ColDef.cellClass`. Use a PowerSheet class (e.g. `powersheet-cell--numeric`). |
| `terp/prefer-powersheet-grid` | TER-1291 | `warn` | Forbid direct `ag-grid-react` imports outside an explicit allow-list. |

Levels will flip to `error` once the matching codemods and Sprint-5 legacy migrations land.

## Rule details

### TER-1289 — `terp/no-bare-card-loading`
- Fires on `<Card>` / `<CardContent>` whose first non-whitespace child is `<Loader2 />` or `<Skeleton />`.
- **Does not** fire on `<Loader2 />` inside a `<Button>` (mutation-pending pattern).
- **Does not** fire on `<OperationalStateSurface>` itself.

### TER-1290 — `terp/no-inline-text-right-on-coldef`
- Fires on object-literal `cellClass` whose static string contains both `text-right` and `font-mono` tokens.
- Scope: `client/src/**` only.
- Allow-list: `client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx` (the primitive defining the alignment contract).
- Ignores function-valued `cellClass` (runtime computed — codemod target is string literals).

### TER-1291 — `terp/prefer-powersheet-grid`
- Fires on any `import … from 'ag-grid-react'` outside the hard-coded allow-list.
- Allow-list:
  - `client/src/components/spreadsheet-native/SpreadsheetPilotGrid.tsx` — inner PowerSheet implementation
  - `client/src/components/ag-grid/AgGridReactCompat.tsx` — shared compat layer
  - `client/src/components/spreadsheet/ClientGrid.tsx` — Sprint-5 legacy (sunset)
  - `client/src/components/spreadsheet/InventoryGrid.tsx` — Sprint-5 legacy (sunset)
  - `client/src/components/spreadsheet/PickPackGrid.tsx` — Sprint-5 legacy (sunset)
  - `client/src/components/work-surface/DirectIntakeWorkSurface.tsx` — Sprint-5 legacy (sunset)

## Tests

27 unit tests across three files in `tests/unit/eslint-rules/`, using ESLint 9 `RuleTester` + vitest. All green locally:

```
Test Files  3 passed (3)
     Tests  27 passed (27)
```

## Verification

- `pnpm check` ✅ zero TypeScript errors
- `pnpm exec vitest run tests/unit/eslint-rules/` ✅ 27/27 pass
- `pnpm lint` — baseline-equivalent (29 pre-existing errors, none introduced by this PR; new rules are wired into strict config only)

## Tier

**SAFE** — lint rules only, no functional / runtime / schema change.

## Follow-ups

- Codemods for existing `text-right font-mono` `cellClass` strings (TER-1290 flip-to-error).
- Sunset grid migrations off `ag-grid-react` (TER-1291 flip-to-error).
- Codemod sweep for bare `<Card>`/`<CardContent>` loaders (TER-1289 flip-to-error).

🤖 Generated with [Factory](https://factory.ai)
Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>