### PR TITLE
fix(ux-v2): breadcrumb resolvers for client/order-creator + /sales single primary [TER-1362/1363/1364]

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import NotFound from "@/pages/NotFound";
 import { Route, Switch } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { BreadcrumbProvider } from "./contexts/BreadcrumbContext";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import DashboardHomePage from "./pages/DashboardHomePage";
 import { AppShell } from "./components/layout/AppShell";
@@ -1114,24 +1115,26 @@ function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider defaultTheme="light" switchable>
-        <TooltipProvider>
-          <Toaster />
-          <VersionChecker />
-          <StagingAgentation />
-          <Router />
-          <CommandPalette
-            open={showCommandPalette}
-            onOpenChange={setShowCommandPalette}
-          />
-          <QuickAddTaskModal
-            isOpen={showQuickAddTask}
-            onClose={() => setShowQuickAddTask(false)}
-          />
-          <KeyboardShortcutsModal
-            open={showKeyboardShortcuts}
-            onOpenChange={setShowKeyboardShortcuts}
-          />
-        </TooltipProvider>
+        <BreadcrumbProvider>
+          <TooltipProvider>
+            <Toaster />
+            <VersionChecker />
+            <StagingAgentation />
+            <Router />
+            <CommandPalette
+              open={showCommandPalette}
+              onOpenChange={setShowCommandPalette}
+            />
+            <QuickAddTaskModal
+              isOpen={showQuickAddTask}
+              onClose={() => setShowQuickAddTask(false)}
+            />
+            <KeyboardShortcutsModal
+              open={showKeyboardShortcuts}
+              onOpenChange={setShowKeyboardShortcuts}
+            />
+          </TooltipProvider>
+        </BreadcrumbProvider>
       </ThemeProvider>
     </ErrorBoundary>
   );

--- a/client/src/components/layout/AppBreadcrumb.tsx
+++ b/client/src/components/layout/AppBreadcrumb.tsx
@@ -12,7 +12,7 @@
  */
 
 import React from "react";
-import { useLocation } from "wouter";
+import { useLocation, useSearch } from "wouter";
 import { Home, ChevronRight } from "lucide-react";
 import {
   Breadcrumb,
@@ -28,6 +28,10 @@ import {
   type BreadcrumbTrailEntry,
   type RouteEntityType,
 } from "@/config/routes";
+import {
+  useBreadcrumbResolvedNamesMap,
+  type BreadcrumbResolvedNames,
+} from "@/contexts/BreadcrumbContext";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { FEATURE_FLAGS } from "@/lib/constants/featureFlags";
 import { trpc } from "@/lib/trpc";
@@ -218,16 +222,55 @@ function useResolvedEntityLabel(
 }
 
 /**
+ * Look up an entry in the merged `resolvedNames` map (TER-1362). Accepts
+ * several candidate keys because page-level code tends to index by the
+ * entity id (`"105"`), but workspace-tab crumbs (`/sales?tab=create-order`)
+ * are only identifiable by the tab value. Returns the first non-empty match.
+ */
+function lookupResolvedName(
+  resolvedNames: BreadcrumbResolvedNames,
+  crumb: BreadcrumbTrailEntry
+): string | null {
+  const candidates: string[] = [];
+  if (crumb.entityId) candidates.push(crumb.entityId);
+
+  // Last path segment (e.g. `"create-order"` for `/sales?tab=create-order`).
+  const lastSegment = crumb.path
+    .split(/[?#]/, 1)[0]
+    ?.split("/")
+    .filter(Boolean)
+    .pop();
+  if (lastSegment) candidates.push(lastSegment);
+
+  for (const key of candidates) {
+    const value = resolvedNames[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
  * Map a registry-derived trail to the flat `BreadcrumbSegment[]` used by the
- * renderer. Applies the resolved label (if any) to the deepest entity-bearing
- * crumb and falls back to `<title> #<id>` for other (or unresolved) segments.
+ * renderer.
+ *
+ * Precedence for each crumb's display name (highest first):
+ *  1. Caller-supplied `resolvedNames` (prop + context, TER-1362).
+ *  2. Async tRPC entity resolution (for the shallowest entity-bearing crumb).
+ *  3. Literal registry title + `#<id>` fallback so users still see the id.
  */
 function trailToSegments(
   trail: readonly BreadcrumbTrailEntry[],
   resolvedFor: BreadcrumbTrailEntry | undefined,
-  resolvedLabel: string | null
+  resolvedLabel: string | null,
+  resolvedNames: BreadcrumbResolvedNames
 ): BreadcrumbSegment[] {
   return trail.map(crumb => {
+    const callerResolved = lookupResolvedName(resolvedNames, crumb);
+    if (callerResolved) {
+      return { name: callerResolved, path: crumb.path, isLast: crumb.isLast };
+    }
     if (
       resolvedFor &&
       resolvedLabel &&
@@ -252,22 +295,44 @@ interface AppBreadcrumbProps {
   customBreadcrumbs?: Array<{ name: string; path?: string }>;
   /** Optional class name for styling */
   className?: string;
+  /**
+   * TER-1362: Optional map from a raw route segment / tab value to a
+   * human-friendly display name. Useful for pages that want to supply an
+   * entity name directly rather than relying on the built-in tRPC resolver
+   * (or for query-param-driven sub-views such as `?tab=create-order`).
+   *
+   * Keys are matched against the crumb's entity id (e.g. `"105"`) and the
+   * last path segment (e.g. `"create-order"` for `/sales?tab=create-order`).
+   * Merged on top of any values registered via `BreadcrumbProvider`, with
+   * props winning on collision.
+   */
+  resolvedNames?: BreadcrumbResolvedNames;
 }
 
 export const AppBreadcrumb = React.memo(function AppBreadcrumb({
   customBreadcrumbs,
   className,
+  resolvedNames: resolvedNamesProp,
 }: AppBreadcrumbProps) {
   const [location] = useLocation();
+  const search = useSearch();
   const { enabled: registryEnabled } = useFeatureFlag(
     FEATURE_FLAGS.uxV2BreadcrumbRegistry
+  );
+  const resolvedNamesFromContext = useBreadcrumbResolvedNamesMap();
+
+  // TER-1362: prop values win over context values on key collision so
+  // direct callers retain full control.
+  const mergedResolvedNames = React.useMemo<BreadcrumbResolvedNames>(
+    () => ({ ...resolvedNamesFromContext, ...(resolvedNamesProp ?? {}) }),
+    [resolvedNamesFromContext, resolvedNamesProp]
   );
 
   // Derive the registry-backed trail (only used when the flag is on).
   const trail = React.useMemo<BreadcrumbTrailEntry[]>(() => {
     if (!registryEnabled || customBreadcrumbs) return [];
-    return buildBreadcrumbTrail(location);
-  }, [registryEnabled, customBreadcrumbs, location]);
+    return buildBreadcrumbTrail(location, search);
+  }, [registryEnabled, customBreadcrumbs, location, search]);
 
   // Resolve the shallowest entity-bearing crumb so parents like
   // `/clients/:id/ledger` still show the client name at the intermediate
@@ -289,7 +354,12 @@ export const AppBreadcrumb = React.memo(function AppBreadcrumb({
         isLast: index === customBreadcrumbs.length - 1,
       }))
     : registryEnabled
-      ? trailToSegments(trail, resolvableEntry, resolvedLabel)
+      ? trailToSegments(
+          trail,
+          resolvableEntry,
+          resolvedLabel,
+          mergedResolvedNames
+        )
       : buildLegacyBreadcrumbs(location);
 
   // Don't render if no breadcrumbs (home page)

--- a/client/src/components/spreadsheet-native/SheetModeToggle.test.tsx
+++ b/client/src/components/spreadsheet-native/SheetModeToggle.test.tsx
@@ -216,6 +216,10 @@ describe("SheetModeToggle", () => {
     });
   });
 
+  // TER-1364: View-mode toggle is not a primary action. The active tab uses
+  // the "secondary" variant (neutral selected state) rather than "default"
+  // (filled primary) so it doesn't compete with the real primary "New Order"
+  // CTA in the Sales workspace header. The inactive tab stays as "outline".
   it("renders a consistent active state for both modes", () => {
     render(
       <SheetModeToggle
@@ -227,7 +231,7 @@ describe("SheetModeToggle", () => {
 
     expect(
       screen.getByRole("tab", { name: "Spreadsheet View" })
-    ).toHaveAttribute("data-variant", "default");
+    ).toHaveAttribute("data-variant", "secondary");
     expect(
       screen.getByRole("tab", { name: "Standard View" })
     ).toHaveAttribute("data-variant", "outline");

--- a/client/src/components/spreadsheet-native/SheetModeToggle.tsx
+++ b/client/src/components/spreadsheet-native/SheetModeToggle.tsx
@@ -68,10 +68,16 @@ export function SheetModeToggle({
       role="tablist"
       aria-label="Surface view mode"
     >
+      {/*
+        TER-1364: View-mode toggle is not a primary action. The active tab
+        uses the "secondary" variant (neutral selected state) and the
+        inactive tab uses "outline" so neither button competes with the
+        filled primary "New Order" CTA in the Sales workspace header.
+      */}
       <Button
         ref={sheetNativeButtonRef}
         size="sm"
-        variant={surfaceMode === "sheet-native" ? "default" : "outline"}
+        variant={surfaceMode === "sheet-native" ? "secondary" : "outline"}
         role="tab"
         aria-selected={surfaceMode === "sheet-native"}
         aria-controls="surface-panel"
@@ -84,7 +90,7 @@ export function SheetModeToggle({
       <Button
         ref={classicButtonRef}
         size="sm"
-        variant={surfaceMode === "classic" ? "default" : "outline"}
+        variant={surfaceMode === "classic" ? "secondary" : "outline"}
         role="tab"
         aria-selected={surfaceMode === "classic"}
         aria-controls="surface-panel"

--- a/client/src/config/routes.ts
+++ b/client/src/config/routes.ts
@@ -296,6 +296,22 @@ export interface BreadcrumbTrailEntry {
   isLast: boolean;
 }
 
+/**
+ * TER-1363: Known workspace `?tab=…` values that should contribute an extra
+ * breadcrumb crumb (e.g. `/sales?tab=create-order` → "Sales > New Order").
+ *
+ * Keyed by the pathname, then by the tab value. Kept as a static map rather
+ * than a dynamic lookup so the breadcrumb stays predictable across pages and
+ * query-param nav remains a first-class breadcrumb citizen.
+ */
+const WORKSPACE_TAB_CRUMB_TITLES: Readonly<
+  Record<string, Readonly<Record<string, string>>>
+> = {
+  "/sales": {
+    "create-order": "New Order",
+  },
+};
+
 function humaniseSegment(segment: string): string {
   if (/^\d+$/.test(segment)) return `#${segment}`;
   return segment
@@ -303,14 +319,36 @@ function humaniseSegment(segment: string): string {
     .replace(/\b\w/g, char => char.toUpperCase());
 }
 
+function extractTabFromSearch(search: string | undefined): string | null {
+  if (!search) return null;
+  const trimmed = search.startsWith("?") ? search.slice(1) : search;
+  if (!trimmed) return null;
+  try {
+    const params = new URLSearchParams(trimmed);
+    const tab = params.get("tab");
+    return tab && tab.length > 0 ? tab : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Walk a pathname one segment at a time and return a breadcrumb trail whose
  * titles come from the registry where possible, falling back to navigation
  * items and then to a humanised version of the raw segment.
  *
+ * When `search` is provided, a recognised `?tab=…` value for the current
+ * pathname contributes an extra trailing crumb — this is how breadcrumbs like
+ * `/sales?tab=create-order` → "Sales > New Order" (TER-1363) stay correct
+ * even though the active sub-view lives in a query parameter rather than the
+ * path.
+ *
  * Returns `[]` for the root path to signal "do not render a breadcrumb".
  */
-export function buildBreadcrumbTrail(pathname: string): BreadcrumbTrailEntry[] {
+export function buildBreadcrumbTrail(
+  pathname: string,
+  search?: string
+): BreadcrumbTrailEntry[] {
   const normalised = normalisePathname(pathname);
   if (normalised === "/" || normalised === "") return [];
 
@@ -344,6 +382,25 @@ export function buildBreadcrumbTrail(pathname: string): BreadcrumbTrailEntry[] {
     const title = navItem?.name ?? humaniseSegment(segment);
     trail.push({ path: accumulated, title, isLast });
   });
+
+  // TER-1363: Append a workspace-tab crumb when the current pathname opts in
+  // via WORKSPACE_TAB_CRUMB_TITLES. We preserve the existing crumbs as
+  // non-last and hand the `isLast` marker to the tab crumb so the render
+  // layer shows "Sales > New Order" rather than "Sales" alone.
+  const tabTitles = WORKSPACE_TAB_CRUMB_TITLES[normalised];
+  const tabValue = tabTitles ? extractTabFromSearch(search) : null;
+  const tabTitle = tabValue && tabTitles ? tabTitles[tabValue] : undefined;
+  if (tabTitle && trail.length > 0) {
+    for (const crumb of trail) {
+      crumb.isLast = false;
+    }
+    const tabSearch = `?tab=${encodeURIComponent(tabValue as string)}`;
+    trail.push({
+      path: `${normalised}${tabSearch}`,
+      title: tabTitle,
+      isLast: true,
+    });
+  }
 
   return trail;
 }

--- a/client/src/contexts/BreadcrumbContext.tsx
+++ b/client/src/contexts/BreadcrumbContext.tsx
@@ -1,0 +1,147 @@
+/**
+ * BreadcrumbContext — TER-1362
+ *
+ * Lets page-level components supply human-friendly labels that the globally
+ * rendered `AppBreadcrumb` should use when it encounters a matching raw
+ * segment (e.g. `/clients/105` → `"Sierra Nevada Farms"`, or
+ * `/sales?tab=create-order` → `"New Order"`).
+ *
+ * `AppBreadcrumb` lives in the shared `AppHeader`, so individual pages do
+ * not render it directly. Pages register their resolved names via the
+ * `useBreadcrumbResolvedNames` hook; the breadcrumb reads from context and
+ * falls back to its built-in tRPC entity resolver / raw `#<id>` for any key
+ * that is not in the map.
+ *
+ * Keys are matched against:
+ *  - Raw URL segments (`"105"`) — the typical shape for `/clients/:id` et al.
+ *  - Tab values (`"create-order"`) — for workspace routes whose active
+ *    sub-view lives in a `?tab=` query param.
+ *
+ * A `null` value explicitly declares "no resolved name yet" (e.g. while the
+ * client query is in flight) and is treated the same as "not provided".
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type BreadcrumbResolvedNames = Record<string, string | null | undefined>;
+
+interface BreadcrumbContextValue {
+  resolvedNames: BreadcrumbResolvedNames;
+  registerResolvedNames: (id: symbol, names: BreadcrumbResolvedNames) => void;
+  unregisterResolvedNames: (id: symbol) => void;
+}
+
+const BreadcrumbContext = createContext<BreadcrumbContextValue | null>(null);
+
+/**
+ * Merge all currently registered name maps into a single flat lookup, with
+ * later registrations winning on key collisions. Undefined/null values are
+ * dropped so the breadcrumb always treats them as "not provided".
+ */
+function mergeResolvedNames(
+  registrations: ReadonlyMap<symbol, BreadcrumbResolvedNames>
+): BreadcrumbResolvedNames {
+  const merged: Record<string, string> = {};
+  for (const entry of registrations.values()) {
+    for (const [key, value] of Object.entries(entry)) {
+      if (typeof value === "string" && value.length > 0) {
+        merged[key] = value;
+      }
+    }
+  }
+  return merged;
+}
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const registrationsRef = useRef<Map<symbol, BreadcrumbResolvedNames>>(
+    new Map()
+  );
+  const [resolvedNames, setResolvedNames] = useState<BreadcrumbResolvedNames>(
+    () => ({})
+  );
+
+  const recomputeResolvedNames = useCallback(() => {
+    setResolvedNames(mergeResolvedNames(registrationsRef.current));
+  }, []);
+
+  const registerResolvedNames = useCallback(
+    (id: symbol, names: BreadcrumbResolvedNames) => {
+      registrationsRef.current.set(id, names);
+      recomputeResolvedNames();
+    },
+    [recomputeResolvedNames]
+  );
+
+  const unregisterResolvedNames = useCallback(
+    (id: symbol) => {
+      if (registrationsRef.current.delete(id)) {
+        recomputeResolvedNames();
+      }
+    },
+    [recomputeResolvedNames]
+  );
+
+  const value = useMemo<BreadcrumbContextValue>(
+    () => ({
+      resolvedNames,
+      registerResolvedNames,
+      unregisterResolvedNames,
+    }),
+    [resolvedNames, registerResolvedNames, unregisterResolvedNames]
+  );
+
+  return (
+    <BreadcrumbContext.Provider value={value}>
+      {children}
+    </BreadcrumbContext.Provider>
+  );
+}
+
+/**
+ * Internal accessor used by `AppBreadcrumb` to read the current merged
+ * resolved-names map. Safe to call outside a provider — defaults to `{}`.
+ */
+export function useBreadcrumbResolvedNamesMap(): BreadcrumbResolvedNames {
+  return useContext(BreadcrumbContext)?.resolvedNames ?? {};
+}
+
+/**
+ * Register a `resolvedNames` map for the breadcrumb while the calling
+ * component is mounted. Safe to call without a provider (in which case it
+ * becomes a no-op, e.g. for tests that do not mount the header).
+ *
+ * @example
+ *   const params = useParams<{ id: string }>();
+ *   const { data: client } = trpc.clients.getById.useQuery({ clientId: +params.id });
+ *   useBreadcrumbResolvedNames({ [params.id]: client?.name ?? null });
+ */
+export function useBreadcrumbResolvedNames(names: BreadcrumbResolvedNames) {
+  const ctx = useContext(BreadcrumbContext);
+  const idRef = useRef<symbol | null>(null);
+
+  // Stable identity for the map contents so we only re-register on real
+  // changes. JSON works here because keys/values are primitives.
+  const serialised = JSON.stringify(names);
+
+  useEffect(() => {
+    if (!ctx) return;
+    if (!idRef.current) idRef.current = Symbol("breadcrumb-resolved-names");
+    const id = idRef.current;
+    ctx.registerResolvedNames(id, names);
+    return () => {
+      ctx.unregisterResolvedNames(id);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx, serialised]);
+}
+
+export default BreadcrumbContext;

--- a/client/src/pages/ClientProfilePage.tsx
+++ b/client/src/pages/ClientProfilePage.tsx
@@ -18,6 +18,7 @@ import { SupplierProfileSection } from "@/components/clients/SupplierProfileSect
 import { VIPPortalSettings } from "@/components/clients/VIPPortalSettings";
 import { CommentWidget } from "@/components/comments/CommentWidget";
 import { BackButton } from "@/components/common/BackButton";
+import { useBreadcrumbResolvedNames } from "@/contexts/BreadcrumbContext";
 import { ConsignmentRangePanel } from "@/components/accounting/ConsignmentRangePanel";
 import { CreditStatusCard } from "@/components/credit/CreditStatusCard";
 import { FreeformNoteWidget } from "@/components/dashboard/widgets-v2";
@@ -375,6 +376,14 @@ export default function ClientProfilePage() {
     supplyQuery.data?.supplier?.context?.settlementSummary ?? null;
   const isCustomer = shell?.roles.includes("Customer") ?? false;
   const isSupplier = shell?.roles.includes("Supplier") ?? false;
+
+  // TER-1362: Contribute the loaded client's name to the global breadcrumb so
+  // `/clients/:id` renders "Clients > <Name>" instead of falling back to the
+  // raw `#<id>` label. Keyed by the raw URL id so AppBreadcrumb picks it up
+  // regardless of whether the route param is `id` or `clientId`.
+  useBreadcrumbResolvedNames(
+    params.id ? { [params.id]: shell?.name ?? null } : {}
+  );
 
   const handleOpenPaymentFollowUp = (type: PaymentCommunicationType) => {
     if (!moneySummary) {

--- a/docs/sessions/active/TER-1362-session.md
+++ b/docs/sessions/active/TER-1362-session.md
@@ -1,0 +1,6 @@
+# TER-1362 Session
+- **Ticket:** TER-1362
+- **Branch:** `fix/ter-1362-1364-breadcrumb-sales`
+- **Status:** In Progress
+- **Started:** 2026-04-24T00:05:24Z
+- **Agent:** Factory Droid (UX v2 fix wave)


### PR DESCRIPTION
## Summary

Fixes three UX v2 issues flagged in the Sales / breadcrumb surface:

### TER-1362 — Client name resolver
- `AppBreadcrumb` now accepts an optional `resolvedNames` prop **and** reads a shared `BreadcrumbContext` so page-level components can supply human-friendly labels for raw URL segments.
- `ClientProfilePage` registers the loaded client's name via `useBreadcrumbResolvedNames`, so `/clients/:id` renders `Clients > Sierra Nevada Farms` instead of falling back to `#105`.
- Falls back to `#<id>` when the client is still loading or resolution fails.

### TER-1363 — Order Creator breadcrumb
- `buildBreadcrumbTrail(pathname, search)` now appends a workspace-tab crumb for recognised `?tab=…` values.
- `/sales?tab=create-order` renders `Sales > New Order` even though the active sub-view lives in a query param rather than a path segment.
- Static tab titles are declared in a tight `WORKSPACE_TAB_CRUMB_TITLES` map keyed by pathname so the breadcrumb stays predictable.

### TER-1364 — /sales dual-primary buttons
- `SheetModeToggle`'s active tab now uses the `secondary` variant (neutral selected state) and the inactive tab stays as `outline`, so neither tab competes with the filled primary "New Order" CTA.
- "New Order" is unchanged — it remains the single primary action in the Sales workspace header.

## Verification
- `pnpm check` — ✅ zero TypeScript errors
- `pnpm lint` — pre-existing errors only; no new errors introduced (verified: modified files IntakeProgressDialog/InventoryKanbanBoard/etc were not touched by this PR)
- Targeted tests — ✅ passing
  - `client/src/config/routes.test.ts` (14 tests)
  - `client/src/components/spreadsheet-native/SheetModeToggle.test.tsx` (13 tests — updated for new `secondary` variant)

## Files Changed
- `client/src/config/routes.ts` — `buildBreadcrumbTrail` accepts search string + tab crumb support
- `client/src/components/layout/AppBreadcrumb.tsx` — `resolvedNames` prop + context consumer, passes search to trail builder
- `client/src/contexts/BreadcrumbContext.tsx` — NEW: `BreadcrumbProvider` + `useBreadcrumbResolvedNames` hook
- `client/src/App.tsx` — wraps the app in `BreadcrumbProvider`
- `client/src/pages/ClientProfilePage.tsx` — registers client name via the new hook
- `client/src/components/spreadsheet-native/SheetModeToggle.tsx` — active variant `default → secondary`
- `client/src/components/spreadsheet-native/SheetModeToggle.test.tsx` — updated expectation

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>