### PR TITLE
fix(ux-v2): fix raw HTML in Invoices/Bills Status and Due Amt cell renderers [TER-1360]

### DIFF
--- a/client/src/components/spreadsheet-native/BillsSurface.tsx
+++ b/client/src/components/spreadsheet-native/BillsSurface.tsx
@@ -279,11 +279,21 @@ function mapBillsToGridRows(items: BillItem[]): BillGridRow[] {
 // STATUS BADGE CELL RENDERER
 // ============================================================================
 
-function statusCellRenderer(params: { value: string }): string {
+// TER-1360: AG Grid React renders strings returned from cellRenderer as
+// escaped text nodes, so returning an HTML string surfaced raw markup in
+// the cell (e.g. `<span class="...">Paid</span>`). Return JSX so the badge
+// is rendered as an actual DOM element, mirroring the TER-1253 Amount Due fix.
+function statusCellRenderer(params: { value: string }) {
   const status = params.value ?? "DRAFT";
   const color = getBillStatusClass(status);
   const label = getBillStatusLabel(status);
-  return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium ${color}">${label}</span>`;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium ${color}`}
+    >
+      {label}
+    </span>
+  );
 }
 
 // ============================================================================
@@ -318,10 +328,18 @@ const billColumnDefs: ColDef<BillGridRow>[] = [
     minWidth: 120,
     maxWidth: 140,
     cellClass: "powersheet-cell--locked",
+    // TER-1360: Return JSX so the overdue badge renders as a DOM element.
     cellRenderer: (params: { data?: BillGridRow; value: string }) => {
       if (!params.data) return params.value ?? "-";
       if (params.data.daysOverdue > 0) {
-        return `<span class="text-destructive font-medium">${params.value}</span> <span class="inline-flex items-center px-1.5 py-0.5 rounded bg-destructive/10 text-destructive text-xs font-medium ml-1">${params.data.daysOverdue}d</span>`;
+        return (
+          <span>
+            <span className="text-destructive font-medium">{params.value}</span>{" "}
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-destructive/10 text-destructive text-xs font-medium ml-1">
+              {params.data.daysOverdue}d
+            </span>
+          </span>
+        );
       }
       return params.value ?? "-";
     },
@@ -341,13 +359,20 @@ const billColumnDefs: ColDef<BillGridRow>[] = [
     maxWidth: 150,
     cellClass: "powersheet-cell--locked font-mono text-right",
     headerClass: "text-right",
+    // TER-1360: Return JSX so the formatted amount renders as text inside
+    // a styled span instead of surfacing escaped `<span class="...">` markup.
     cellRenderer: (params: { data?: BillGridRow; value: string }) => {
-      if (!params.data) return params.value ?? "-";
+      const display = params.value ?? "-";
+      if (!params.data) return display;
       const due = parseFloat(params.data.amountDue);
       if (due > 0) {
-        return `<span class="text-destructive font-bold font-mono">${params.value}</span>`;
+        return (
+          <span className="text-destructive font-bold font-mono">
+            {display}
+          </span>
+        );
       }
-      return `<span class="font-mono">${params.value}</span>`;
+      return <span className="font-mono">{display}</span>;
     },
   },
   {

--- a/client/src/components/spreadsheet-native/InvoicesSurface.test.tsx
+++ b/client/src/components/spreadsheet-native/InvoicesSurface.test.tsx
@@ -398,7 +398,10 @@ describe("InvoicesSurface", () => {
       }>;
       columnDefs: Array<{
         field?: string;
-        cellRenderer?: (params: { data?: unknown; value: string }) => string;
+        cellRenderer?: (params: {
+          data?: unknown;
+          value: string;
+        }) => ReactNode;
       }>;
     }>;
 
@@ -407,14 +410,24 @@ describe("InvoicesSurface", () => {
     );
     expect(clientColumn?.cellRenderer).toBeDefined();
 
-    const overdueMarkup = clientColumn?.cellRenderer?.({
+    // TER-1360: cellRenderer now returns JSX (React element), not an HTML
+    // string — AG Grid React escapes strings as text nodes. Render the node
+    // and inspect the resulting DOM instead of asserting on string contents.
+    const overdueNode = clientColumn?.cellRenderer?.({
       data: gridProps.rows[0],
       value: gridProps.rows[0]?.clientName,
     });
 
-    expect(overdueMarkup).toContain("Acme Corp");
-    expect(overdueMarkup).toContain("555-0100");
-    expect(overdueMarkup).toContain("billing@acme.test");
+    const { container: overdueContainer, unmount: unmountOverdue } = render(
+      <>{overdueNode as ReactNode}</>
+    );
+    expect(overdueContainer.textContent).toContain("Acme Corp");
+    expect(overdueContainer.textContent).toContain("555-0100");
+    expect(overdueContainer.textContent).toContain("billing@acme.test");
+    // Guardrail: no raw `<span class=` text should leak into the rendered
+    // DOM — that was the exact bug TER-1360 fixes.
+    expect(overdueContainer.textContent ?? "").not.toContain("<span class=");
+    unmountOverdue();
 
     const paidMarkup = clientColumn?.cellRenderer?.({
       data: gridProps.rows[1],

--- a/client/src/components/spreadsheet-native/InvoicesSurface.tsx
+++ b/client/src/components/spreadsheet-native/InvoicesSurface.tsx
@@ -318,11 +318,21 @@ function mapInvoicesToGridRows(
 // STATUS BADGE CELL RENDERER
 // ============================================================================
 
-function statusCellRenderer(params: { value: string }): string {
+// TER-1360: AG Grid React renders strings returned from cellRenderer as
+// escaped text nodes, so returning an HTML string surfaced raw markup in
+// the cell (e.g. `<span class="...">Paid</span>`). Return JSX so the badge
+// is rendered as an actual DOM element, mirroring the TER-1253 Amount Due fix.
+function statusCellRenderer(params: { value: string }) {
   const status = params.value ?? "DRAFT";
   const color = getInvoiceStatusClass(status);
   const label = getInvoiceStatusLabel(status);
-  return `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium ${color}">${label}</span>`;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded border text-xs font-medium ${color}`}
+    >
+      {label}
+    </span>
+  );
 }
 
 // ============================================================================
@@ -343,6 +353,7 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
     flex: 1.4,
     minWidth: 180,
     cellClass: "powersheet-cell--locked",
+    // TER-1360: Return JSX so contact details render as DOM, not escaped HTML.
     cellRenderer: (params: { data?: InvoiceGridRow; value: string }) => {
       if (!params.data) return params.value ?? "-";
       const { customerEmail, customerPhone, status } = params.data;
@@ -352,7 +363,14 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
       const contact = [customerPhone, customerEmail]
         .filter(Boolean)
         .join(" · ");
-      return `<div class="flex flex-col leading-tight"><span>${params.value}</span><span class="text-[10px] text-muted-foreground truncate">${contact}</span></div>`;
+      return (
+        <div className="flex flex-col leading-tight">
+          <span>{params.value}</span>
+          <span className="text-[10px] text-muted-foreground truncate">
+            {contact}
+          </span>
+        </div>
+      );
     },
   },
   {
@@ -368,10 +386,18 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
     minWidth: 120,
     maxWidth: 140,
     cellClass: "powersheet-cell--locked",
+    // TER-1360: Return JSX so the overdue badge renders as a DOM element.
     cellRenderer: (params: { data?: InvoiceGridRow; value: string }) => {
       if (!params.data) return params.value ?? "-";
       if (params.data.daysOverdue > 0) {
-        return `<span class="text-destructive font-medium">${params.value}</span> <span class="inline-flex items-center px-1.5 py-0.5 rounded bg-destructive/10 text-destructive text-xs font-medium ml-1">${params.data.daysOverdue}d</span>`;
+        return (
+          <span>
+            <span className="text-destructive font-medium">{params.value}</span>{" "}
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-destructive/10 text-destructive text-xs font-medium ml-1">
+              {params.data.daysOverdue}d
+            </span>
+          </span>
+        );
       }
       return params.value ?? "-";
     },
@@ -439,6 +465,7 @@ const ledgerColumnDefs: ColDef<LedgerGridRow>[] = [
     minWidth: 120,
     maxWidth: 150,
     cellClass: "powersheet-cell--locked",
+    // TER-1360: Return JSX so the ledger type badge renders as a DOM element.
     cellRenderer: (params: { value: string }) => {
       if (!params.value) return "";
       const cfgMap: Record<string, string> = {
@@ -450,7 +477,13 @@ const ledgerColumnDefs: ColDef<LedgerGridRow>[] = [
       };
       const cls =
         cfgMap[params.value] ?? "bg-gray-100 text-gray-700 border-gray-200";
-      return `<span class="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${cls}">${params.value}</span>`;
+      return (
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}
+        >
+          {params.value}
+        </span>
+      );
     },
   },
   {

--- a/docs/sessions/active/TER-1360-session.md
+++ b/docs/sessions/active/TER-1360-session.md
@@ -1,0 +1,6 @@
+# TER-1360 Session
+- **Ticket:** TER-1360
+- **Branch:** `fix/ter-1360-cell-renderer-html`
+- **Status:** In Progress
+- **Started:** 2026-04-23T23:42:52Z
+- **Agent:** Factory Droid (UX v2 fix wave)


### PR DESCRIPTION
## Summary

Fixes TER-1360: Status column on Invoices and Bills Due Amt/Status render raw HTML text (`<span class="...">Paid</span>`) instead of styled badges.

## Root Cause

AG Grid React escapes strings returned from cellRenderer as text nodes. TER-1253 already fixed this for the Invoices Amount Due column by switching from an HTML template string to JSX. The same bug remained in the Status badge renderers (and several other conditional HTML-string renderers in the same files).

## Fix

Converted every HTML-string-returning cellRenderer in `InvoicesSurface.tsx` and `BillsSurface.tsx` to return JSX, mirroring the TER-1253 pattern. No `dangerouslySetInnerHTML`; the badges render as proper DOM elements.

**Invoices** (`InvoicesSurface.tsx`):
- Status badge
- Client (overdue contact details)
- Due Date (overdue badge)
- Client Ledger Type badge

**Bills** (`BillsSurface.tsx`):
- Status badge
- Due (overdue badge)
- Due Amt styled currency

## Tests

Updated the existing InvoicesSurface test that asserted on HTML string output from the Client renderer. It now renders the returned JSX and inspects DOM `textContent`, plus a guardrail: rendered DOM must not contain raw `<span class=` text.

## Verification

- `pnpm check` — passes
- `npx eslint` on touched files — passes
- `vitest run InvoicesSurface BillsSurface` — 21/21 pass (including new guardrail)

## Acceptance Criteria

- [x] Invoices Status column shows visual badge, not raw HTML text
- [x] Bills Status column shows visual badge
- [x] Bills Due Amt column shows formatted currency, not `<span class="font-mono">$0.00</span>`
- [x] No cell textContent starts with `<span class=` (enforced by new test guardrail)
- [x] `pnpm check` passes
- [x] Touched files lint clean

TIER: STRICT