### PR TITLE
feat(ux-v2): ManusSheet primitive — enforced drawer affordances [TER-1294]

### DIFF
--- a/client/src/components/feature-flags/index.ts
+++ b/client/src/components/feature-flags/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { FeatureFlag, ModuleGate, RequireFeature } from "./FeatureFlag";
+export { UX_V2_FLAGS, isUxV2FlagEnabled, type UxV2FlagKey } from "./uxV2Flags";

--- a/client/src/components/feature-flags/uxV2Flags.ts
+++ b/client/src/components/feature-flags/uxV2Flags.ts
@@ -1,0 +1,42 @@
+/**
+ * UX v2 Feature Flags (TER-1283 epic)
+ *
+ * Centralized registry of feature-flag keys that gate the "Manus" UX v2 wave.
+ * All UX v2 primitives (ManusSheet, Manus breadcrumbs, etc.) read flags via
+ * `useFeatureFlag(UX_V2_FLAGS.DRAWER)` so that rollout can be staged per
+ * surface in the feature-flags admin UI without code changes.
+ *
+ * Flag semantics:
+ *
+ * - `ux.v2.drawer` — Enables the ManusSheet primitive (TER-1294) in place of
+ *   the legacy `@/components/ui/sheet` drawer. When disabled, call sites
+ *   should fall back to the existing Sheet component. Default when flag is
+ *   absent from the server response: **disabled** (safe default).
+ *
+ * Add new UX v2 flags to `UX_V2_FLAGS` below; do NOT hard-code flag strings
+ * at call sites.
+ */
+
+/**
+ * UX v2 feature flag keys. Keys are namespaced `ux.v2.*` to keep them grouped
+ * in the feature-flags admin and to disambiguate from legacy `work-surface-*`
+ * flags in `useWorkSurfaceFeatureFlags`.
+ */
+export const UX_V2_FLAGS = {
+  /** Enforced ManusSheet drawer primitive (TER-1294). */
+  DRAWER: "ux.v2.drawer",
+} as const;
+
+export type UxV2FlagKey = (typeof UX_V2_FLAGS)[keyof typeof UX_V2_FLAGS];
+
+/**
+ * Default-off predicate. Call sites should prefer
+ * `useFeatureFlag(UX_V2_FLAGS.DRAWER).enabled` directly, but this helper is
+ * provided for non-React contexts where we only have a raw flags map.
+ */
+export function isUxV2FlagEnabled(
+  flags: Record<string, boolean> | undefined,
+  flag: UxV2FlagKey
+): boolean {
+  return flags?.[flag] ?? false;
+}

--- a/client/src/components/ui/manus-sheet.tsx
+++ b/client/src/components/ui/manus-sheet.tsx
@@ -1,0 +1,293 @@
+/**
+ * ManusSheet — UX v2 enforced drawer primitive (TER-1294)
+ *
+ * Wraps the existing Radix-based Sheet (`@/components/ui/sheet`) with a fixed
+ * set of affordances that the "Manus" UX v2 language mandates on every drawer
+ * surface:
+ *
+ *   1. Visible close-X button in the top-right corner (always rendered).
+ *   2. "Esc to close" hint rendered inside the drawer footer by default.
+ *   3. Focus return to the triggering element on close, via `useReturnFocus`.
+ *      Works for both explicit `triggerRef` call sites AND the legacy
+ *      ref-less `<SheetTrigger>` call sites flagged in QA report §8.
+ *   4. Canonical `size` prop: "sm" | "md" | "lg" → 400 / 640 / 800px wide.
+ *   5. `onOpenChange` is driven by close-X click, Esc key, and backdrop click
+ *      (all provided by Radix Dialog's `onOpenChange` semantics).
+ *
+ * The existing `Sheet`, `SheetContent`, etc. exports from `@/components/ui/sheet`
+ * are NOT modified — this is a new, additive primitive. Gate consumption on the
+ * `ux.v2.drawer` feature flag (see `@/components/feature-flags/uxV2Flags`).
+ *
+ * @example
+ * ```tsx
+ * import {
+ *   ManusSheet,
+ *   ManusSheetContent,
+ *   ManusSheetHeader,
+ *   ManusSheetTitle,
+ *   ManusSheetFooter,
+ * } from "@/components/ui/manus-sheet";
+ * import { SheetTrigger } from "@/components/ui/sheet";
+ *
+ * function Example() {
+ *   const [open, setOpen] = useState(false);
+ *   return (
+ *     <ManusSheet open={open} onOpenChange={setOpen}>
+ *       <SheetTrigger asChild>
+ *         <Button>Open</Button>
+ *       </SheetTrigger>
+ *       <ManusSheetContent size="md">
+ *         <ManusSheetHeader>
+ *           <ManusSheetTitle>Edit item</ManusSheetTitle>
+ *         </ManusSheetHeader>
+ *         <div className="px-4">{/* body ... *\/}</div>
+ *         <ManusSheetFooter>
+ *           <Button onClick={() => setOpen(false)}>Save</Button>
+ *         </ManusSheetFooter>
+ *       </ManusSheetContent>
+ *     </ManusSheet>
+ *   );
+ * }
+ * ```
+ */
+
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Sheet } from "@/components/ui/sheet";
+import { useReturnFocus } from "@/hooks/useReturnFocus";
+
+/**
+ * Canonical ManusSheet widths.
+ * These match the UX v2 spec (docs/ux-review/02-Implementation_Strategy.md §4.4).
+ */
+export type ManusSheetSize = "sm" | "md" | "lg";
+
+const SIZE_CLASSNAMES: Record<ManusSheetSize, string> = {
+  sm: "w-full sm:max-w-[400px]",
+  md: "w-full sm:max-w-[640px]",
+  lg: "w-full sm:max-w-[800px]",
+};
+
+const SIZE_PIXELS: Record<ManusSheetSize, number> = {
+  sm: 400,
+  md: 640,
+  lg: 800,
+};
+
+/** Exposed for testing / downstream telemetry. */
+export function getManusSheetWidthPx(size: ManusSheetSize): number {
+  return SIZE_PIXELS[size];
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+/**
+ * ManusSheet root. Thin pass-through around the existing `Sheet` (Radix Dialog
+ * Root) so that `onOpenChange`, `open`, `defaultOpen`, and `modal` props
+ * continue to behave exactly as they do on the stock primitive.
+ */
+function ManusSheet(
+  props: React.ComponentProps<typeof Sheet>
+): React.ReactElement {
+  return <Sheet data-slot="manus-sheet" {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+export interface ManusSheetContentProps
+  extends Omit<
+    React.ComponentProps<typeof SheetPrimitive.Content>,
+    "children"
+  > {
+  /** Side the drawer slides in from. Defaults to "right". */
+  side?: "right" | "left";
+  /** Canonical width. Defaults to "md" (640px). */
+  size?: ManusSheetSize;
+  /**
+   * Optional ref to the triggering element. If omitted, focus is returned to
+   * whatever element was focused at the moment the drawer opened (legacy
+   * ref-less trigger support).
+   */
+  triggerRef?: React.RefObject<HTMLElement | null>;
+  /** Label for the enforced close-X button. Defaults to "Close". */
+  closeLabel?: string;
+  children?: React.ReactNode;
+}
+
+function ManusSheetContent({
+  side = "right",
+  size = "md",
+  triggerRef,
+  closeLabel = "Close",
+  className,
+  children,
+  ...props
+}: ManusSheetContentProps): React.ReactElement {
+  // Return focus to trigger on close (works for ref'd and ref-less triggers).
+  useReturnFocus({ triggerRef });
+
+  return (
+    <SheetPrimitive.Portal>
+      <SheetPrimitive.Overlay
+        data-slot="manus-sheet-overlay"
+        className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50"
+      />
+      <SheetPrimitive.Content
+        data-slot="manus-sheet-content"
+        data-size={size}
+        data-side={side}
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-0 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full border-l",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full border-r",
+          SIZE_CLASSNAMES[size],
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {/*
+         * Enforced close-X affordance.
+         * Always rendered; cannot be opted out. Clicking this triggers
+         * Radix's onOpenChange(false) via the Dialog.Close primitive, which
+         * mirrors Esc and backdrop-click behavior.
+         */}
+        <SheetPrimitive.Close
+          aria-label={closeLabel}
+          data-slot="manus-sheet-close"
+          className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+        >
+          <XIcon className="size-4" aria-hidden="true" />
+          <span className="sr-only">{closeLabel}</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPrimitive.Portal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header / Title / Description
+// ---------------------------------------------------------------------------
+
+function ManusSheetHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.ReactElement {
+  return (
+    <div
+      data-slot="manus-sheet-header"
+      // `pr-10` reserves horizontal space so the enforced close-X does not
+      // overlap header content (icon is ~16px at top-right + padding).
+      className={cn("flex flex-col gap-1.5 border-b p-4 pr-10", className)}
+      {...props}
+    />
+  );
+}
+
+function ManusSheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>): React.ReactElement {
+  return (
+    <SheetPrimitive.Title
+      data-slot="manus-sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function ManusSheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<
+  typeof SheetPrimitive.Description
+>): React.ReactElement {
+  return (
+    <SheetPrimitive.Description
+      data-slot="manus-sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Footer
+// ---------------------------------------------------------------------------
+
+export interface ManusSheetFooterProps extends React.ComponentProps<"div"> {
+  /**
+   * If `false`, suppresses the "Esc to close" hint. Defaults to `true`.
+   * Consumers should only disable this in exceptional cases (e.g. nested
+   * footers inside multi-step flows) — the hint is a UX v2 contract.
+   */
+  showEscHint?: boolean;
+}
+
+function ManusSheetFooter({
+  className,
+  children,
+  showEscHint = true,
+  ...props
+}: ManusSheetFooterProps): React.ReactElement {
+  return (
+    <div
+      data-slot="manus-sheet-footer"
+      className={cn(
+        "mt-auto flex flex-col gap-2 border-t p-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showEscHint ? (
+        <p
+          data-slot="manus-sheet-esc-hint"
+          className="text-muted-foreground mt-1 text-xs"
+        >
+          Press{" "}
+          <kbd className="border-border bg-muted rounded border px-1.5 py-0.5 font-mono text-[10px]">
+            Esc
+          </kbd>{" "}
+          to close
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Close convenience
+// ---------------------------------------------------------------------------
+
+function ManusSheetClose(
+  props: React.ComponentProps<typeof SheetPrimitive.Close>
+): React.ReactElement {
+  return <SheetPrimitive.Close data-slot="manus-sheet-close-action" {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  ManusSheet,
+  ManusSheetContent,
+  ManusSheetHeader,
+  ManusSheetTitle,
+  ManusSheetDescription,
+  ManusSheetFooter,
+  ManusSheetClose,
+};

--- a/client/src/hooks/useReturnFocus.ts
+++ b/client/src/hooks/useReturnFocus.ts
@@ -1,0 +1,147 @@
+/**
+ * useReturnFocus
+ *
+ * Hook that captures the currently focused element on mount and returns focus
+ * to it (or to a provided `triggerRef`) on unmount or when explicitly invoked.
+ *
+ * Why this exists (TER-1294):
+ * Not all Sheet / Dialog call-sites in TERP hold an explicit ref to the
+ * element that opened the drawer. Per the QA report (§8, Radix Sheet
+ * trap-focus semantics), 6 of 12 current Sheet call sites rely on
+ * `<SheetTrigger>` children without forwarding a ref. If focus-return only
+ * worked when a ref was provided, those call sites would silently break
+ * accessibility.
+ *
+ * This hook therefore supports BOTH modes:
+ *
+ * 1. Explicit trigger ref (preferred):
+ *    ```tsx
+ *    const triggerRef = useRef<HTMLButtonElement>(null);
+ *    useReturnFocus({ triggerRef });
+ *    ```
+ *
+ * 2. Implicit capture (fallback for ref-less triggers):
+ *    The hook snapshots `document.activeElement` at mount time (i.e. at the
+ *    moment the drawer content renders, which for Radix Dialog is synchronous
+ *    with the click that opened it). On unmount it restores focus to that
+ *    element — no ref required from the caller.
+ *
+ * The hook should be used INSIDE the portal-rendered content (e.g. within
+ * `<SheetContent>` children) so that mount = drawer open and unmount =
+ * drawer close.
+ *
+ * @example
+ * ```tsx
+ * function ManusSheetContent({ children }: Props) {
+ *   useReturnFocus();
+ *   return <SheetContent>{children}</SheetContent>;
+ * }
+ * ```
+ *
+ * @example With explicit trigger ref
+ * ```tsx
+ * const triggerRef = useRef<HTMLButtonElement>(null);
+ * const { returnFocus } = useReturnFocus({ triggerRef });
+ * // ... later, manually return focus (optional)
+ * returnFocus();
+ * ```
+ */
+
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+
+export interface UseReturnFocusOptions {
+  /**
+   * Optional ref to the element that should receive focus on close.
+   * If not provided, the hook falls back to whatever was
+   * `document.activeElement` at the moment the hook mounted.
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
+
+  /**
+   * If `false`, the hook will NOT automatically return focus on unmount.
+   * Use this when you want to call `returnFocus()` manually.
+   * Defaults to `true`.
+   */
+  autoReturnOnUnmount?: boolean;
+
+  /**
+   * If `true`, the hook is a no-op. Useful for conditionally disabling
+   * return-focus behavior without changing hook call order.
+   * Defaults to `false`.
+   */
+  disabled?: boolean;
+}
+
+export interface UseReturnFocusReturn {
+  /**
+   * Manually trigger focus return. Safe to call multiple times; only the
+   * first successful call takes effect per mount cycle.
+   */
+  returnFocus: () => void;
+}
+
+/**
+ * Capture active element on mount, restore it on unmount (or on demand).
+ */
+export function useReturnFocus(
+  options: UseReturnFocusOptions = {}
+): UseReturnFocusReturn {
+  const { triggerRef, autoReturnOnUnmount = true, disabled = false } = options;
+
+  // Element that had focus when the drawer/dialog opened.
+  const capturedElementRef = useRef<HTMLElement | null>(null);
+  // Whether we've already restored focus for this mount.
+  const hasRestoredRef = useRef(false);
+
+  // Capture the currently-focused element synchronously on first render.
+  // Using a ref-init pattern (rather than useEffect) guarantees we capture
+  // BEFORE Radix moves focus into the dialog.
+  if (
+    capturedElementRef.current === null &&
+    !disabled &&
+    typeof document !== "undefined"
+  ) {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active !== document.body) {
+      capturedElementRef.current = active;
+    }
+  }
+
+  const returnFocus = useCallback(() => {
+    if (disabled) return;
+    if (hasRestoredRef.current) return;
+
+    // Prefer explicit trigger ref (safer because it survives DOM churn).
+    const target = triggerRef?.current ?? capturedElementRef.current ?? null;
+
+    if (target && typeof target.focus === "function") {
+      try {
+        // `preventScroll` avoids a jarring scroll jump when focus returns
+        // to an element that is outside the current viewport.
+        target.focus({ preventScroll: true });
+        hasRestoredRef.current = true;
+      } catch {
+        // Swallow: element may have been detached from the DOM.
+        hasRestoredRef.current = true;
+      }
+    } else {
+      // No viable target; mark done so we don't keep retrying.
+      hasRestoredRef.current = true;
+    }
+  }, [triggerRef, disabled]);
+
+  useEffect(() => {
+    if (disabled) return;
+    if (!autoReturnOnUnmount) return;
+
+    return () => {
+      returnFocus();
+    };
+    // `returnFocus` identity is stable across renders thanks to useCallback,
+    // but we still depend on it to honor exhaustive-deps.
+  }, [autoReturnOnUnmount, disabled, returnFocus]);
+
+  return { returnFocus };
+}
+
+export default useReturnFocus;

--- a/docs/sessions/active/TER-1294-session.md
+++ b/docs/sessions/active/TER-1294-session.md
@@ -1,0 +1,7 @@
+# TER-1294 Agent Session
+
+- **Ticket:** TER-1294
+- **Branch:** `feat/ter-1294-manus-sheet`
+- **Status:** In Progress
+- **Started:** 2026-04-23T19:00:33Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

Implements **TER-1294** — the `ManusSheet` UX v2 drawer primitive and its supporting `useReturnFocus` hook. Part of the TER-1283 April 23 frontend UX v2 epic.

## What's new

- **`client/src/components/ui/manus-sheet.tsx`** — New primitive wrapping the Radix-based `Sheet` with enforced affordances:
  - Always-visible close-X in the top-right corner
  - "Esc to close" hint rendered in the drawer footer by default (opt-out via `showEscHint={false}`)
  - Canonical `size` prop: `sm | md | lg` → **400 / 640 / 800 px**
  - `onOpenChange` wired through Radix Dialog semantics (close-X, Esc, backdrop click)
  - Exports: `ManusSheet`, `ManusSheetContent`, `ManusSheetHeader`, `ManusSheetTitle`, `ManusSheetDescription`, `ManusSheetFooter`, `ManusSheetClose`
- **`client/src/hooks/useReturnFocus.ts`** — New hook that captures the focused element at mount and restores focus on unmount. **Handles both ref'd and ref-less triggers** (per QA report §8 — 6 of 12 current Sheet call sites don't hold a trigger ref).
- **`client/src/components/feature-flags/uxV2Flags.ts`** — New `UX_V2_FLAGS` registry with the `ux.v2.drawer` key.

## Backward compatibility

The existing `@/components/ui/sheet` exports (`Sheet`, `SheetContent`, etc.) are **unchanged**. ManusSheet is additive; call sites opt in behind the `ux.v2.drawer` flag.

## Acceptance criteria

- [x] `ManusSheet` exported from `client/src/components/ui/manus-sheet.tsx`
- [x] Close-X button visible in all drawer variants
- [x] "Esc to close" hint visible in drawer footer
- [x] `useReturnFocus` wired — works for ref'd and non-ref'd triggers
- [x] `size` prop maps to 400/640/800px widths
- [x] `ux.v2.drawer` flag defined
- [x] `pnpm check` passes (zero TypeScript errors in touched code)
- [x] `pnpm lint` passes for touched files
- [x] Existing `Sheet` imports continue working

## Verification

```bash
pnpm check   # ✅ zero TS errors
pnpm lint    # ✅ no new issues in touched files
```

## Source

docs/ux-review/02-Implementation_Strategy.md §4.4

Linear: [TER-1294](https://linear.app/terpcorp/issue/TER-1294)