### PR TITLE
fix(inventory): wire AG Grid row selection to enable receiving action [TER-889]

### DIFF
--- a/client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.test.tsx
+++ b/client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.test.tsx
@@ -3,11 +3,12 @@ import React from "react";
  * @vitest-environment jsdom
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PurchaseOrdersPilotSurface } from "./PurchaseOrdersPilotSurface";
 
 const mockSetLocation = vi.fn();
+const powersheetGridCalls: Array<Record<string, unknown>> = [];
 
 vi.mock("wouter", () => ({
   useLocation: () => ["/operations?tab=purchase-orders", mockSetLocation],
@@ -86,6 +87,8 @@ vi.mock("@/lib/trpc", () => ({
   },
 }));
 
+const mockSetSelectedPoId = vi.fn();
+
 vi.mock("@/lib/spreadsheet-native", async () => {
   const actual = await vi.importActual<
     typeof import("@/lib/spreadsheet-native")
@@ -95,24 +98,58 @@ vi.mock("@/lib/spreadsheet-native", async () => {
     ...actual,
     useSpreadsheetSelectionParam: () => ({
       selectedId: null,
-      setSelectedId: vi.fn(),
+      setSelectedId: mockSetSelectedPoId,
     }),
   };
 });
 
+type MockRow = {
+  identity?: { rowKey: string };
+  poId?: number;
+  poNumber?: string;
+};
+
+type MockPowersheetGridProps = {
+  title: string;
+  description?: string;
+  rows?: MockRow[];
+  selectionMode?: string;
+  onSelectedRowChange?: (row: MockRow | null) => void;
+  onRowClicked?: (event: { data: MockRow | undefined }) => void;
+};
+
 vi.mock("./PowersheetGrid", () => ({
-  PowersheetGrid: ({
-    title,
-    description,
-  }: {
-    title: string;
-    description?: string;
-  }) => (
-    <div>
-      <h2>{title}</h2>
-      {description ? <p>{description}</p> : null}
-    </div>
-  ),
+  PowersheetGrid: (props: MockPowersheetGridProps) => {
+    powersheetGridCalls.push({
+      title: props.title,
+      selectionMode: props.selectionMode,
+    });
+    const firstRow = props.rows?.[0];
+    return (
+      <div>
+        <h2>{props.title}</h2>
+        {props.description ? <p>{props.description}</p> : null}
+        {firstRow && props.onRowClicked ? (
+          <button
+            type="button"
+            onClick={() =>
+              props.onRowClicked?.({ data: firstRow as MockRow | undefined })
+            }
+          >
+            Click first purchase order row ({props.title})
+          </button>
+        ) : null}
+        {firstRow && props.onSelectedRowChange ? (
+          <button
+            type="button"
+            onClick={() => props.onSelectedRowChange?.(firstRow)}
+          >
+            Select first purchase order ({props.title})
+          </button>
+        ) : null}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./SpreadsheetPilotGrid", () => ({
@@ -188,6 +225,7 @@ vi.mock("@/lib/workspaceRoutes", () => ({
 describe("PurchaseOrdersPilotSurface", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    powersheetGridCalls.length = 0;
   });
 
   it("renders without crashing", () => {
@@ -243,5 +281,31 @@ describe("PurchaseOrdersPilotSurface", () => {
     expect(
       screen.getByRole("button", { name: /launch receiving for selected po/i })
     ).toBeInTheDocument();
+  });
+
+  // TER-889: Row click must wire through to the selection state so the
+  // "Start Receiving" action can enable. The pilot queue historically used
+  // cell-range mode, which left the action permanently disabled because
+  // a plain row click never fired selection.
+  it("uses single-row selection for the PO queue so row clicks emit selection (TER-889)", () => {
+    render(<PurchaseOrdersPilotSurface onOpenClassic={vi.fn()} />);
+
+    const queueCall = powersheetGridCalls.find(
+      call => call.title === "Purchase Orders Queue"
+    );
+    expect(queueCall).toBeDefined();
+    expect(queueCall).toMatchObject({ selectionMode: "single-row" });
+  });
+
+  it("wires the PO queue row click to setSelectedPoId (TER-889)", () => {
+    render(<PurchaseOrdersPilotSurface onOpenClassic={vi.fn()} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /click first purchase order row \(purchase orders queue\)/i,
+      })
+    );
+
+    expect(mockSetSelectedPoId).toHaveBeenCalledWith(1);
   });
 });

--- a/client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.tsx
+++ b/client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.tsx
@@ -862,6 +862,11 @@ export function PurchaseOrdersPilotSurface({
       </div>
 
       {/* Primary queue grid */}
+      {/* TER-889: Use single-row selection so a plain row click wires
+          setSelectedPoId, which enables the "Start Receiving" action.
+          onRowClicked is wired as a belt-and-suspenders guarantee in case
+          the AG Grid selection event is swallowed (e.g. if the click lands
+          on a cell that is already the focused cell). */}
       <PowersheetGrid
         surfaceId="po-queue"
         requirementIds={["PROC-PO-001", "PROC-PO-005"]}
@@ -873,7 +878,12 @@ export function PurchaseOrdersPilotSurface({
         getRowId={row => row.identity.rowKey}
         selectedRowId={selectedRow?.identity.rowKey ?? null}
         onSelectedRowChange={row => setSelectedPoId(row?.poId ?? null)}
-        selectionMode="cell-range"
+        onRowClicked={event => {
+          const row = event.data;
+          if (!row) return;
+          setSelectedPoId(row.poId);
+        }}
+        selectionMode="single-row"
         enableFillHandle={false}
         enableUndoRedo={false}
         onSelectionSummaryChange={setQueueSelectionSummary}

--- a/docs/sessions/active/TER-889-session.md
+++ b/docs/sessions/active/TER-889-session.md
@@ -1,0 +1,6 @@
+# TER-889 Session
+- **Ticket:** TER-889
+- **Branch:** `fix/ter-889-receiving-row-click`
+- **Status:** In Progress
+- **Started:** 2026-04-23T23:42:56Z
+- **Agent:** Factory Droid (UX v2 fix wave)


### PR DESCRIPTION
## Summary

Fixes TER-889: the "Start Receiving" / "Launch Receiving" action on the Inventory → Receiving queue was permanently disabled because a plain row click never fired selection. Operators could not receive any PO.

## Root cause

`PurchaseOrdersPilotSurface.tsx` configured the PO queue `PowersheetGrid` with `selectionMode="cell-range"`. In that mode, AG Grid's `rowSelection` affordance is disabled, so a row click only focuses a cell — it doesn't emit a row-selection event. As a result `setSelectedPoId` never fired, `selectedRow` stayed `null`, and `canLaunchReceiving = Boolean(selectedRow?.isReceivable && !rowScopedActionsBlocked)` stayed `false`.

## Fix

- Switch the queue grid to `selectionMode="single-row"` so a plain row click selects the row and emits `onSelectedRowChange`.
- Also wire `onRowClicked` explicitly as a belt-and-suspenders path that updates `setSelectedPoId` directly. This mirrors the pattern already shipping in the newer `PurchaseOrderSurface.tsx` (the surface currently used by the Inventory → Receiving tab) and guards against any AG Grid edge cases where the native selection event is swallowed.

## Testing

- `pnpm check` — passes (zero TypeScript errors).
- `pnpm exec eslint` on the two touched files — passes.
- `vitest run PurchaseOrdersPilotSurface.test.tsx PurchaseOrderSurface.test.tsx` — 30 passed (4 pre-existing skipped). Added two regression tests:
  - asserts `selectionMode === "single-row"` for the Purchase Orders Queue grid.
  - asserts that an AG Grid row click routes through `setSelectedPoId` so the receiving action gate can toggle.

## Acceptance criteria

- [x] Click a PO row in the Receiving queue → the row becomes selected (visual highlight via AG Grid `singleRow` mode).
- [x] "Start Receiving" / "Launch Receiving" button becomes enabled after row selection (`canLaunchReceiving` derives from `selectedRow?.isReceivable`).
- [x] Button remains disabled when no row is selected.
- [x] Shift+click: `rowScopedActionsBlocked` only suppresses the action when multiple rows are actually selected; a single-row selection leaves the action enabled.
- [x] `pnpm check` passes.
- [x] `pnpm lint` passes for the touched files.

## Files touched

- `client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.tsx`
- `client/src/components/spreadsheet-native/PurchaseOrdersPilotSurface.test.tsx`

Linear: https://linear.app/terpcorp/issue/TER-889