### PR TITLE
feat(ux-v2): persisted sidebar group state via navState.ts [TER-1306]

### DIFF
--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -25,12 +25,16 @@ import { cn } from "@/lib/utils";
 import {
   buildNavigationAccessModel,
   defaultQuickLinkPaths,
+  navigationGroups,
   navigationItems,
   type NavigationGroupKey,
 } from "@/config/navigation";
 import { normalizeOperationsTab } from "@/lib/workspaceRoutes";
+import { FEATURE_FLAGS } from "@/lib/constants/featureFlags";
 import { useFeatureFlags } from "@/hooks/useFeatureFlag";
+import { useOptionalFeatureFlag } from "@/contexts/FeatureFlagContext";
 import { useNavigationState } from "@/hooks/useNavigationState";
+import { getNavOpenGroups, setNavOpenGroups } from "@/lib/navState";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/_core/hooks/useAuth";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -120,6 +124,22 @@ function getDefaultOpenGroups(currentPath: string) {
   } satisfies Record<NavigationGroupKey, boolean>;
 }
 
+/**
+ * TER-1306: Map the persisted array of open group keys into the full
+ * {@link NavigationGroupKey} record used by the sidebar. Unknown keys are
+ * discarded; missing keys default to closed.
+ */
+function openGroupsFromPersisted(
+  persisted: string[]
+): Record<NavigationGroupKey, boolean> {
+  const openSet = new Set(persisted);
+  const next: Partial<Record<NavigationGroupKey, boolean>> = {};
+  for (const { key } of navigationGroups) {
+    next[key] = openSet.has(key);
+  }
+  return next as Record<NavigationGroupKey, boolean>;
+}
+
 export const Sidebar = React.memo(function Sidebar({
   open = false,
   onClose,
@@ -134,9 +154,26 @@ export const Sidebar = React.memo(function Sidebar({
   const { data: currentUser } = trpc.auth.me.useQuery(undefined, {
     staleTime: 60_000,
   });
+  // TER-1306: When the ux.v2.nav-persist flag is enabled, the sidebar reads
+  // the last-known open groups from localStorage on mount and writes back on
+  // every accordion toggle so state survives refreshes and navigation.
+  const navPersistEnabled = useOptionalFeatureFlag(
+    FEATURE_FLAGS.uxV2NavPersist
+  );
   const [openGroups, setOpenGroups] = useState<
     Record<NavigationGroupKey, boolean>
-  >(() => getDefaultOpenGroups(`${location}${search || ""}`));
+  >(() => {
+    const defaults = getDefaultOpenGroups(`${location}${search || ""}`);
+    if (!navPersistEnabled) {
+      return defaults;
+    }
+    const persisted = getNavOpenGroups();
+    if (persisted.length === 0) {
+      return defaults;
+    }
+    return openGroupsFromPersisted(persisted);
+  });
+  const navHydratedFromStorageRef = useRef(navPersistEnabled);
   const [collapsed, setCollapsed] = useState(false);
 
   // BUG-103: Auto-close the mobile drawer whenever the active route changes so
@@ -178,11 +215,25 @@ export const Sidebar = React.memo(function Sidebar({
   );
   const groupedNavigation = navigationAccessModel.groups;
 
-  const toggleGroup = useCallback((key: NavigationGroupKey) => {
-    flushSync(() => {
-      setOpenGroups(prev => ({ ...prev, [key]: !prev[key] }));
-    });
-  }, []);
+  const toggleGroup = useCallback(
+    (key: NavigationGroupKey) => {
+      flushSync(() => {
+        setOpenGroups(prev => {
+          const next = { ...prev, [key]: !prev[key] };
+          if (navPersistEnabled) {
+            // TER-1306: Persist the full set of currently-open group keys on
+            // every accordion toggle so the state survives refresh/navigation.
+            const openKeys = (
+              Object.keys(next) as NavigationGroupKey[]
+            ).filter(groupKey => next[groupKey]);
+            setNavOpenGroups(openKeys);
+          }
+          return next;
+        });
+      });
+    },
+    [navPersistEnabled]
+  );
 
   const isActivePath = useCallback(
     (path: string) => {
@@ -220,6 +271,22 @@ export const Sidebar = React.memo(function Sidebar({
       prev[activeGroupKey] ? prev : { ...prev, [activeGroupKey]: true }
     );
   }, [activeGroupKey]);
+
+  // TER-1306: Feature flags load asynchronously; if the ux.v2.nav-persist
+  // flag flips from false → true after the initial render, hydrate the
+  // sidebar from localStorage exactly once so the user still sees their
+  // persisted layout on cold loads.
+  useEffect(() => {
+    if (!navPersistEnabled || navHydratedFromStorageRef.current) {
+      return;
+    }
+    navHydratedFromStorageRef.current = true;
+    const persisted = getNavOpenGroups();
+    if (persisted.length === 0) {
+      return;
+    }
+    setOpenGroups(openGroupsFromPersisted(persisted));
+  }, [navPersistEnabled]);
 
   return (
     <>

--- a/client/src/lib/constants/featureFlags.ts
+++ b/client/src/lib/constants/featureFlags.ts
@@ -46,6 +46,19 @@ export const FEATURE_FLAGS = {
    * Linear: TER-1295
    */
   uxV2PageHeaderInvariant: "ux.v2.page-header-invariant",
+  /**
+   * UX v2 persisted sidebar open-group state.
+   *
+   * When enabled, the `AppSidebar` reads the open/closed state of navigation
+   * groups from `localStorage` on mount and writes back on every accordion
+   * toggle, so the user's sidebar layout survives page refreshes and
+   * navigation. When disabled, the sidebar falls back to the default
+   * route-driven open-group behavior.
+   *
+   * See: docs/ux-review/02-Implementation_Strategy.md §4.6
+   * Linear: TER-1306
+   */
+  uxV2NavPersist: "ux.v2.nav-persist",
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/client/src/lib/navState.ts
+++ b/client/src/lib/navState.ts
@@ -1,0 +1,78 @@
+/**
+ * Persisted sidebar navigation open-group state.
+ *
+ * Stores which navigation groups the user has expanded in the sidebar so that
+ * the selection survives full page reloads and in-app navigation. This follows
+ * the same synchronous `localStorage` + `CustomEvent` pattern used by
+ * {@link ./uiDensity.ts}.
+ *
+ * Gated by the `ux.v2.nav-persist` feature flag at the call site.
+ *
+ * See: docs/ux-review/02-Implementation_Strategy.md §4.6
+ * Linear: TER-1306
+ */
+
+export const NAV_OPEN_GROUPS_STORAGE_KEY = "terp.nav.open-groups.v1";
+export const NAV_OPEN_GROUPS_CHANGE_EVENT = "terp-nav-open-groups-change";
+
+function hasLocalStorage(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.localStorage !== "undefined"
+  );
+}
+
+/**
+ * Read the persisted list of open navigation group keys.
+ *
+ * Returns an empty array when nothing has been persisted, when the value
+ * cannot be parsed, or when `localStorage` is unavailable (e.g. during SSR).
+ * The read is synchronous and is expected to complete in <1ms.
+ */
+export function getNavOpenGroups(): string[] {
+  if (!hasLocalStorage()) {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(NAV_OPEN_GROUPS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((value): value is string => typeof value === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the list of open navigation group keys and notify listeners.
+ *
+ * Writes synchronously to `localStorage` and dispatches a
+ * {@link NAV_OPEN_GROUPS_CHANGE_EVENT} `CustomEvent` so that other instances
+ * of the sidebar (or diagnostic tooling) can react without a page reload.
+ */
+export function setNavOpenGroups(groups: string[]): void {
+  if (hasLocalStorage()) {
+    try {
+      window.localStorage.setItem(
+        NAV_OPEN_GROUPS_STORAGE_KEY,
+        JSON.stringify(groups)
+      );
+    } catch {
+      // Ignore quota / privacy-mode failures — persistence is best-effort.
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new window.CustomEvent(NAV_OPEN_GROUPS_CHANGE_EVENT, {
+        detail: groups,
+      })
+    );
+  }
+}


### PR DESCRIPTION
Implements TER-1306: persisted sidebar nav group state using localStorage, modeled on existing uiDensity.ts pattern.

- New `client/src/lib/navState.ts` — localStorage + CustomEvent helpers (key: `terp.nav.open-groups.v1`)
- `FEATURE_FLAGS.uxV2NavPersist` = `ux.v2.nav-persist` added  
- `AppSidebar` wired behind flag — seeds state from localStorage, writes back on accordion toggle
- Flag off: behavior unchanged from main