### PR TITLE
feat(ux-v2): AppBreadcrumb route registry + config/routes.ts [TER-1297]

### DIFF
--- a/client/src/components/layout/AppBreadcrumb.tsx
+++ b/client/src/components/layout/AppBreadcrumb.tsx
@@ -1,8 +1,14 @@
 /**
  * App Breadcrumb Component
- * UX-009: Automatic breadcrumb navigation based on current route
+ * UX-009: Automatic breadcrumb navigation based on current route.
+ * TER-1297: Registry-driven breadcrumbs with async entity name resolution.
  *
- * Generates breadcrumbs from the current URL path and navigation config.
+ * - When the `ux.v2.breadcrumb-registry` feature flag is enabled, segment
+ *   titles come from the shared `@/config/routes` registry, and dynamic
+ *   detail segments (e.g. `/clients/:id`) resolve to a human-friendly name
+ *   via tRPC. Failed/unknown resolutions fall back to `#<rawId>`.
+ * - When the flag is disabled, the component preserves the legacy
+ *   `navigationItems` + `customRouteNames` lookup behaviour.
  */
 
 import React from "react";
@@ -17,6 +23,14 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { navigationItems } from "@/config/navigation";
+import {
+  buildBreadcrumbTrail,
+  type BreadcrumbTrailEntry,
+  type RouteEntityType,
+} from "@/config/routes";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { FEATURE_FLAGS } from "@/lib/constants/featureFlags";
+import { trpc } from "@/lib/trpc";
 
 interface BreadcrumbSegment {
   name: string;
@@ -26,7 +40,7 @@ interface BreadcrumbSegment {
 
 /**
  * Custom route name mappings for paths not in navigation config
- * or for dynamic route segments
+ * or for dynamic route segments. Preserved for the legacy (flag-off) path.
  */
 const customRouteNames: Record<string, string> = {
   create: "Create",
@@ -42,9 +56,9 @@ const customRouteNames: Record<string, string> = {
 };
 
 /**
- * Get display name for a route segment
+ * Get display name for a route segment (legacy path only).
  */
-function getSegmentName(segment: string, fullPath: string): string {
+function getLegacySegmentName(segment: string, fullPath: string): string {
   // Check if full path matches a navigation item
   const navItem = navigationItems.find(item => item.path === fullPath);
   if (navItem) {
@@ -68,10 +82,10 @@ function getSegmentName(segment: string, fullPath: string): string {
 }
 
 /**
- * Build breadcrumb segments from current path
+ * Legacy (flag-off) breadcrumb builder, preserved 1:1 from the pre-TER-1297
+ * implementation so we can safely roll the flag back.
  */
-function buildBreadcrumbs(pathname: string): BreadcrumbSegment[] {
-  // Don't show breadcrumbs on home page
+function buildLegacyBreadcrumbs(pathname: string): BreadcrumbSegment[] {
   if (pathname === "/") {
     return [];
   }
@@ -86,13 +100,151 @@ function buildBreadcrumbs(pathname: string): BreadcrumbSegment[] {
     const isLast = index === segments.length - 1;
 
     breadcrumbs.push({
-      name: getSegmentName(segment, currentPath),
+      name: getLegacySegmentName(segment, currentPath),
       path: currentPath,
       isLast,
     });
   });
 
   return breadcrumbs;
+}
+
+/**
+ * Attempt to resolve a single entity id to a human-friendly display name.
+ *
+ * Important: all of the tRPC `useQuery` hooks below are mounted on every
+ * render to keep hook order stable, but only the one matching `entityType`
+ * has `enabled: true`. The rest are inert. This keeps the breadcrumb free
+ * from network chatter when there is no entity segment in the current path.
+ */
+function useResolvedEntityLabel(
+  entityType: RouteEntityType | undefined,
+  rawEntityId: string | undefined
+): string | null {
+  const numericId =
+    rawEntityId !== undefined ? Number.parseInt(rawEntityId, 10) : Number.NaN;
+  const hasValidId = Number.isFinite(numericId) && numericId > 0;
+  const queryId = hasValidId ? numericId : 0;
+
+  const clientQuery = trpc.clients.getById.useQuery(
+    { clientId: queryId },
+    {
+      enabled:
+        hasValidId && (entityType === "client" || entityType === "supplier"),
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }
+  );
+  const orderQuery = trpc.orders.getById.useQuery(
+    { id: queryId },
+    {
+      enabled: hasValidId && entityType === "order",
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }
+  );
+  const invoiceQuery = trpc.accounting.invoices.getById.useQuery(
+    { id: queryId },
+    {
+      enabled: hasValidId && entityType === "invoice",
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }
+  );
+  const billQuery = trpc.accounting.bills.getById.useQuery(
+    { id: queryId },
+    {
+      enabled: hasValidId && entityType === "bill",
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }
+  );
+  const productQuery = trpc.productCatalogue.getById.useQuery(
+    { id: queryId },
+    {
+      enabled: hasValidId && entityType === "product",
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }
+  );
+
+  if (!entityType || !hasValidId) return null;
+
+  switch (entityType) {
+    case "client":
+    case "supplier": {
+      const name = clientQuery.data?.name;
+      return typeof name === "string" && name.length > 0 ? name : null;
+    }
+    case "order": {
+      const orderNumber = orderQuery.data?.orderNumber;
+      return typeof orderNumber === "string" && orderNumber.length > 0
+        ? orderNumber
+        : null;
+    }
+    case "invoice": {
+      const invoiceData = invoiceQuery.data as
+        | { invoiceNumber?: string | null }
+        | null
+        | undefined;
+      const invoiceNumber = invoiceData?.invoiceNumber;
+      return typeof invoiceNumber === "string" && invoiceNumber.length > 0
+        ? invoiceNumber
+        : null;
+    }
+    case "bill": {
+      const billData = billQuery.data as
+        | { billNumber?: string | null }
+        | null
+        | undefined;
+      const billNumber = billData?.billNumber;
+      return typeof billNumber === "string" && billNumber.length > 0
+        ? billNumber
+        : null;
+    }
+    case "product": {
+      const productData = productQuery.data as
+        | { nameCanonical?: string | null }
+        | null
+        | undefined;
+      const productName = productData?.nameCanonical;
+      return typeof productName === "string" && productName.length > 0
+        ? productName
+        : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map a registry-derived trail to the flat `BreadcrumbSegment[]` used by the
+ * renderer. Applies the resolved label (if any) to the deepest entity-bearing
+ * crumb and falls back to `<title> #<id>` for other (or unresolved) segments.
+ */
+function trailToSegments(
+  trail: readonly BreadcrumbTrailEntry[],
+  resolvedFor: BreadcrumbTrailEntry | undefined,
+  resolvedLabel: string | null
+): BreadcrumbSegment[] {
+  return trail.map(crumb => {
+    if (
+      resolvedFor &&
+      resolvedLabel &&
+      crumb.path === resolvedFor.path &&
+      crumb.entityType === resolvedFor.entityType
+    ) {
+      return { name: resolvedLabel, path: crumb.path, isLast: crumb.isLast };
+    }
+    if (crumb.entityType && crumb.entityId) {
+      return {
+        name: `${crumb.title} #${crumb.entityId}`,
+        path: crumb.path,
+        isLast: crumb.isLast,
+      };
+    }
+    return { name: crumb.title, path: crumb.path, isLast: crumb.isLast };
+  });
 }
 
 interface AppBreadcrumbProps {
@@ -107,15 +259,38 @@ export const AppBreadcrumb = React.memo(function AppBreadcrumb({
   className,
 }: AppBreadcrumbProps) {
   const [location] = useLocation();
+  const { enabled: registryEnabled } = useFeatureFlag(
+    FEATURE_FLAGS.uxV2BreadcrumbRegistry
+  );
 
-  // Use custom breadcrumbs if provided, otherwise generate from path
-  const breadcrumbs = customBreadcrumbs
+  // Derive the registry-backed trail (only used when the flag is on).
+  const trail = React.useMemo<BreadcrumbTrailEntry[]>(() => {
+    if (!registryEnabled || customBreadcrumbs) return [];
+    return buildBreadcrumbTrail(location);
+  }, [registryEnabled, customBreadcrumbs, location]);
+
+  // Resolve the shallowest entity-bearing crumb so parents like
+  // `/clients/:id/ledger` still show the client name at the intermediate
+  // crumb rather than a raw id.
+  const resolvableEntry = React.useMemo(
+    () => trail.find(t => Boolean(t.entityType && t.entityId)),
+    [trail]
+  );
+  const resolvedLabel = useResolvedEntityLabel(
+    resolvableEntry?.entityType,
+    resolvableEntry?.entityId
+  );
+
+  // Compose the breadcrumb list for rendering.
+  const breadcrumbs: BreadcrumbSegment[] = customBreadcrumbs
     ? customBreadcrumbs.map((crumb, index) => ({
         name: crumb.name,
         path: crumb.path || "",
         isLast: index === customBreadcrumbs.length - 1,
       }))
-    : buildBreadcrumbs(location);
+    : registryEnabled
+      ? trailToSegments(trail, resolvableEntry, resolvedLabel)
+      : buildLegacyBreadcrumbs(location);
 
   // Don't render if no breadcrumbs (home page)
   if (breadcrumbs.length === 0) {

--- a/client/src/config/routes.test.ts
+++ b/client/src/config/routes.test.ts
@@ -1,0 +1,155 @@
+/**
+ * TER-1297 — Unit tests for the breadcrumb route registry.
+ *
+ * These tests exercise `matchRoute` and `buildBreadcrumbTrail` directly so we
+ * can prove:
+ *  - Static patterns resolve to their titles (e.g. `/accounting/invoices`).
+ *  - Dynamic patterns capture ids and surface the entity type + id.
+ *  - Unknown segments fall back to the navigation items / humanised form.
+ *  - The TER-1297 acceptance criteria (ClientProfile P0, OrderCreator UX-4)
+ *    are satisfied by the trail output.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { matchRoute, buildBreadcrumbTrail } from "./routes";
+
+describe("matchRoute", () => {
+  it("matches static routes and returns no params", () => {
+    const match = matchRoute("/accounting/invoices");
+    expect(match?.entry.pattern).toBe("/accounting/invoices");
+    expect(match?.entry.title).toBe("Invoices");
+    expect(match?.params).toEqual({});
+  });
+
+  it("returns null for unknown paths", () => {
+    expect(matchRoute("/this/does/not/exist")).toBeNull();
+  });
+
+  it("ignores query strings and fragments", () => {
+    const match = matchRoute("/clients?tab=active");
+    expect(match?.entry.pattern).toBe("/clients");
+  });
+
+  it("matches dynamic client detail routes and captures :id", () => {
+    const match = matchRoute("/clients/123");
+    expect(match?.entry.pattern).toBe("/clients/:id");
+    expect(match?.entry.entityType).toBe("client");
+    expect(match?.params.id).toBe("123");
+  });
+
+  it("matches nested dynamic client ledger routes with :clientId", () => {
+    const match = matchRoute("/clients/42/ledger");
+    expect(match?.entry.pattern).toBe("/clients/:clientId/ledger");
+    expect(match?.entry.entityType).toBe("client");
+    expect(match?.params.clientId).toBe("42");
+  });
+
+  it("strips trailing slashes before matching", () => {
+    const match = matchRoute("/orders/");
+    expect(match?.entry.pattern).toBe("/orders");
+  });
+});
+
+describe("buildBreadcrumbTrail", () => {
+  it("returns an empty trail for the root path", () => {
+    expect(buildBreadcrumbTrail("/")).toEqual([]);
+  });
+
+  it("derives static titles from the registry", () => {
+    const trail = buildBreadcrumbTrail("/accounting/invoices");
+    expect(trail.map(t => t.title)).toEqual(["Accounting", "Invoices"]);
+    expect(trail.at(-1)?.isLast).toBe(true);
+  });
+
+  it("marks dynamic client detail pages with an entityType and entityId (P0 fix)", () => {
+    // UX-2 P0: ClientProfilePage must show the client's context in the
+    // breadcrumb so users know which client they are on.
+    const trail = buildBreadcrumbTrail("/clients/123");
+    expect(trail).toHaveLength(2);
+    expect(trail[0]).toMatchObject({
+      path: "/clients",
+      title: "Clients",
+      isLast: false,
+    });
+    expect(trail[1]).toMatchObject({
+      path: "/clients/123",
+      title: "Client",
+      entityType: "client",
+      entityId: "123",
+      isLast: true,
+    });
+  });
+
+  it("resolves intermediate client context in nested routes", () => {
+    const trail = buildBreadcrumbTrail("/clients/42/ledger");
+    expect(trail).toHaveLength(3);
+    // The `/clients/:clientId/ledger` pattern is registered with an entity
+    // type so the deepest crumb still carries the id — but the intermediate
+    // `/clients/42` crumb is *also* matched against the `/clients/:id`
+    // pattern and carries the entity id, which is what we want for labeling.
+    expect(trail[1].entityType).toBe("client");
+    expect(trail[1].entityId).toBe("42");
+    expect(trail[2]).toMatchObject({
+      path: "/clients/42/ledger",
+      title: "Ledger",
+      isLast: true,
+    });
+  });
+
+  it("renders the Order Creator page as 'New Order' (UX-4)", () => {
+    // UX-4: breadcrumb shows "New Order" not "Sales" for /sales/new.
+    const trail = buildBreadcrumbTrail("/sales/new");
+    expect(trail.map(t => t.title)).toEqual(["Sales", "New Order"]);
+    expect(trail[1].entityType).toBeUndefined();
+  });
+
+  it("covers the minimum detail-entity routes required by TER-1297", () => {
+    expect(buildBreadcrumbTrail("/orders/5").at(-1)).toMatchObject({
+      entityType: "order",
+      entityId: "5",
+      title: "Order",
+    });
+    expect(buildBreadcrumbTrail("/invoices/7").at(-1)).toMatchObject({
+      entityType: "invoice",
+      entityId: "7",
+      title: "Invoice",
+    });
+    expect(buildBreadcrumbTrail("/bills/9").at(-1)).toMatchObject({
+      entityType: "bill",
+      entityId: "9",
+      title: "Bill",
+    });
+    expect(buildBreadcrumbTrail("/products/11").at(-1)).toMatchObject({
+      entityType: "product",
+      entityId: "11",
+      title: "Product",
+    });
+    expect(
+      buildBreadcrumbTrail("/accounting/invoices/21").at(-1)
+    ).toMatchObject({
+      entityType: "invoice",
+      entityId: "21",
+      title: "Invoice",
+    });
+    expect(buildBreadcrumbTrail("/accounting/bills/33").at(-1)).toMatchObject({
+      entityType: "bill",
+      entityId: "33",
+      title: "Bill",
+    });
+  });
+
+  it("humanises unknown segments as a last resort", () => {
+    const trail = buildBreadcrumbTrail("/made-up-route/sub-page");
+    expect(trail[0].title).toBe("Made Up Route");
+    expect(trail[1].title).toBe("Sub Page");
+    // Unknown segments must not carry an entity type.
+    expect(trail[0].entityType).toBeUndefined();
+    expect(trail[1].entityType).toBeUndefined();
+  });
+
+  it("formats numeric unknown segments as #<id> to keep the legacy contract", () => {
+    const trail = buildBreadcrumbTrail("/made-up-route/99");
+    expect(trail[1].title).toBe("#99");
+  });
+});

--- a/client/src/config/routes.ts
+++ b/client/src/config/routes.ts
@@ -1,0 +1,349 @@
+/**
+ * Route Registry (TER-1297)
+ *
+ * Central pattern → title map used by `AppBreadcrumb` to generate breadcrumb
+ * labels from the current URL without each feature having to register custom
+ * breadcrumb props. Dynamic detail routes (e.g. `/clients/:id`) additionally
+ * declare an `entityType` so the breadcrumb component can asynchronously
+ * resolve a human-friendly name (client name, order number, etc.) via tRPC.
+ *
+ * Design notes:
+ * - Patterns use Wouter's `:param` syntax to match existing routes in
+ *   `client/src/App.tsx` 1-for-1.
+ * - Entries are consulted in insertion order. Keep specific patterns (e.g.
+ *   `/sales/new`) above their generic siblings (e.g. `/sales`) — although the
+ *   walker in `buildBreadcrumbTrail` only calls `matchRoute` on
+ *   path-prefix-by-prefix, so ordering rarely matters.
+ * - Titles are intentionally short (1–3 words) because they render inside a
+ *   compact header breadcrumb bar.
+ *
+ * Related:
+ * - `AppBreadcrumb.tsx` consumes this registry behind the
+ *   `ux.v2.breadcrumb-registry` feature flag.
+ * - `navigation.ts` remains the source of truth for sidebar + command palette
+ *   entries; this file exists specifically for breadcrumb titling.
+ */
+
+import { navigationItems } from "./navigation";
+
+/** Entity types supported by the breadcrumb resolver. */
+export type RouteEntityType =
+  | "client"
+  | "order"
+  | "invoice"
+  | "bill"
+  | "product"
+  | "supplier";
+
+/** A single entry in the route registry. */
+export interface RouteRegistryEntry {
+  /** Wouter-style path pattern, e.g. "/clients/:id". */
+  pattern: string;
+  /** Display title for this exact path. */
+  title: string;
+  /**
+   * Optional entity type. When set, `AppBreadcrumb` will try to resolve the
+   * breadcrumb label to a human-friendly name (e.g. client name) using the
+   * id extracted from the matching `idParam` (default `"id"`).
+   */
+  entityType?: RouteEntityType;
+  /** Param name that holds the entity id. Defaults to `"id"`. */
+  idParam?: string;
+}
+
+/**
+ * The registry. Keep entries grouped by feature for readability.
+ */
+export const routeRegistry: readonly RouteRegistryEntry[] = [
+  // ── Dashboard / home ─────────────────────────────────────────────────────
+  { pattern: "/", title: "Dashboard" },
+  { pattern: "/dashboard", title: "Dashboard" },
+
+  // ── Sales ────────────────────────────────────────────────────────────────
+  { pattern: "/sales", title: "Sales" },
+  { pattern: "/sales/new", title: "New Order" },
+  { pattern: "/sales-sheets", title: "Sales Sheets" },
+  { pattern: "/sales-sheet", title: "Sales Sheet" },
+  { pattern: "/sales-portal", title: "Sales Portal" },
+  { pattern: "/sell", title: "Sell" },
+  { pattern: "/sell/orders", title: "Orders" },
+
+  // ── Orders ───────────────────────────────────────────────────────────────
+  { pattern: "/orders", title: "Orders" },
+  { pattern: "/orders/new", title: "New Order" },
+  { pattern: "/orders/create", title: "New Order" },
+  { pattern: "/orders/:id", title: "Order", entityType: "order" },
+  { pattern: "/quotes", title: "Quotes" },
+
+  // ── Clients / relationships ──────────────────────────────────────────────
+  { pattern: "/relationships", title: "Relationships" },
+  { pattern: "/clients", title: "Clients" },
+  { pattern: "/clients/:id", title: "Client", entityType: "client" },
+  {
+    pattern: "/clients/:clientId/ledger",
+    title: "Ledger",
+    entityType: "client",
+    idParam: "clientId",
+  },
+  {
+    pattern: "/clients/:clientId/vip-portal-config",
+    title: "VIP Portal",
+    entityType: "client",
+    idParam: "clientId",
+  },
+  { pattern: "/client-ledger", title: "Client Ledger" },
+  { pattern: "/client-needs", title: "Client Needs" },
+  { pattern: "/suppliers", title: "Suppliers" },
+  { pattern: "/vendors", title: "Suppliers" },
+  {
+    pattern: "/vendors/:id",
+    title: "Supplier",
+    entityType: "supplier",
+  },
+
+  // ── Inventory / products / purchasing ────────────────────────────────────
+  { pattern: "/inventory", title: "Inventory" },
+  { pattern: "/inventory/:id", title: "Item" },
+  { pattern: "/inventory-browse", title: "Inventory" },
+  { pattern: "/operations", title: "Operations" },
+  { pattern: "/products", title: "Products" },
+  { pattern: "/products/:id", title: "Product", entityType: "product" },
+  { pattern: "/strains", title: "Strains" },
+  { pattern: "/strains/new", title: "New Strain" },
+  { pattern: "/strains/:id", title: "Strain" },
+  { pattern: "/admin/strains", title: "Strain Admin" },
+  { pattern: "/product-intake", title: "Product Intake" },
+  { pattern: "/purchase-orders", title: "Purchase Orders" },
+  { pattern: "/purchase-orders/classic", title: "Classic" },
+  { pattern: "/procurement", title: "Procurement" },
+  { pattern: "/pick-pack", title: "Pick & Pack" },
+  { pattern: "/warehouse/pick-pack", title: "Pick & Pack" },
+  { pattern: "/photography", title: "Photography" },
+  { pattern: "/receiving", title: "Receiving" },
+  { pattern: "/intake", title: "Intake" },
+  { pattern: "/direct-intake", title: "Direct Intake" },
+  { pattern: "/intake-receipts", title: "Intake Receipts" },
+  { pattern: "/returns", title: "Returns" },
+  { pattern: "/samples", title: "Samples" },
+  { pattern: "/locations", title: "Locations" },
+  { pattern: "/matchmaking", title: "Matchmaking" },
+  { pattern: "/live-shopping", title: "Live Shopping" },
+  { pattern: "/demand-supply", title: "Demand & Supply" },
+  { pattern: "/vendor-supply", title: "Vendor Supply" },
+  { pattern: "/needs", title: "Needs" },
+  { pattern: "/interest-list", title: "Interest List" },
+
+  // ── Accounting / finance ─────────────────────────────────────────────────
+  { pattern: "/accounting", title: "Accounting" },
+  { pattern: "/accounting/dashboard", title: "Dashboard" },
+  { pattern: "/accounting/invoices", title: "Invoices" },
+  {
+    pattern: "/accounting/invoices/:id",
+    title: "Invoice",
+    entityType: "invoice",
+  },
+  { pattern: "/accounting/bills", title: "Bills" },
+  {
+    pattern: "/accounting/bills/:id",
+    title: "Bill",
+    entityType: "bill",
+  },
+  { pattern: "/accounting/payments", title: "Payments" },
+  { pattern: "/accounting/general-ledger", title: "General Ledger" },
+  { pattern: "/accounting/chart-of-accounts", title: "Chart of Accounts" },
+  { pattern: "/accounting/expenses", title: "Expenses" },
+  { pattern: "/accounting/bank-accounts", title: "Bank Accounts" },
+  { pattern: "/accounting/bank-transactions", title: "Bank Transactions" },
+  { pattern: "/accounting/fiscal-periods", title: "Fiscal Periods" },
+  { pattern: "/accounting/cash-locations", title: "Cash Locations" },
+  { pattern: "/invoices", title: "Invoices" },
+  { pattern: "/invoices/:id", title: "Invoice", entityType: "invoice" },
+  { pattern: "/bills", title: "Bills" },
+  { pattern: "/bills/:id", title: "Bill", entityType: "bill" },
+  { pattern: "/payments", title: "Payments" },
+  { pattern: "/ar-ap", title: "AR / AP" },
+  { pattern: "/accounts-receivable", title: "Accounts Receivable" },
+  { pattern: "/credits", title: "Credits" },
+  { pattern: "/credits/manage", title: "Manage Credits" },
+  { pattern: "/credit-settings", title: "Credit Settings" },
+  { pattern: "/analytics", title: "Analytics" },
+  { pattern: "/reports", title: "Reports" },
+  { pattern: "/reports/shrinkage", title: "Shrinkage" },
+  { pattern: "/leaderboard", title: "Leaderboard" },
+  { pattern: "/pricing/rules", title: "Pricing Rules" },
+  { pattern: "/pricing/profiles", title: "Pricing Profiles" },
+  { pattern: "/pricing-rules", title: "Pricing Rules" },
+
+  // ── Admin / settings ─────────────────────────────────────────────────────
+  { pattern: "/settings", title: "Settings" },
+  { pattern: "/settings/cogs", title: "COGS" },
+  { pattern: "/settings/notifications", title: "Notifications" },
+  { pattern: "/settings/display", title: "Display" },
+  { pattern: "/settings/feature-flags", title: "Feature Flags" },
+  { pattern: "/system-settings", title: "System Settings" },
+  { pattern: "/feature-flags", title: "Feature Flags" },
+  { pattern: "/users", title: "Users" },
+  { pattern: "/admin", title: "Admin" },
+  { pattern: "/admin/users", title: "Users" },
+  { pattern: "/admin/roles/new", title: "New Role" },
+  { pattern: "/admin/metrics", title: "System Metrics" },
+  { pattern: "/account", title: "Account" },
+
+  // ── Workflow / calendar / tasks ──────────────────────────────────────────
+  { pattern: "/calendar", title: "Calendar" },
+  { pattern: "/calendar/invitations", title: "Invitations" },
+  { pattern: "/scheduling", title: "Scheduling" },
+  { pattern: "/time-clock", title: "Time Clock" },
+  { pattern: "/todo", title: "Todo" },
+  { pattern: "/todos", title: "Todo Lists" },
+  { pattern: "/todos/:listId", title: "List" },
+  { pattern: "/todo-lists", title: "Todo Lists" },
+  { pattern: "/notifications", title: "Notifications" },
+  { pattern: "/inbox", title: "Inbox" },
+  { pattern: "/alerts", title: "Alerts" },
+  { pattern: "/workflow-queue", title: "Workflow Queue" },
+  { pattern: "/search", title: "Search" },
+  { pattern: "/help", title: "Help" },
+  { pattern: "/spreadsheet-view", title: "Spreadsheet View" },
+];
+
+/** Result of a successful registry match. */
+export interface RouteMatch {
+  entry: RouteRegistryEntry;
+  /** Extracted path params, keyed by param name (without the leading colon). */
+  params: Record<string, string>;
+}
+
+interface CompiledRoute {
+  entry: RouteRegistryEntry;
+  regexp: RegExp;
+  paramNames: string[];
+}
+
+/**
+ * Escape a literal path segment for use inside a RegExp. Kept as a standalone
+ * helper so it can be unit-tested if needed.
+ */
+function escapeRegExpLiteral(segment: string): string {
+  return segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileRoute(entry: RouteRegistryEntry): CompiledRoute {
+  const paramNames: string[] = [];
+  const segments = entry.pattern.split("/").map(seg => {
+    if (seg.startsWith(":")) {
+      paramNames.push(seg.slice(1));
+      return "([^/]+)";
+    }
+    return escapeRegExpLiteral(seg);
+  });
+  return {
+    entry,
+    regexp: new RegExp(`^${segments.join("/")}$`),
+    paramNames,
+  };
+}
+
+// Compile all registered routes once at module load so per-render matching is
+// cheap (just array iteration + regex exec).
+const compiledRoutes: readonly CompiledRoute[] = routeRegistry.map(compileRoute);
+
+/**
+ * Normalise a pathname before matching. Strips any trailing slash except for
+ * the root `/`, and strips query/hash fragments.
+ */
+function normalisePathname(pathname: string): string {
+  const withoutQuery = pathname.split(/[?#]/, 1)[0] ?? "";
+  if (withoutQuery.length > 1 && withoutQuery.endsWith("/")) {
+    return withoutQuery.slice(0, -1);
+  }
+  return withoutQuery || "/";
+}
+
+/**
+ * Look up a pathname in the registry. Returns the first matching entry (with
+ * extracted params) or `null` if no pattern matches.
+ */
+export function matchRoute(pathname: string): RouteMatch | null {
+  const normalised = normalisePathname(pathname);
+  for (const compiled of compiledRoutes) {
+    const match = compiled.regexp.exec(normalised);
+    if (!match) continue;
+    const params: Record<string, string> = {};
+    compiled.paramNames.forEach((name, i) => {
+      // match[0] is the full match; params start at index 1.
+      const value = match[i + 1];
+      if (value !== undefined) {
+        params[name] = value;
+      }
+    });
+    return { entry: compiled.entry, params };
+  }
+  return null;
+}
+
+/** A single breadcrumb crumb derived from the path + registry. */
+export interface BreadcrumbTrailEntry {
+  /** Concrete href for this crumb (cumulative path prefix). */
+  path: string;
+  /** Resolved title to render for this crumb. */
+  title: string;
+  /** Entity type (carried through from the registry) for async resolution. */
+  entityType?: RouteEntityType;
+  /** Raw id extracted from path params, when the matched entry has one. */
+  entityId?: string;
+  /** True for the deepest crumb in the trail. */
+  isLast: boolean;
+}
+
+function humaniseSegment(segment: string): string {
+  if (/^\d+$/.test(segment)) return `#${segment}`;
+  return segment
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+/**
+ * Walk a pathname one segment at a time and return a breadcrumb trail whose
+ * titles come from the registry where possible, falling back to navigation
+ * items and then to a humanised version of the raw segment.
+ *
+ * Returns `[]` for the root path to signal "do not render a breadcrumb".
+ */
+export function buildBreadcrumbTrail(pathname: string): BreadcrumbTrailEntry[] {
+  const normalised = normalisePathname(pathname);
+  if (normalised === "/" || normalised === "") return [];
+
+  const segments = normalised.split("/").filter(Boolean);
+  const trail: BreadcrumbTrailEntry[] = [];
+
+  let accumulated = "";
+  segments.forEach((segment, index) => {
+    accumulated += `/${segment}`;
+    const isLast = index === segments.length - 1;
+    const match = matchRoute(accumulated);
+
+    if (match) {
+      const entityIdParam = match.entry.idParam ?? "id";
+      const entityId =
+        match.entry.entityType && match.params[entityIdParam]
+          ? match.params[entityIdParam]
+          : undefined;
+      trail.push({
+        path: accumulated,
+        title: match.entry.title,
+        entityType: match.entry.entityType,
+        entityId,
+        isLast,
+      });
+      return;
+    }
+
+    // Fallbacks: navigation items (exact path), then humanised segment.
+    const navItem = navigationItems.find(item => item.path === accumulated);
+    const title = navItem?.name ?? humaniseSegment(segment);
+    trail.push({ path: accumulated, title, isLast });
+  });
+
+  return trail;
+}

--- a/client/src/lib/constants/featureFlags.ts
+++ b/client/src/lib/constants/featureFlags.ts
@@ -6,6 +6,19 @@ export const FEATURE_FLAGS = {
    */
   uxV2States: "ux.v2.states",
   /**
+   * UX v2 grid numeric defaults.
+   *
+   * When enabled, `SpreadsheetPilotGrid` auto-applies right-alignment,
+   * tabular-nums styling, and locale-aware value formatters to column
+   * definitions whose `cellDataType` is "currency", "number", or "percent".
+   * Explicit `cellClass` / `valueFormatter` overrides on a ColDef are
+   * preserved (no clobbering).
+   *
+   * See: docs/ux-review/02-Implementation_Strategy.md §4.2
+   * Linear: TER-1285
+   */
+  uxV2Grid: "ux.v2.grid",
+  /**
    * TER-1297: Enables the central route registry backing `<AppBreadcrumb>`.
    *
    * When enabled, the breadcrumb derives its segment titles from

--- a/client/src/lib/constants/featureFlags.ts
+++ b/client/src/lib/constants/featureFlags.ts
@@ -6,16 +6,16 @@ export const FEATURE_FLAGS = {
    */
   uxV2States: "ux.v2.states",
   /**
-   * UX v2 grid numeric defaults.
+   * TER-1297: Enables the central route registry backing `<AppBreadcrumb>`.
    *
-   * When enabled, `SpreadsheetPilotGrid` auto-applies right-alignment,
-   * tabular-nums styling, and locale-aware value formatters to column
-   * definitions whose `cellDataType` is "currency", "number", or "percent".
-   * Explicit `cellClass` / `valueFormatter` overrides on a ColDef are
-   * preserved (no clobbering).
-   *
-   * See: docs/ux-review/02-Implementation_Strategy.md §4.2
-   * Linear: TER-1285
+   * When enabled, the breadcrumb derives its segment titles from
+   * `client/src/config/routes.ts` and asynchronously resolves dynamic id
+   * segments (e.g. `/clients/:id`) to human-friendly names via tRPC. When
+   * disabled the component falls back to the legacy `navigationItems` +
+   * `customRouteNames` lookup. Default when absent from the server
+   * response: **disabled** (safe default).
    */
-  uxV2Grid: "ux.v2.grid",
+  uxV2BreadcrumbRegistry: "ux.v2.breadcrumb-registry",
 } as const;
+
+export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/docs/sessions/active/TER-1297-session.md
+++ b/docs/sessions/active/TER-1297-session.md
@@ -1,0 +1,7 @@
+# TER-1297 Agent Session
+
+- **Ticket:** TER-1297
+- **Branch:** `feat/ter-1297-app-breadcrumb-routes`
+- **Status:** In Progress
+- **Started:** 2026-04-23T19:00:38Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

TER-1297 (Epic TER-1283 · UX v2 wave). Introduces a central pattern → title route registry (`client/src/config/routes.ts`) that backs `<AppBreadcrumb>`, gated behind the new `ux.v2.breadcrumb-registry` feature flag. Dynamic detail routes carry an `entityType` so the breadcrumb asynchronously resolves the id to a human-friendly name (client name, order number, invoice number, bill number, product name) via tRPC, falling back to the raw id when resolution fails or the flag is off. The legacy `navigationItems` + `customRouteNames` path is preserved 1:1 for safe rollback.

Source: `docs/ux-review/02-Implementation_Strategy.md` §4.10

## Closes

- **ClientProfilePage UX-2 (P0)** — client identity is now rendered in the breadcrumb for `/clients/:id`, so users always see which client they are on. The name is resolved via `trpc.clients.getById` and gracefully falls back to `Client #<id>` if the lookup fails.
- **OrderCreatorPage UX-4** — `/sales/new` now reads **`New Order`** in the breadcrumb instead of the legacy `Sales > New`.
- Two additional findings via the registry's general pattern coverage (nested `/clients/:id/ledger`, supplier detail page, and the other entity detail pages have consistent labels).

## Scope

| File | Change |
|------|--------|
| `client/src/config/routes.ts` | **New** — registry + `matchRoute` / `buildBreadcrumbTrail` helpers |
| `client/src/config/routes.test.ts` | **New** — 14 unit tests covering matcher + trail behaviour |
| `client/src/components/layout/AppBreadcrumb.tsx` | Reads from the registry behind the feature flag; unchanged when flag is off |
| `client/src/lib/constants/featureFlags.ts` | Adds `uxV2BreadcrumbRegistry: \"ux.v2.breadcrumb-registry\"` |

Minimum entity-detail routes covered (per TER-1297): `/clients/:id`, `/orders/:id`, `/invoices/:id`, `/accounting/invoices/:id`, `/bills/:id`, `/accounting/bills/:id`, `/products/:id`, `/vendors/:id` (plus a broad set of static routes — sales, accounting, inventory, settings, calendar, etc.).

## Feature flag

`ux.v2.breadcrumb-registry` — **default OFF**. When disabled, `<AppBreadcrumb>` uses the legacy segment-name lookup. Flip the flag in the admin UI to roll out.

## Verification

- `pnpm check` passes (TypeScript zero-errors).
- `pnpm lint` on changed files passes with no new errors. The 29 pre-existing project-wide lint errors are unrelated and predate this branch.
- `pnpm vitest run client/src/config/routes.test.ts` — **14/14 passing**.
- Registry trail is verified against the TER-1297 acceptance criteria:
  - `/clients/123` → `Home > Clients > Client` (resolved to the client's name)
  - `/clients/42/ledger` → `Home > Clients > Client > Ledger` (intermediate client context)
  - `/sales/new` → `Home > Sales > New Order`
  - `/orders/5`, `/invoices/7`, `/bills/9`, `/products/11` all carry the correct entityType + id for resolution.

## Risk

LOW. All new behaviour is gated behind `ux.v2.breadcrumb-registry` (default off). Legacy breadcrumb output is byte-identical when the flag is off because the original `buildBreadcrumbs` logic was preserved verbatim as `buildLegacyBreadcrumbs`.
