### PR TITLE
docs(qa): UX v2 live QA report 2026-04-23

### DIFF
--- a/docs/qa-reports/ux-v2-qa-2026-04-23.md
+++ b/docs/qa-reports/ux-v2-qa-2026-04-23.md
@@ -1,0 +1,352 @@
+# UX V2 Live Browser QA Report
+
+**Date**: 2026-04-23
+**Target**: TERP Staging (`https://terp-staging-yicld.ondigitalocean.app`)
+**Epic**: TER-1283 — April 23 frontend work
+**QA Tooling**: `agent-browser` v0.x (Chromium via Playwright) — `~/.factory/tools/agent-browser/bin/agent-browser`
+**Test Account**: Auto-logged in as "QA Super Admin" via `DEMO_MODE=true`
+**Screenshot directory**: `docs/qa-reports/screenshots/ux-v2-2026-04-23/`
+**Evidence method**: Live navigation + DOM inspection via `eval` + `localStorage` reads + browser console inspection. No production writes, no commits, no PRs.
+
+---
+
+## 1. Executive Summary
+
+The UX v2 primitives from Epic TER-1283 **landed partially**. Several primitives are clearly live and working (FreshnessBadge on main dashboard, PageHeader one-primary-action on Feature Flags, empty-state card pattern on the Order Creator client picker, and most of the known-issue fixes TER-1255/1257/1258/1260). Other primitives either regressed or did not render in the pages exercised.
+
+### ✅ Shipped & verified working
+- **OperationalStateSurface** — Home dashboard shows both an error state ("Unable to load daily snapshot") and an empty state ("No upcoming appointments") as styled cards with icons. Client picker in Order Creator returns a styled "No customers - Try a different search term" empty state.
+- **PowersheetGrid numeric defaults** — On `/accounting?tab=bank-accounts` the Balance column is right-aligned, font-mono, and formatted `$1,250,000.00` / `-$25,000.00`. Invoices `Amount Due` column renders clean currency with color state (green `$0.00` for paid, red for outstanding). Order totals in sales standard view are right-aligned (`$761.32`, `$347.36`, `$28,102.16`).
+- **PageHeader one-primary-action** — Feature Flags page: "Initialize Defaults" is now outline, "Add Control" is the sole filled primary (TER-1295 verified). Accounting dashboard: "Pay Supplier" is sole primary.
+- **FreshnessBadge** — Main dashboard shows `Live Updated: 10:28 PM` at the top (TER-1296 wired here).
+- **Sidebar navState localStorage** — `terp-navigation-state:user:1` key exists with `{"collapsedGroups":[],"pinnedPaths":[…]}` shape. TER-1306 plumbing is present.
+- **Deep-link preservation** — `/sales/new` → `/sales?tab=create-order`; `/accounting/invoices` → `/accounting?tab=invoices`; `/accounting/bills` → `/accounting?tab=bills`. Deep-link contract honored (TER-1260).
+- **AppBreadcrumb** — On `/accounting/doesnotexist` the trailing "Doesnotexist" segment is rendered as a non-clickable `<span>` (not as an `<a>`).
+- **TER-1257** — Standard View on `/sales?tab=orders&surface=classic` shows populated grid with 50+ orders; counts `Drafts 50 · Pending 37 · Ready 6 · Shipped 7`.
+- **TER-1258** — Main dashboard Inventory Value reads `$34.2M` with `38,185 live units`.
+- **TER-1259** — Client picker in Order Creator shows 40 real clients; typing "QA" returns empty state (no "QA Write-Path Client" fixtures leaking).
+- **TER-1260** — `/sales/new` redirects cleanly to Order Creator.
+- **TER-1256** — Invoice detail drawer total exactly matches grid total (`$8,535.78` drawer = `$8,535.78` grid). Sales order detail drawer total (`$761.32`) matches grid (`$761.32`). No 100× inflation observed.
+
+### 🚨 Shipped but broken / regressions
+- **TER-1253 regressed onto adjacent columns.** Amount Due on Invoices is now clean, but the **Status** column on Invoices and the **Due Amt + Status** columns on Bills render the literal string `<span class="…">Paid</span>` as visible cell text. Confirmed via DOM inspection: cell `innerHTML` contains the HTML-escaped entity `&lt;span class="…"&gt;Paid&lt;/span&gt;`, meaning the browser is displaying the raw markup.
+- **TER-1254 still open — CRITICAL.** `evans-mac-mini.tailbe55dd.ts.net/sessions` and `/health` are still attempted from the Agentation subsystem on every navigation. CSP blocks the requests with `default-src 'self'`, but a single page load generates 400+ console errors. The tailnet URL is compiled into the production client bundle.
+
+### ❌ Did not visibly ship
+- **Accounting tabGroups 4-group reorg (TER-1305)** — `/accounting` still renders the flat 10-tab bar (Dashboard · Invoices · Payments · Bills · Expenses · General Ledger · Chart of Accounts · Bank Accounts · Bank Transactions · Fiscal Periods). The promised `Overview | Receivables | Payables | Ledger` grouping is **not** present.
+- **ClientProfilePage breadcrumb (TER-1297 UX-2)** — `/clients/105` shows `Home > Clients > #105`, not `Home > Clients > Sierra Nevada Farms`.
+- **OrderCreatorPage breadcrumb (TER-1297 UX-4)** — `/sales?tab=create-order` shows `Home > Sales`, not `Home > Sales > New Order`.
+- **Glossary sweep (TER-1315)** — `/relationships?tab=clients` text contains `Customer` 31× and `Buyer` 22×. Order Creator still has "KEEP THE CUSTOMER, DOCUMENT TYPE, AND TOTALS IN ONE WORKING FRAME" header, "Select a customer to start this order" CTA, and "Customer…" combobox placeholder. Sidebar Sales Quick Actions still labeled "Recent Customers".
+- **FreshnessBadge on `/clients` and `/sales`** — Both still show the legacy green `Saved` pill; `freshnessBadge` querySelector returned `null` on the clients page. Only `/` has the new badge.
+- **PageHeader on `/sales`** — Two filled-primary buttons co-exist in the header: orange "Spreadsheet View" (view toggle) **and** orange "New Order" (action). Violates the one-primary invariant.
+- **Sidebar navState persistence (TER-1306)** — Clicking the sidebar group-toggle buttons updates `aria-expanded` correctly but does **not** write to `localStorage.collapsedGroups` (remained `[]` across repeated toggles).
+
+### Overall verdict
+**Mixed.** Roughly ~55% of UX v2 primitives are live and correct, ~15% shipped but have functional regressions (TER-1253 Status column, TER-1254 tailnet URL), ~30% are code-merged but not rendered in the pages exercised (tabGroups, breadcrumb registry extensions, FreshnessBadge broader wiring, glossary sweep, sidebar persistence write-path). Recommend filing follow-up tickets before marking Epic TER-1283 "done".
+
+---
+
+## 2. Primitive-by-primitive results
+
+### Block 1 — OperationalStateSurface (TER-1284, `ux.v2.states`)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 1.1 Empty state card (invoices) | `/accounting?tab=invoices` | **PASS** | Invoices workspace has data; empty-state pattern validated via Order Creator client picker: typing "QA" shows styled card with user icon + "No customers - Try a different search term". `24-client-search.png` |
+| 1.2 Empty state (bills) | `/accounting?tab=bills` | **PASS (data)** | Grid populates with 46 bills; structure consistent with invoices. `02-bills.png` |
+| 1.3 Loading skeleton (clients) | `/relationships?tab=clients` | **PASS (no reflow)** | Grid loads without floating spinner; no layout reflow observed. `03-clients.png` |
+| 1.4 Error state (home) | `/` | **PASS (partial)** | "Today at a Glance" card shows `Unable to load daily snapshot - Transaction or inbox data could not be loaded` in structured card with folder icon. However, **no retry button** is present. `27-home-kpis.png` |
+| 1.5 Empty state (appointments) | `/` | **PASS** | "No upcoming appointments - No appointments scheduled for the next 7 days" in styled card with calendar icon. `27-home-kpis.png` |
+
+**Verdict: PASS**, with one minor FAIL — the error state in "Today at a Glance" is missing a retry button.
+
+---
+
+### Block 2 — PowersheetGrid numeric defaults (TER-1285, `ux.v2.grid`)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 2.1 Bank Accounts — Balance alignment / format | `/accounting?tab=bank-accounts` | **PASS** | `col-id="currentBalance"`: `text-align: right`, `font-family: ui-monospace…`, class `font-mono text-right`, innerHTML plain text. Values: `-$25,000.00`, `$1,250,000.00`, `$350,000.00`, `$500,000.00`. `13-bank-accounts.png` |
+| 2.2 Invoices — Amount Due (TER-1253 primary column) | `/accounting?tab=invoices` | **PASS** | `amountDueFormatted` col innerHTML: `<span class="text-[var(--success)] font-mono">$0.00</span>` — rendered properly as HTML, not as text. Right-aligned. `01-invoices.png` |
+| 2.3 Invoices — **Status** column | `/accounting?tab=invoices` | **FAIL (regression)** | `col-id="status"` cells show `textContent: "<span class=\"inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200\">Paid</span>"`. `innerHTML`: `&lt;span class="…"&gt;Paid&lt;/span&gt;`. 21 affected cells. Status column is the right-most column in the grid so visually off-screen in the default viewport. |
+| 2.4 Bills — Due Amt column | `/accounting?tab=bills` | **FAIL** | `col-id="amountDueFormatted"` cells show `textContent: "<span class=\"font-mono\">$0.00</span>"` — rendered as literal text. Aria-colindex 6, directly visible in the viewport. 21+ affected cells. `02-bills.png` |
+| 2.5 Bills — Status column | `/accounting?tab=bills` | **FAIL** | Same raw-HTML-as-text pattern on `col-id="status"`. |
+| 2.6 Sales order totals | `/sales?tab=orders&surface=classic` | **PASS** | Totals render as `$761.32`, `$347.36`, `$1,905.60`, `$28,102.16`, `$72,580.54` — right-aligned, tabular. `19-standard-view.png` |
+| 2.7 Inventory grid numeric (% and $) | `/inventory` | **N/A (kanban)** | Default inventory surface is a kanban board (Awaiting Intake / Live / On Hold). Card values (`$182.91`, aggregate `$34,216,536.41 value`) format correctly. No traditional grid to evaluate. `12c-inventory.png` |
+
+**Verdict: PARTIAL.** Currency columns are aligned and formatted correctly. The Status column pattern is a clear regression and should reopen TER-1253 or spawn a successor ticket covering Bills Due Amt + both Status columns.
+
+---
+
+### Block 3 — ManusSheet drawer (TER-1294, `ux.v2.drawer`)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 3.1 Users — "Add User" drawer | `/settings?tab=users` | **N/A** | Create New User renders as an **inline form** on the Access Control page (Username / Password / Display Name + orange "Create User" button), not a drawer. ManusSheet is not used here. `14b-users.png` |
+| 3.2 `/settings/users` route | `/settings/users` | **FAIL (nav)** | Returns a 404 page; correct path is `/settings?tab=users`. `14-users.png` |
+| 3.3 Invoice detail drawer — X button | `/accounting?tab=invoices` → INV-000120 click | **PASS** | Drawer opens from right; close button with `aria-label="Close panel"` present in top-right. `17-invoice-drawer.png` |
+| 3.4 Invoice drawer — "Esc to close" hint | same | **FAIL** | DOM scan `/\bEsc(ape)?\b.{0,30}close/i` returned **0 matches** across the drawer's text nodes. No visible hint in header or footer. |
+| 3.5 Invoice drawer — Escape closes drawer | same | **PASS** | Drawer closes on Escape. Close-panel button disappears from DOM. |
+| 3.6 Invoice drawer — Focus return | same | **FAIL** | After Escape, `document.activeElement.tagName === "BODY"`. Focus does not return to the row that opened the drawer. |
+| 3.7 Client drawer (Sierra Nevada Farms) | `/relationships?tab=clients` → row button | **PASS (X)** / **FAIL (hint)** | Drawer opens with X close button (`aria-label="Close panel"`) and "Open full profile" button. No "Esc to close" hint found. Escape closes drawer; focus goes to BODY (no return). `04-client-profile.png` |
+
+**Verdict: PARTIAL.** X button consistently present. **Esc-to-close hint missing** and **focus return on close missing** — both are explicit TER-1294 requirements per the task checklist.
+
+---
+
+### Block 4 — PageHeader one-primary-action (TER-1295)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 4.1 `/analytics` | `/analytics` | **PASS** | Header has 2 buttons — "Last 30 days" (transparent bg) and "Export" (transparent bg). Zero primaries. `08-analytics.png` |
+| 4.2 `/settings?tab=feature-flags` — Initialize Defaults | | **PASS (TER-1295 verified)** | `Initialize Defaults` is outline (not primary), `Refresh` is outline, and `Add Control` is the sole filled-orange primary. `09b-feature-flags.png`. Confirmation dialog on click not verified (to avoid mutating state), but the button is visually demoted as expected. |
+| 4.3 `/accounting?tab=dashboard` | | **PASS** | Sole primary: "Pay Supplier" (dark brown/red filled). `10-accounting-dash.png` |
+| 4.4 `/sales` | `/sales` | **FAIL** | Header has TWO filled primary-styled buttons: orange **"Spreadsheet View"** (view toggle, selected) and orange **"New Order"** (action). Two primaries in the same visual weight zone violates the invariant. `11-sales.png`, `18-sales-orders.png` |
+| 4.5 `/inventory` | | **PASS** | No filled primary in header; "Save View" is outline. `12c-inventory.png` |
+| 4.6 Home dashboard | `/` | **PASS** | KPI tiles only, no primary in header. `27-home-kpis.png` |
+
+**Verdict: MOSTLY PASS**, with `/sales` the one violating page.
+
+---
+
+### Block 5 — AppBreadcrumb route registry (TER-1297)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 5.1 Client profile breadcrumb | `/clients/105` | **FAIL** | Breadcrumb DOM: `Home (link) > Clients (link /clients) > #105 (span)`. Promised TER-1297 UX-2 fix to display client name ("Sierra Nevada Farms") **did not land**. `05b-client-drawer.png` |
+| 5.2 Order Creator breadcrumb | `/sales?tab=create-order` | **FAIL** | Breadcrumb DOM: `[Home, Home, Home, Sales, Sales]` — just `Home > Sales`. No "New Order" trailing segment. TER-1297 UX-4 not shipped. `06-sales-new.png`, `21-order-creator.png` |
+| 5.3 404 breadcrumb | `/accounting/doesnotexist` | **PASS** | Breadcrumb DOM: `Home (link /) > Accounting (link /accounting) > Doesnotexist (span, non-clickable)`. Bad URL segment is not a link. `07b-404-verify.png` |
+| 5.4 Accounting section breadcrumb | `/accounting?tab=invoices` | **PASS** | `Home > Accounting` — correct workspace breadcrumb. |
+
+**Verdict: PARTIAL.** Route registry works for 404 and top-level workspaces, but ClientProfilePage and OrderCreatorPage entries are missing.
+
+---
+
+### Block 6 — WorkspaceFilterBar (TER-1310)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 6.1 Sales Spreadsheet View — filter strip | `/sales?tab=orders` (Spreadsheet) | **PARTIAL** | Below the tab row there is a search input + "New Order" action + a command strip ("Select an order to take action · New Draft / Delete Draft / Accounting / Fulfillment / View Details / Classic"). Status chips `All 100 · 50 drafts · 50 confirmed` appear further down inside the Orders Queue card — filters are mixed with bulk actions rather than in a clean dedicated strip. `11-sales.png` |
+| 6.2 Sales Standard View — filter strip | `/sales?surface=classic` | **PASS** | Dedicated strip directly below the tab row: status pills (`Drafts(50)`, `Confirmed(50)`), search, All filter dropdown, Newest sort, Refresh. `19-standard-view.png` |
+| 6.3 Inventory filter strip | `/inventory` | **PASS** | Strip directly below tabs: search (SKU/product/supplier), "Live" status filter, "Filters" button, "Default (available now)" view selector, "Save View". `12c-inventory.png` |
+| 6.4 Filter URL deep-link | | **INCONCLUSIVE** | Programmatic click on the `50 drafts` chip was intercepted; URL change after applying a filter could not be verified reliably in this session. |
+
+**Verdict: PARTIAL PASS.** Layout is present for Standard View and Inventory; URL deep-link not verified.
+
+---
+
+### Block 7 — Sidebar navState persistence (TER-1306)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 7.1 localStorage key exists | `/accounting` | **PASS** | `localStorage['terp-navigation-state:user:1']` = `{"collapsedGroups":[],"pinnedPaths":["/","/sales?tab=create-order","/inventory?tab=receiving","/relationships?tab=clients"]}`. Schema matches TER-1306 design. |
+| 7.2 Auto-expand active workspace | `/accounting` → Finance | **PASS** | On `/accounting`, `Finance` sidebar group has `aria-expanded="true"` while `Sell`, `Buy`, `Operations`, `Relationships`, `Admin` are `false`. |
+| 7.3 Persisted collapse on user click | Collapse Finance + reload | **FAIL** | Clicking the Finance toggle flipped `aria-expanded` to `false` but `collapsedGroups` in localStorage remained `[]`. After reload, state snapped back to route-driven default. User interactions are **not** being persisted. |
+| 7.4 Cross-navigation persistence | `/accounting → /sales → /accounting` | **PASS (auto)** | Route-driven auto-expand works for each workspace, but this is not user-state persistence. |
+
+**Verdict: PARTIAL.** Storage slot exists and is consumed for route-driven auto-expand, but toggle writes are not happening. TER-1306 is half-wired.
+
+---
+
+### Block 8 — Accounting tabGroups 4-group reorg (TER-1305)
+
+| Test | Verdict | Evidence |
+| ---- | ------- | -------- |
+| 8.1 Top-level group count | **FAIL (did not ship)** | `/accounting` tabs via DOM scan: `["Dashboard","Invoices","Payments","Bills","Expenses","General Ledger","Chart of Accounts","Bank Accounts","Bank Transactions","Fiscal Periods"]` — 10 flat tabs. The 4-group layout (Overview / Receivables / Payables / Ledger) is **not rendered**. `10-accounting-dash.png`, `01-invoices.png` |
+| 8.2 Deep-link `/accounting/invoices` | **PASS** | Rewrites to `/accounting?tab=invoices` and selects Invoices correctly. |
+| 8.3 Deep-link `?tab=invoices` | **PASS** | Direct load selects Invoices tab. |
+
+**Verdict: FAIL on the visible primitive**, PASS on deep-link preservation. TER-1305 needs a flag check or render-path review — the schema may have shipped without a consumer.
+
+---
+
+### Block 9 — FreshnessBadge (TER-1296)
+
+| Test | Page | Verdict | Evidence |
+| ---- | ---- | ------- | -------- |
+| 9.1 Main dashboard | `/` | **PASS** | `Live Updated: 10:28 PM` visible in the page header next to "Thursday, Apr 23 – Here's what needs your attention today". `27-home-kpis.png` |
+| 9.2 `/relationships?tab=clients` | | **FAIL** | `freshnessBadge` querySelector returned `null`. Green `✓ Saved` pill is still present. `03-clients.png` |
+| 9.3 `/sales?tab=orders` Standard View | | **FAIL** | `Saved` pill present; no freshness badge. `19-standard-view.png` |
+| 9.4 `/accounting?tab=dashboard` | | **FAIL** | No freshness indicator on KPI cards or page header. `10-accounting-dash.png` |
+
+**Verdict: PARTIAL.** Primitive is live only on the main dashboard; has **not** replaced the "Saved" pill on the other surfaces listed in TER-1296.
+
+---
+
+### Block 10 — Glossary changes (TER-1315)
+
+| Surface | "Customer" / "Buyer" / "Vendor Invoice" still present? | Verdict |
+| ------- | ------------------------------------------------------ | ------- |
+| 10.1 `/relationships?tab=clients` column headers | Column headers use correct "Clients", "Suppliers" as tabs; "Relationship", "Status", "Last Activity", "LTV", "Debt", "Orders" columns. | **PASS** on columns |
+| 10.2 `/relationships?tab=clients` page text (full sweep) | **`Customer` appears 31 times** (e.g. "Recent Customers" sidebar link, row-type labels). **`Buyer` appears 22 times** (e.g. relationship-type label for each row). `Client` appears only 2 times. | **FAIL** |
+| 10.3 Sidebar Sales Quick Actions | "Recent Customers" link visible. | **FAIL** |
+| 10.4 Order Creator header + CTA | Header: `"KEEP THE CUSTOMER, DOCUMENT TYPE, AND TOTALS IN ONE WORKING FRAME"`. Empty state: `"Select a customer to start this order. Choose a customer above to begin a new order…"`. Combobox button label: `"Customer…"`. Empty search state: `"No customers - Try a different search term"`. | **FAIL** |
+| 10.5 `/inventory` | "SKU" used in search placeholder; no "Inventory Line" label. "Item" only appears inside generated SKU strings. | **PASS (with caveat)** |
+| 10.6 `/accounting?tab=bills` | `Vendor Invoice` → **0 occurrences** ✅. `Vendor` → 1 occurrence ("Pay Vendor" button, should be "Pay Supplier"). `Bill` → 3 occurrences. | **PASS on literal test**, **minor glossary miss on "Pay Vendor" button** |
+
+**Verdict: PARTIAL FAIL.** The glossary sweep did not reach the Order Creator header/CTA/placeholder, the relationships grid text, or the sidebar "Recent Customers" label.
+
+---
+
+### Block 11 — Sales Catalogue fixes (TER-1011 / TER-1012 / TER-1013)
+
+| Test | Verdict | Evidence |
+| ---- | ------- | -------- |
+| 11.1 `$0` price persistence (TER-1011) | **NOT TESTED** | Creating + persisting a catalogue line with an explicit `$0` price requires client selection + item add + save + reload on staging data. Avoided mutating staging state. Sales Catalogue builder loads correctly (`Sales Catalogue` tab, `Draft name`, `Client` input, empty-state "Select a client to start building a catalogue", Handoff strip with Share Link / → Sales Order / → Quote / Live). `25-catalogues.png`, `26-sales-catalogues.png` |
+| 11.2 Share error toast (TER-1012) | **NOT TESTED** | Requires an existing saved catalogue to trigger Share. No fixture available. |
+| 11.3 Print preview (TER-1013) | **NOT TESTED** | Same blocker. |
+
+**Verdict: NOT TESTED.** Recommend seeding a staging fixture catalogue (e.g., `QA Zero-Price Sheet`) so these three regressions can be re-verified through the UI.
+
+---
+
+## 3. Known-issues recheck (TER-1253 → TER-1260)
+
+| Issue | Status | Evidence |
+| ----- | ------ | -------- |
+| **TER-1253** Raw HTML in Invoices Amount Due | **PARTIALLY FIXED / NEW REGRESSIONS** | Amount Due on Invoices → FIXED (clean `<span>` renders). Status column on Invoices → literal `<span class="…">Paid</span>` text (21 cells). Due Amt + Status on Bills → same raw-HTML-as-text pattern. The fix migrated the bug instead of eliminating it. **Reopen or file successor ticket.** |
+| **TER-1254** `evans-mac-mini.tailbe55dd.ts.net` | **STILL OPEN — CRITICAL** | Browser console shows **426 instances** of `Connecting to 'https://evans-mac-mini.tailbe55dd.ts.net/sessions'` / `/health` being blocked by CSP `default-src 'self'`. Source: `[Agentation] Failed to initialize session, using local storage: TypeError: Failed to fetch` with stack into `react-vendor-DDLUwdO5.js`. The tailnet URL is still compiled into the production client. |
+| **TER-1255** Accounting Dashboard $0 AR | **PARTIALLY FIXED** | Main dashboard `/` shows `$963,104` Outstanding Receivables with `41 open invoices` — FIXED. `/accounting?tab=dashboard` "RECEIVABLES" card shows `$963,103.66 · 371 overdue invoices ready for follow-up` — also FIXED. `10-accounting-dash.png`, `27-home-kpis.png` |
+| **TER-1256** Order detail 100× inflated totals | **FIXED** | Sales order drawer (S-1774561722503, Sunset Dispensary) shows Total `$761.32` matching grid total `$761.32`. `20-order-detail.png`. Invoice drawer (INV-000120) shows `Total $8,535.78` matching grid total `$8,535.78`. `17-invoice-drawer.png`. No 100× inflation observed. |
+| **TER-1257** Standard View shows 0 orders | **FIXED** | `/sales?surface=classic` Standard View displays populated grid with 50+ orders and counts `Drafts 50 · Pending 37 · Ready 6 · Shipped 7`. `19-standard-view.png` |
+| **TER-1258** Dashboard Inventory Value "—" | **FIXED** | Main dashboard shows `INVENTORY VALUE $34.2M · 38,185 live units`. `27-home-kpis.png` |
+| **TER-1259** QA test clients in picker | **FIXED** | Order Creator client picker shows real clients (Sunset Dispensary, Mendocino Supply, San Jose Supply, Emerald Organics 7, etc.). Typing "QA" returns empty state `"No customers - Try a different search term"`. No `QA Write-Path Client` fixtures leaked. `22-client-picker.png`, `24-client-search.png` |
+| **TER-1260** `/sales/new` → 404 | **FIXED** | `/sales/new` redirects cleanly to `/sales?tab=create-order` and renders the Order Creator. `06-sales-new.png`, `21-order-creator.png` |
+
+---
+
+## 4. New bugs found
+
+### 🚨 CRITICAL
+
+1. **TER-1254 sibling: `evans-mac-mini.tailbe55dd.ts.net` still compiled into production client**
+   - **Severity**: Critical
+   - **Repro**: Load any staging page with DevTools Console open. Observe repeated CSP block messages.
+   - **Evidence**: `Connecting to 'https://evans-mac-mini.tailbe55dd.ts.net/sessions' violates the following Content Security Policy directive: "default-src 'self'". …` — 426 occurrences in a single session's console. Call stack: `[Agentation] Failed to initialize session, using local storage: TypeError: Failed to fetch at j_ (…/react-vendor-DDLUwdO5.js:2130:2496)`.
+   - **Impact**: A developer-owned tailnet hostname is shipped to every user in the production-equivalent client bundle. CSP blocks the egress, so no data leaks, but the URL identifies Evan's personal machine and is a compliance red flag.
+   - **Suggested Linear label**: `security · production · client-bundle · TER-1254-follow-up`
+
+2. **TER-1253 regression: Status column on Invoices + Bills renders raw HTML as text**
+   - **Severity**: Critical (data presentation)
+   - **Repro**: Navigate to `/accounting?tab=invoices` or `/accounting?tab=bills`. Observe Status column (and Due Amt on Bills) for any row.
+   - **Evidence**: DOM inspection of `[col-id="status"][role="gridcell"]` on Invoices: `innerHTML = "&lt;span class=\"inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200\"&gt;Paid&lt;/span&gt;"`. Same on Bills. Bills `amountDueFormatted` column: `innerHTML = "&lt;span class=\"font-mono\"&gt;$0.00&lt;/span&gt;"`.
+   - **Impact**: Users see developer markup as cell text in two user-facing accounting grids. On Bills, this is the visible Due Amt column (not off-screen like on Invoices). Cannot distinguish paid vs draft vs overdue without hovering / inspecting the DOM.
+   - **Suggested Linear label**: `bug · accounting · regression · TER-1253-continued`
+
+### HIGH
+
+3. **Accounting tabGroups 4-group reorg (TER-1305) not rendered**
+   - **Severity**: High (feature didn't ship)
+   - **Repro**: `/accounting` still shows 10 flat tabs.
+   - **Impact**: Information architecture benefit promised by TER-1305 not delivered.
+   - **Suggested label**: `bug · feature-flag · TER-1305-follow-up`
+
+4. **ClientProfilePage breadcrumb shows `#105` instead of client name (TER-1297 UX-2)**
+   - **Severity**: High
+   - **Repro**: `/clients/105` → breadcrumb = `Home > Clients > #105`.
+   - **Impact**: Users cannot identify which client profile they're on from the breadcrumb.
+   - **Suggested label**: `bug · breadcrumb · TER-1297`
+
+5. **OrderCreatorPage breadcrumb missing "New Order" segment (TER-1297 UX-4)**
+   - **Severity**: High
+   - **Repro**: `/sales/new` or `/sales?tab=create-order` → breadcrumb = `Home > Sales`.
+   - **Impact**: No breadcrumb affordance that the user is inside a create flow.
+   - **Suggested label**: `bug · breadcrumb · TER-1297`
+
+6. **`/sales` header has two filled primary buttons (violates TER-1295)**
+   - **Severity**: High
+   - **Repro**: `/sales?tab=orders` Spreadsheet surface. Orange "Spreadsheet View" toggle and orange "New Order" action co-exist with the same visual weight.
+   - **Suggested label**: `bug · page-header · TER-1295`
+
+7. **Glossary: "Customer" and "Buyer" widespread on `/relationships?tab=clients` + Order Creator**
+   - **Severity**: High (product language consistency)
+   - **Repro**: `/relationships?tab=clients` → body text scan: 31× "Customer", 22× "Buyer". `/sales?tab=create-order` → header + empty-state CTA + combobox placeholder use "Customer". Sidebar → "Recent Customers".
+   - **Impact**: Party-model terminology is inconsistent after the TER-1315 sweep.
+   - **Suggested label**: `bug · glossary · TER-1315-follow-up`
+
+8. **ManusSheet drawer missing "Esc to close" hint and focus-return behavior (TER-1294)**
+   - **Severity**: High (accessibility / task-checklist)
+   - **Repro**: Open invoice detail drawer (INV-000120) or client drawer. Esc hint absent from header/footer. After Escape closes drawer, `document.activeElement === document.body` (focus does not return to opening element).
+   - **Suggested label**: `bug · drawer · TER-1294-follow-up`
+
+### MEDIUM
+
+9. **FreshnessBadge not wired on `/clients`, `/sales`, `/accounting/dashboard` (TER-1296)**
+   - **Severity**: Medium
+   - **Repro**: Main dashboard shows new badge (`Live Updated: 10:28 PM`); the other three pages still show legacy green `Saved` pill with no timestamp.
+   - **Suggested label**: `bug · freshness-badge · TER-1296-follow-up`
+
+10. **Sidebar navState `collapsedGroups` not written on user click (TER-1306)**
+    - **Severity**: Medium
+    - **Repro**: `/accounting` → click "Finance" group toggle → `aria-expanded` flips to `false` but `localStorage['terp-navigation-state:user:1'].collapsedGroups` remains `[]`. Reload reverts to route-driven default.
+    - **Impact**: Promised "persisted sidebar group state" is half-wired.
+    - **Suggested label**: `bug · sidebar · TER-1306-follow-up`
+
+11. **Home `Today at a Glance` error state is missing a retry button (TER-1284)**
+    - **Severity**: Medium
+    - **Repro**: `/` shows `Unable to load daily snapshot - Transaction or inbox data could not be loaded` in a styled card, but no "Retry" button is present.
+    - **Suggested label**: `bug · error-state · TER-1284-follow-up`
+
+### LOW
+
+12. **"Pay Vendor" button on `/accounting?tab=bills` uses deprecated term**
+    - **Severity**: Low (glossary)
+    - **Repro**: Bills workspace → "Pay Vendor" in the command strip. Should be "Pay Supplier".
+    - **Suggested label**: `bug · glossary · TER-1315-follow-up`
+
+13. **`/settings/users` returns a 404 (direct route only; `?tab=users` works)**
+    - **Severity**: Low
+    - **Repro**: `/settings/users` → 404 page; `/settings?tab=users` renders correctly.
+    - **Impact**: Direct-link and external docs that reference `/settings/users` will break.
+    - **Suggested label**: `bug · route-registry · TER-1260-follow-up`
+
+### Console errors observed across navigation
+- **`Failed to load resource: the server responded with a status of 500 ()`** — 6+ instances during a typical session. The call URL is not logged in the error message; investigate via DevTools Network tab for endpoints returning 500 under DEMO_MODE super admin.
+- **`[Agentation] Failed to initialize session, using local storage: TypeError: Failed to fetch`** — tied to TER-1254 (CSP-blocked tailnet calls).
+- No uncaught JS exceptions observed; the 500s appear to be handled gracefully by UI fallbacks.
+
+---
+
+## 5. Screenshots taken (this session)
+
+All saved to `docs/qa-reports/screenshots/ux-v2-2026-04-23/`:
+
+| # | Filename | Block / context |
+| - | -------- | --------------- |
+| 00 | `00-home.png` | Initial auto-logged-in home dashboard |
+| 01 | `01-invoices.png` | `/accounting?tab=invoices` populated grid (Block 2 & 8 evidence) |
+| 02 | `02-bills.png` | `/accounting?tab=bills` showing raw HTML in Due Amt column |
+| 03 | `03-clients.png` | `/relationships?tab=clients` — legacy "Saved" pill, no FreshnessBadge |
+| 04 | `04-client-profile.png` | Sierra Nevada Farms drawer after row click |
+| 05 | `05-client-full-profile.png`, `05b-client-drawer.png`, `05c-current.png` | Full client profile (breadcrumb `Clients > #105`) + nav side-effects |
+| 06 | `06-sales-new.png` | `/sales/new` redirected to Order Creator (Block 5 + TER-1260) |
+| 07 | `07-404.png`, `07b-404-verify.png` | 404 page with `Home > Accounting > Doesnotexist` breadcrumb |
+| 08 | `08-analytics.png` | `/analytics` header (zero primaries) |
+| 09 | `09-feature-flags.png`, `09b-feature-flags.png` | Feature Controls page (TER-1295 verification) |
+| 10 | `10-accounting-dash.png` | Accounting dashboard — "Pay Supplier" sole primary, 10 flat tabs |
+| 11 | `11-sales.png` | `/sales` — two primary buttons ("Spreadsheet View" + "New Order") |
+| 12 | `12-inventory.png`, `12b-inventory.png`, `12c-inventory.png` | Inventory kanban with filter strip |
+| 13 | `13-bank-accounts.png` | Bank Accounts grid (currency alignment) |
+| 14 | `14-users.png`, `14b-users.png`, `14c-users-scrolled.png` | `/settings/users` 404 and `/settings?tab=users` form |
+| 15-17 | `15-invoice-drawer.png`, `15b-inv.png`, `16-inv-for-drawer.png`, `17-invoice-drawer.png` | Invoice detail drawer iteration |
+| 18 | `18-sales-orders.png` | `/sales` Spreadsheet View with command strip |
+| 19 | `19-standard-view.png` | `/sales?surface=classic` Standard View (TER-1257 fixed) |
+| 20 | `20-order-detail.png` | Sales order detail drawer (TER-1256 — totals match) |
+| 21 | `21-order-creator.png` | Order Creator empty state (Block 5 + glossary) |
+| 22-24 | `22-client-picker.png`, `23-client-picker-QA.png`, `24-client-search.png` | Client picker + QA search (TER-1259 verified) |
+| 25-26 | `25-catalogues.png`, `26-sales-catalogues.png` | Sales Catalogue builder (Block 11 not tested) |
+| 27 | `27-home-kpis.png` | Home dashboard KPIs + FreshnessBadge + error state (TER-1258, TER-1296, Block 1) |
+
+---
+
+## 6. Environment & tool notes
+
+- `agent-browser` (personal install at `~/.factory/tools/agent-browser/bin/agent-browser`) with bundled Chromium via Playwright.
+- All navigation used staging auto-login under `DEMO_MODE=true` as Super Admin. Role-based tests (e.g., "as qa.accounting@terp.test") were **not** rerun; follow-up pass needed if permission surfaces are in scope.
+- Click-by-text sometimes landed on sidebar links instead of the intended page control (global click handlers intercepted). Where the click destination was incorrect, that is called out in the evidence column. This caused Block 6 URL-filter deep-link and Block 3 users drawer test to be partially inconclusive.
+- No production traffic was touched. No PR opened. No commits made.
+
+---
+
+**Report generated**: 2026-04-23 by Factory Droid (Exec Mode) using `agent-browser` for live browser evidence.
+**Status**: Complete — see Section 4 for bug intake to file in Linear.


### PR DESCRIPTION
Adds live browser QA report for Epic TER-1283 UX v2 wave. 12 follow-up bugs filed as TER-1360 through TER-1371. Screenshots in docs/qa-reports/screenshots/ux-v2-2026-04-23/.