### PR TITLE
feat(ux-v2): FreshnessBadge primitive [TER-1296]

### DIFF
--- a/client/src/components/ui/freshness-badge.tsx
+++ b/client/src/components/ui/freshness-badge.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * FreshnessBadge — small primitive that surfaces data freshness inline.
+ *
+ * Reads `dataUpdatedAt` (epoch ms) from a tRPC/React Query result and renders:
+ *   - live:    "Live · 2m ago"           (relative time, refreshes every 60s)
+ *   - nightly: "Nightly · as of 06:00"   (clock time, HH:MM)
+ *   - hourly:  "Hourly · 06:00"          (clock time, HH:MM)
+ *
+ * [TER-1296] — UX-7 freshness disclosure for workspace pages.
+ */
+export type FreshnessCadence = "live" | "nightly" | "hourly";
+
+export type FreshnessBadgeProps = Omit<
+  React.ComponentProps<"span">,
+  "children"
+> & {
+  /** React Query / tRPC query result — only `dataUpdatedAt` (ms epoch) is read. */
+  queryResult: { dataUpdatedAt: number };
+  /** Cadence of the underlying data source. */
+  cadence: FreshnessCadence;
+  className?: string;
+};
+
+function formatRelative(fromMs: number, nowMs: number): string {
+  const diffSec = Math.max(0, Math.floor((nowMs - fromMs) / 1000));
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+function formatClock(fromMs: number): string {
+  if (!fromMs) return "--:--";
+  const d = new Date(fromMs);
+  const hh = d.getHours().toString().padStart(2, "0");
+  const mm = d.getMinutes().toString().padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+const CADENCE_LABEL: Record<FreshnessCadence, string> = {
+  live: "Live",
+  nightly: "Nightly",
+  hourly: "Hourly",
+};
+
+export function FreshnessBadge({
+  queryResult,
+  cadence,
+  className,
+  ...props
+}: FreshnessBadgeProps) {
+  const { dataUpdatedAt } = queryResult;
+
+  // Tick every 60s so the relative label stays fresh without a parent re-render.
+  const [now, setNow] = React.useState<number>(() => Date.now());
+  React.useEffect(() => {
+    if (cadence !== "live") return;
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, [cadence]);
+
+  let suffix: string;
+  if (cadence === "live") {
+    suffix = dataUpdatedAt ? formatRelative(dataUpdatedAt, now) : "—";
+  } else if (cadence === "nightly") {
+    suffix = `as of ${formatClock(dataUpdatedAt)}`;
+  } else {
+    suffix = formatClock(dataUpdatedAt);
+  }
+
+  const label = `${CADENCE_LABEL[cadence]} · ${suffix}`;
+
+  return (
+    <span
+      data-slot="freshness-badge"
+      data-cadence={cadence}
+      className={cn(
+        "inline-flex items-center gap-1 text-xs text-muted-foreground whitespace-nowrap",
+        className,
+      )}
+      aria-label={label}
+      title={dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleString() : undefined}
+      {...props}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default FreshnessBadge;

--- a/docs/sessions/active/TER-1296-session.md
+++ b/docs/sessions/active/TER-1296-session.md
@@ -1,0 +1,7 @@
+# TER-1296 Agent Session
+
+- **Ticket:** TER-1296
+- **Branch:** `feat/ter-1296-freshness-badge`
+- **Status:** In Progress
+- **Started:** 2026-04-23T00:00:00Z
+- **Agent:** Factory Droid (UX v2 wave launcher — FreshnessBadge primitive)


### PR DESCRIPTION
## Summary

Adds `FreshnessBadge` — a small UI primitive that surfaces data freshness inline by reading `dataUpdatedAt` from a tRPC/React Query result.

**File:** `client/src/components/ui/freshness-badge.tsx` (new, ~97 lines)

### Rendering

| Cadence   | Output                      | Behavior                               |
| --------- | --------------------------- | -------------------------------------- |
| `live`    | `Live · 2m ago`             | Relative time, refreshes every 60s via `setInterval` |
| `nightly` | `Nightly · as of 06:00`     | Clock time (HH:MM)                     |
| `hourly`  | `Hourly · 06:00`            | Clock time (HH:MM)                     |

### Ticket

- Linear: **TER-1296** (Epic TER-1283)
- Closes 1 finding — **T-10** (`RelationshipsWorkspacePage.clients` UX-7 freshness disclosure)

## Scope

- Additive only — primitive exported, no consumers wired yet.
- No feature flag needed.
- No server / schema / DB changes.

## Acceptance Criteria

- [x] `FreshnessBadge` exported from `client/src/components/ui/freshness-badge.tsx`
- [x] Renders relative time for `live` cadence, clock time for `nightly` / `hourly`
- [x] Auto-refreshes every 60s (only when `cadence === "live"`, cleared on unmount)
- [x] `pnpm check` passes (zero TS errors)
- [x] `pnpm lint` passes for the new file (pre-existing unrelated errors untouched)

## Verification

```bash
pnpm check   # ✅ 0 errors
pnpm lint    # ✅ freshness-badge.tsx clean (only pre-existing unrelated lint errors elsewhere)
```

## Tier

SAFE — additive UI primitive, no behavior changes to existing code paths.