### PR TITLE
feat(ux-v2): WorkspaceFilterBar slot + useWorkspaceFilter hook [TER-1310]

### DIFF
--- a/client/src/components/feature-flags/uxV2Flags.ts
+++ b/client/src/components/feature-flags/uxV2Flags.ts
@@ -3,7 +3,7 @@
  *
  * Centralized registry of feature-flag keys that gate the "Manus" UX v2 wave.
  * All UX v2 primitives (ManusSheet, Manus breadcrumbs, etc.) read flags via
- * `useFeatureFlag(UX_V2_FLAGS.DRAWER)` so that rollout can be staged per
+ * `useFeatureFlag(UX_V2_FLAGS.XXX)` so that rollout can be staged per
  * surface in the feature-flags admin UI without code changes.
  *
  * Flag semantics:
@@ -24,6 +24,11 @@
  *   (TER-1305). When disabled, the shell falls back to the single flat
  *   `tabs` rail so deep links keep working unchanged. Default when flag is
  *   absent from the server response: **disabled** (safe default).
+ * - `ux.v2.filter-bar` — Enables the standardized `WorkspaceFilterBar` slot
+ *   on `LinearWorkspaceShell` (TER-1310) plus the `useWorkspaceFilter()`
+ *   URL-state hook. When disabled, surfaces should continue to render their
+ *   own ad-hoc filter bars. Default when flag is absent from the server
+ *   response: **disabled** (safe default).
  *
  * Add new UX v2 flags to `UX_V2_FLAGS` below; do NOT hard-code flag strings
  * at call sites.
@@ -45,6 +50,8 @@ export const UX_V2_FLAGS = {
    * rail when this flag is off even if `tabGroups` is present.
    */
   WORKSPACE_TABS: "ux.v2.workspace-tabs",
+  /** Workspace-level filter bar slot + useWorkspaceFilter hook (TER-1310). */
+  FILTER_BAR: "ux.v2.filter-bar",
 } as const;
 
 export type UxV2FlagKey = (typeof UX_V2_FLAGS)[keyof typeof UX_V2_FLAGS];

--- a/client/src/components/layout/LinearWorkspaceShell.tsx
+++ b/client/src/components/layout/LinearWorkspaceShell.tsx
@@ -44,6 +44,17 @@ interface LinearWorkspaceShellProps<T extends string> {
    */
   tabGroups?: readonly LinearWorkspaceTabGroup<T>[];
   commandStrip?: ReactNode;
+  /**
+   * Optional UX v2 standardized filter surface (TER-1310). Rendered
+   * immediately below the tab row / command strip when provided. Intended
+   * to host a `<WorkspaceFilterBar>` from
+   * `@/components/layout/WorkspaceFilterBar`, which in turn wraps filter
+   * inputs driven by `useWorkspaceFilter()`.
+   *
+   * Intentionally not rendered at all when absent, so surfaces that don't
+   * opt in see no additional whitespace.
+   */
+  filterStrip?: ReactNode;
   children: ReactNode;
   className?: string;
   density?: "default" | "compact";
@@ -88,6 +99,7 @@ export function LinearWorkspaceShell<T extends string>({
   onTabChange,
   tabGroups,
   commandStrip,
+  filterStrip,
   children,
   className,
   density = "default",
@@ -263,6 +275,14 @@ export function LinearWorkspaceShell<T extends string>({
               <div className="linear-workspace-command-strip">
                 {commandStrip}
               </div>
+            </div>
+          ) : null}
+          {filterStrip ? (
+            <div
+              className="linear-workspace-filter-row"
+              data-slot="linear-workspace-filter-row"
+            >
+              {filterStrip}
             </div>
           ) : null}
           {children}

--- a/client/src/components/layout/WorkspaceFilterBar.test.tsx
+++ b/client/src/components/layout/WorkspaceFilterBar.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for WorkspaceFilterBar + LinearWorkspaceShell filterStrip slot
+ * (TER-1310).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  LinearWorkspacePanel,
+  LinearWorkspaceShell,
+} from "./LinearWorkspaceShell";
+import { WorkspaceFilterBar } from "./WorkspaceFilterBar";
+
+describe("WorkspaceFilterBar", () => {
+  it("renders children inside a toolbar with default aria-label", () => {
+    render(
+      <WorkspaceFilterBar>
+        <button>Status</button>
+      </WorkspaceFilterBar>
+    );
+    const toolbar = screen.getByRole("toolbar", { name: "Filters" });
+    expect(toolbar).toBeInTheDocument();
+    expect(toolbar).toContainElement(
+      screen.getByRole("button", { name: "Status" })
+    );
+  });
+
+  it("honors a custom aria-label", () => {
+    render(
+      <WorkspaceFilterBar aria-label="Order filters">
+        <span>facet</span>
+      </WorkspaceFilterBar>
+    );
+    expect(
+      screen.getByRole("toolbar", { name: "Order filters" })
+    ).toBeInTheDocument();
+  });
+
+  it("carries the canonical `linear-workspace-filter-strip` class for shared chrome", () => {
+    render(
+      <WorkspaceFilterBar>
+        <span>facet</span>
+      </WorkspaceFilterBar>
+    );
+    const toolbar = screen.getByRole("toolbar");
+    expect(toolbar.className).toContain("linear-workspace-filter-strip");
+  });
+});
+
+describe("LinearWorkspaceShell filterStrip slot", () => {
+  it("does not render the filter row when filterStrip is absent", () => {
+    render(
+      <LinearWorkspaceShell
+        title="Orders"
+        activeTab="queue"
+        tabs={[
+          { value: "queue", label: "Queue" },
+          { value: "details", label: "Details" },
+        ]}
+        onTabChange={() => {}}
+      >
+        <LinearWorkspacePanel value="queue">
+          <div>Queue content</div>
+        </LinearWorkspacePanel>
+      </LinearWorkspaceShell>
+    );
+    expect(
+      document.querySelector(
+        "[data-slot='linear-workspace-filter-row']"
+      )
+    ).toBeNull();
+  });
+
+  it("renders the filter row below the tab row when filterStrip is provided", () => {
+    render(
+      <LinearWorkspaceShell
+        title="Orders"
+        activeTab="queue"
+        tabs={[
+          { value: "queue", label: "Queue" },
+          { value: "details", label: "Details" },
+        ]}
+        onTabChange={() => {}}
+        filterStrip={
+          <WorkspaceFilterBar aria-label="Order filters">
+            <button>Pending</button>
+          </WorkspaceFilterBar>
+        }
+      >
+        <LinearWorkspacePanel value="queue">
+          <div>Queue content</div>
+        </LinearWorkspacePanel>
+      </LinearWorkspaceShell>
+    );
+    const filterRow = document.querySelector(
+      "[data-slot='linear-workspace-filter-row']"
+    );
+    expect(filterRow).not.toBeNull();
+    expect(filterRow).toContainElement(
+      screen.getByRole("toolbar", { name: "Order filters" })
+    );
+    expect(filterRow).toContainElement(
+      screen.getByRole("button", { name: "Pending" })
+    );
+  });
+});

--- a/client/src/components/layout/WorkspaceFilterBar.tsx
+++ b/client/src/components/layout/WorkspaceFilterBar.tsx
@@ -1,0 +1,85 @@
+/**
+ * WorkspaceFilterBar — UX v2 standardized filter surface slot (TER-1310)
+ *
+ * A thin, styled container that is designed to be rendered in the
+ * `filterStrip` slot of `LinearWorkspaceShell`. It provides the consistent
+ * padding, border, and background that every workspace-level filter surface
+ * should share, so individual surfaces no longer declare their own ad-hoc
+ * filter bars.
+ *
+ * Callers supply the actual filter inputs (chips, search fields, dropdowns,
+ * etc.) as children. Actual filter state should be driven through
+ * `useWorkspaceFilter()` so that filters deep-link via URL search params.
+ *
+ * See: docs/ux-review/02-Implementation_Strategy.md §4.3
+ * Linear: TER-1310 (epic TER-1283)
+ *
+ * @example
+ * ```tsx
+ * import { WorkspaceFilterBar } from "@/components/layout/WorkspaceFilterBar";
+ * import { useWorkspaceFilter } from "@/hooks/useWorkspaceFilter";
+ *
+ * function OrdersShell() {
+ *   const { filter, setFilter } = useWorkspaceFilter();
+ *   return (
+ *     <LinearWorkspaceShell
+ *       title="Orders"
+ *       activeTab={tab}
+ *       tabs={tabs}
+ *       onTabChange={setTab}
+ *       filterStrip={
+ *         <WorkspaceFilterBar>
+ *           <StatusChips
+ *             value={filter.status ?? "all"}
+ *             onChange={next => setFilter({ status: next })}
+ *           />
+ *         </WorkspaceFilterBar>
+ *       }
+ *     >
+ *       {…}
+ *     </LinearWorkspaceShell>
+ *   );
+ * }
+ * ```
+ */
+
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface WorkspaceFilterBarProps {
+  /**
+   * Filter inputs to render inside the bar — chips, search fields, dropdowns,
+   * date range pickers, etc. The bar itself is unopinionated about the
+   * controls; it only provides the shared chrome.
+   */
+  children?: ReactNode;
+  /**
+   * Optional extra class names to merge with the default chrome. Prefer
+   * leaving this unset — the point of the primitive is shared styling.
+   */
+  className?: string;
+  /**
+   * Optional ARIA label. Defaults to "Filters" so assistive tech can
+   * distinguish the filter strip from the tab row above it.
+   */
+  "aria-label"?: string;
+}
+
+export function WorkspaceFilterBar({
+  children,
+  className,
+  "aria-label": ariaLabel = "Filters",
+}: WorkspaceFilterBarProps) {
+  return (
+    <div
+      role="toolbar"
+      aria-label={ariaLabel}
+      data-slot="workspace-filter-bar"
+      className={cn("linear-workspace-filter-strip", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default WorkspaceFilterBar;

--- a/client/src/hooks/useWorkspaceFilter.test.ts
+++ b/client/src/hooks/useWorkspaceFilter.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for useWorkspaceFilter (TER-1310).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWorkspaceFilter } from "./useWorkspaceFilter";
+
+let mockPath = "/orders";
+let mockSearch = "";
+const mockSetLocation = vi.fn();
+
+vi.mock("wouter", () => ({
+  useLocation: () => [mockPath, mockSetLocation],
+  useSearch: () => mockSearch,
+}));
+
+describe("useWorkspaceFilter", () => {
+  beforeEach(() => {
+    mockSetLocation.mockClear();
+    mockPath = "/orders";
+    mockSearch = "";
+  });
+
+  it("returns an empty filter when no filter params are present", () => {
+    const { result } = renderHook(() => useWorkspaceFilter());
+    expect(result.current.filter).toEqual({});
+  });
+
+  it("parses filter[key]=value pairs from the URL", () => {
+    // URLSearchParams encodes `[` / `]` as %5B / %5D when serialized; the
+    // browser also accepts the unencoded form in the address bar. We support
+    // both — the encoded form is what wouter forwards to us after navigation.
+    mockSearch = "?filter%5Bstatus%5D=pending&filter%5Bowner%5D=evan";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    expect(result.current.filter).toEqual({
+      status: "pending",
+      owner: "evan",
+    });
+  });
+
+  it("also parses unencoded filter[key]=value pairs (deep link from address bar)", () => {
+    mockSearch = "?filter[status]=pending";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    expect(result.current.filter).toEqual({ status: "pending" });
+  });
+
+  it("ignores non-filter params when reading", () => {
+    mockSearch = "?tab=quotes&filter%5Bstatus%5D=pending&page=2";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    expect(result.current.filter).toEqual({ status: "pending" });
+  });
+
+  it("sets a filter facet via setFilter()", () => {
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: "pending" });
+    });
+
+    expect(mockSetLocation).toHaveBeenCalledTimes(1);
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    expect(nextUrl.startsWith("/orders?")).toBe(true);
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.get("filter[status]")).toBe("pending");
+  });
+
+  it("preserves unrelated search params when setting a filter", () => {
+    mockSearch = "?tab=quotes&page=2";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: "pending" });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.get("tab")).toBe("quotes");
+    expect(nextParams.get("page")).toBe("2");
+    expect(nextParams.get("filter[status]")).toBe("pending");
+  });
+
+  it("removes a facet when set to empty string", () => {
+    mockSearch = "?filter%5Bstatus%5D=pending&filter%5Bowner%5D=evan";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: "" });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.has("filter[status]")).toBe(false);
+    expect(nextParams.get("filter[owner]")).toBe("evan");
+  });
+
+  it("removes a facet when set to null/undefined", () => {
+    mockSearch = "?filter%5Bstatus%5D=pending";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: null });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    expect(nextUrl).toBe("/orders");
+  });
+
+  it("clearFilter() removes every filter[*] param but keeps other params", () => {
+    mockSearch =
+      "?tab=quotes&filter%5Bstatus%5D=pending&filter%5Bowner%5D=evan&page=2";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.clearFilter();
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.has("filter[status]")).toBe(false);
+    expect(nextParams.has("filter[owner]")).toBe(false);
+    expect(nextParams.get("tab")).toBe("quotes");
+    expect(nextParams.get("page")).toBe("2");
+  });
+
+  it("emits a bare path (no trailing '?') when every param is removed", () => {
+    mockSearch = "?filter%5Bstatus%5D=pending";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.clearFilter();
+    });
+
+    expect(mockSetLocation).toHaveBeenCalledWith("/orders");
+  });
+
+  it("setFilter() can patch multiple facets at once", () => {
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: "pending", owner: "evan" });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.get("filter[status]")).toBe("pending");
+    expect(nextParams.get("filter[owner]")).toBe("evan");
+  });
+
+  it("setFilter() overwrites an existing facet value", () => {
+    mockSearch = "?filter%5Bstatus%5D=pending";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ status: "shipped" });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    const nextParams = new URLSearchParams(nextUrl.split("?")[1]);
+    expect(nextParams.get("filter[status]")).toBe("shipped");
+  });
+
+  it("strips any stale query-string off of the wouter location before rebuilding", () => {
+    mockPath = "/orders?stale=true";
+    mockSearch = "?filter%5Bstatus%5D=pending";
+
+    const { result } = renderHook(() => useWorkspaceFilter());
+
+    act(() => {
+      result.current.setFilter({ owner: "evan" });
+    });
+
+    const nextUrl = mockSetLocation.mock.calls[0][0] as string;
+    // Path portion must not include the stale `?stale=true` — we rebuild
+    // exclusively from the current `useSearch()` snapshot.
+    expect(nextUrl.split("?")[0]).toBe("/orders");
+    expect(nextUrl).not.toContain("stale=true");
+  });
+});

--- a/client/src/hooks/useWorkspaceFilter.ts
+++ b/client/src/hooks/useWorkspaceFilter.ts
@@ -1,0 +1,151 @@
+/**
+ * useWorkspaceFilter — UX v2 workspace filter URL state (TER-1310)
+ *
+ * Stores active workspace filter state in URL search params using the
+ * `filter[key]=value` bracket notation so that links are deep-linkable:
+ *
+ *   /orders?filter[status]=pending&filter[owner]=evan
+ *
+ * Returns the parsed filter as a flat `Record<string, string>` map — callers
+ * access individual filter facets via `filter["status"]`, `filter["owner"]`,
+ * etc. Setting a value to `""`, `null`, or `undefined` removes that facet
+ * from the URL. `clearFilter()` removes every `filter[*]` param in one shot
+ * without disturbing unrelated params (e.g. `tab`, `page`).
+ *
+ * Wouter is used for URL state — same pattern as `useQueryTabState` and
+ * `useTableUrlState` elsewhere in the codebase (TER-1212).
+ *
+ * Pair this with `<WorkspaceFilterBar>` (the container) rendered in the
+ * `filterStrip` slot of `LinearWorkspaceShell`.
+ *
+ * See: docs/ux-review/02-Implementation_Strategy.md §4.3
+ * Linear: TER-1310 (epic TER-1283)
+ *
+ * @example
+ * ```tsx
+ * const { filter, setFilter, clearFilter } = useWorkspaceFilter();
+ *
+ * // Read:
+ * const status = filter["status"] ?? "all";
+ *
+ * // Patch a single facet:
+ * setFilter({ status: "pending" });
+ *
+ * // Remove a facet:
+ * setFilter({ status: "" });
+ *
+ * // Clear every filter:
+ * clearFilter();
+ * ```
+ */
+
+import { useCallback, useMemo } from "react";
+import { useLocation, useSearch } from "wouter";
+
+/** Regex matching the `filter[<key>]` URL param convention. */
+const FILTER_PARAM_PATTERN = /^filter\[([^\]]+)\]$/;
+
+/** Build the canonical URL param name for a filter facet. */
+function filterParamKey(key: string): string {
+  return `filter[${key}]`;
+}
+
+/**
+ * Parsed filter map. Keys are facet names (e.g. "status", "owner"); values are
+ * the current string value for that facet. Facets with empty/missing values
+ * are omitted from the map.
+ */
+export type WorkspaceFilter = Record<string, string>;
+
+/**
+ * Patch payload for `setFilter`. Any facet whose value is `""`, `null`, or
+ * `undefined` is removed from the URL; otherwise the facet is set/replaced.
+ */
+export type WorkspaceFilterPatch = Record<
+  string,
+  string | null | undefined
+>;
+
+export interface UseWorkspaceFilterReturn {
+  /** Current filter map parsed from the URL. Always a stable snapshot. */
+  filter: WorkspaceFilter;
+  /** Merge the provided patch into the URL filter. */
+  setFilter: (patch: WorkspaceFilterPatch) => void;
+  /** Remove every `filter[*]` param from the URL in one call. */
+  clearFilter: () => void;
+}
+
+/**
+ * Strip any query-string portion off a wouter location. Wouter's
+ * `useLocation` is usually path-only, but a few call sites concat search
+ * strings before passing us back, so we defensively slice.
+ */
+function pathOnly(location: string): string {
+  const queryIdx = location.indexOf("?");
+  return queryIdx === -1 ? location : location.slice(0, queryIdx);
+}
+
+/**
+ * Build a new URL from (path, params) — omits the `?` when there are no
+ * params so we don't emit bare `/orders?`.
+ */
+function buildUrl(path: string, params: URLSearchParams): string {
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+export function useWorkspaceFilter(): UseWorkspaceFilterReturn {
+  const [location, setLocation] = useLocation();
+  const search = useSearch();
+
+  const filter = useMemo<WorkspaceFilter>(() => {
+    const params = new URLSearchParams(search);
+    const parsed: WorkspaceFilter = {};
+    params.forEach((value, key) => {
+      const match = FILTER_PARAM_PATTERN.exec(key);
+      if (match) {
+        const facet = match[1];
+        if (facet && value !== "") {
+          parsed[facet] = value;
+        }
+      }
+    });
+    return parsed;
+  }, [search]);
+
+  const setFilter = useCallback(
+    (patch: WorkspaceFilterPatch) => {
+      const params = new URLSearchParams(search);
+      for (const facet of Object.keys(patch)) {
+        const value = patch[facet];
+        const paramKey = filterParamKey(facet);
+        if (value === null || value === undefined || value === "") {
+          params.delete(paramKey);
+        } else {
+          params.set(paramKey, value);
+        }
+      }
+      setLocation(buildUrl(pathOnly(location), params));
+    },
+    [location, search, setLocation]
+  );
+
+  const clearFilter = useCallback(() => {
+    const params = new URLSearchParams(search);
+    // Collect first, delete after — mutating during iteration is undefined.
+    const keysToDelete: string[] = [];
+    params.forEach((_value, key) => {
+      if (FILTER_PARAM_PATTERN.test(key)) {
+        keysToDelete.push(key);
+      }
+    });
+    for (const key of keysToDelete) {
+      params.delete(key);
+    }
+    setLocation(buildUrl(pathOnly(location), params));
+  }, [location, search, setLocation]);
+
+  return { filter, setFilter, clearFilter };
+}
+
+export default useWorkspaceFilter;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -530,6 +530,38 @@
     gap: 0.25rem;
   }
 
+  /**
+   * UX v2 filter strip row (TER-1310).
+   *
+   * Wraps a <WorkspaceFilterBar> rendered in the `filterStrip` slot of
+   * LinearWorkspaceShell. Sits directly below the tab row so the border
+   * seam reads as a continuation of the shell chrome.
+   */
+  .linear-workspace-filter-row {
+    display: flex;
+    min-width: 0;
+    background: var(--card);
+    border-bottom: 1px solid
+      color-mix(in oklab, var(--border) 76%, transparent);
+  }
+
+  .linear-workspace-filter-strip {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+    padding: 0.55rem 1rem 0.6rem;
+    row-gap: 0.4rem;
+  }
+
+  .linear-workspace-shell[data-density="compact"]
+    .linear-workspace-filter-strip {
+    gap: 0.35rem;
+    padding: 0.4rem 0.85rem 0.45rem;
+  }
+
   .linear-workspace-content {
     margin-top: 0;
     min-height: 0;

--- a/docs/sessions/active/TER-1310-session.md
+++ b/docs/sessions/active/TER-1310-session.md
@@ -1,0 +1,7 @@
+# TER-1310 Agent Session
+
+- **Ticket:** TER-1310
+- **Branch:** `feat/ter-1310-workspace-filter-bar`
+- **Status:** In Progress
+- **Started:** 2026-04-23T19:28:42Z
+- **Agent:** Factory Droid (UX v2 wave launcher — session pre-initialized)


### PR DESCRIPTION
## Summary

Adds a standardized filter surface to the workspace shell so individual surfaces no longer declare their own ad-hoc filter bars. Closes the largest bucket in the corrected UX v2 finding distribution.

- **Linear**: TER-1310 (epic TER-1283, April 23 frontend UX v2 work)
- **Spec**: docs/ux-review/02-Implementation_Strategy.md §4.3

## What's in the box

1. **`<WorkspaceFilterBar>`** (`client/src/components/layout/WorkspaceFilterBar.tsx`)
   - Thin, styled container with shared padding / border / background chrome.
   - Accepts children (filter inputs: chips, search fields, dropdowns, date ranges, etc.) — unopinionated about the controls themselves.
   - `role="toolbar"` with default `aria-label="Filters"` (overridable) so assistive tech distinguishes the filter strip from the tab row above it.

2. **`useWorkspaceFilter()`** (`client/src/hooks/useWorkspaceFilter.ts`)
   - Persists active filter facets to URL search params using the `filter[key]=value` bracket convention.
   - **Deep-linkable**: `/orders?filter[status]=pending` restores that filter on page load. Works for both URLSearchParams-encoded (`%5B`/`%5D`) and unencoded forms from the address bar.
   - API: `{ filter, setFilter, clearFilter }` — `filter` is a flat `Record<string,string>`; `setFilter({ status: '' | null | undefined })` removes that facet; `clearFilter()` wipes every `filter[*]` param in one call without disturbing unrelated params (tab, page, etc.).
   - Built on wouter's `useLocation`/`useSearch` — same pattern as `useQueryTabState` and `useTableUrlState` (TER-1212).

3. **`LinearWorkspaceShell` filterStrip slot** (`client/src/components/layout/LinearWorkspaceShell.tsx`)
   - Adds optional `filterStrip?: ReactNode` prop, rendered immediately below the tab row / command strip.
   - **Slot is omitted entirely when absent** — no layout break / extra whitespace for surfaces that don't opt in.
   - Gains matching `.linear-workspace-filter-row` / `.linear-workspace-filter-strip` CSS with default + compact density variants that mirror the existing tab-row chrome.

4. **`ux.v2.filter-bar`** feature flag (`client/src/components/feature-flags/uxV2Flags.ts`)
   - Default off. Lets rollout be staged per surface without code changes, matching the `ux.v2.*` pattern established by the drawer / workspace-tabs flags.

## Acceptance criteria

- [x] `WorkspaceFilterBar` component created.
- [x] `useWorkspaceFilter` hook stores filter in URL params and restores on load.
- [x] `LinearWorkspaceShell` renders `filterStrip` slot below tab row.
- [x] Deep linking works (`?filter[status]=pending` round-trips through the hook).
- [x] No layout break when `filterStrip` is absent (slot unrendered).
- [x] `pnpm check` passes.
- [x] `pnpm lint` passes for new files (pre-existing repo lint debt unchanged).

## Test coverage

- `client/src/hooks/useWorkspaceFilter.test.ts` — 13 cases (parsing encoded + unencoded bracket notation, set/overwrite/remove facets, preserve unrelated params, clearFilter, stale-query defensive slice).
- `client/src/components/layout/WorkspaceFilterBar.test.tsx` — 5 cases (toolbar role + aria-label, shared chrome class, shell slot hidden when absent, shell slot renders children below tab row).

All 18 new tests pass locally under Vitest jsdom.

## Scope guardrails

- No server / tRPC / database files touched.
- Primitive is additive — existing `LinearWorkspaceShell` call sites compile unchanged (filterStrip is optional).

🤖 Generated with [Factory Droid](https://factory.ai)