### PR TITLE
fix(ux-v2): ManusSheet Esc hint + focus return; sidebar toggle persistence [TER-1366/1368]

### DIFF
--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -17,7 +17,6 @@ import {
   LogOut,
   Plus,
   Truck,
-  UserCircle2,
   Users,
   X,
 } from "lucide-react";
@@ -30,15 +29,12 @@ import {
   type NavigationGroupKey,
 } from "@/config/navigation";
 import { normalizeOperationsTab } from "@/lib/workspaceRoutes";
-import { FEATURE_FLAGS } from "@/lib/constants/featureFlags";
 import { useFeatureFlags } from "@/hooks/useFeatureFlag";
-import { useOptionalFeatureFlag } from "@/contexts/FeatureFlagContext";
 import { useNavigationState } from "@/hooks/useNavigationState";
 import { getNavOpenGroups, setNavOpenGroups } from "@/lib/navState";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/_core/hooks/useAuth";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 
 export interface SidebarProps {
@@ -154,26 +150,24 @@ export const Sidebar = React.memo(function Sidebar({
   const { data: currentUser } = trpc.auth.me.useQuery(undefined, {
     staleTime: 60_000,
   });
-  // TER-1306: When the ux.v2.nav-persist flag is enabled, the sidebar reads
-  // the last-known open groups from localStorage on mount and writes back on
-  // every accordion toggle so state survives refreshes and navigation.
-  const navPersistEnabled = useOptionalFeatureFlag(
-    FEATURE_FLAGS.uxV2NavPersist
-  );
+  // TER-1306 / TER-1368: The sidebar unconditionally reads the last-known
+  // open groups from localStorage on mount and writes back on every
+  // accordion toggle so the state survives refresh and navigation. Earlier
+  // the behaviour was gated behind the `ux.v2.nav-persist` feature flag, but
+  // the flag defaulted on everywhere and its async loading caused a race
+  // where user toggles that fired before the flag resolved were silently
+  // dropped (TER-1368). Persistence is now always-on; the storage layer
+  // (`@/lib/navState`) is already SSR-safe and swallows quota errors.
   const [openGroups, setOpenGroups] = useState<
     Record<NavigationGroupKey, boolean>
   >(() => {
     const defaults = getDefaultOpenGroups(`${location}${search || ""}`);
-    if (!navPersistEnabled) {
-      return defaults;
-    }
     const persisted = getNavOpenGroups();
     if (persisted.length === 0) {
       return defaults;
     }
     return openGroupsFromPersisted(persisted);
   });
-  const navHydratedFromStorageRef = useRef(navPersistEnabled);
   const [collapsed, setCollapsed] = useState(false);
 
   // BUG-103: Auto-close the mobile drawer whenever the active route changes so
@@ -215,25 +209,21 @@ export const Sidebar = React.memo(function Sidebar({
   );
   const groupedNavigation = navigationAccessModel.groups;
 
-  const toggleGroup = useCallback(
-    (key: NavigationGroupKey) => {
-      flushSync(() => {
-        setOpenGroups(prev => {
-          const next = { ...prev, [key]: !prev[key] };
-          if (navPersistEnabled) {
-            // TER-1306: Persist the full set of currently-open group keys on
-            // every accordion toggle so the state survives refresh/navigation.
-            const openKeys = (
-              Object.keys(next) as NavigationGroupKey[]
-            ).filter(groupKey => next[groupKey]);
-            setNavOpenGroups(openKeys);
-          }
-          return next;
-        });
+  const toggleGroup = useCallback((key: NavigationGroupKey) => {
+    flushSync(() => {
+      setOpenGroups(prev => {
+        const next = { ...prev, [key]: !prev[key] };
+        // TER-1306 / TER-1368: Persist the full set of currently-open group
+        // keys on every accordion toggle so the state survives refresh and
+        // navigation. Write is unconditional (see state-init comment above).
+        const openKeys = (Object.keys(next) as NavigationGroupKey[]).filter(
+          groupKey => next[groupKey]
+        );
+        setNavOpenGroups(openKeys);
+        return next;
       });
-    },
-    [navPersistEnabled]
-  );
+    });
+  }, []);
 
   const isActivePath = useCallback(
     (path: string) => {
@@ -266,27 +256,15 @@ export const Sidebar = React.memo(function Sidebar({
     }
   }, [location, search]);
 
+  // Route-driven auto-expand: whenever the active workspace group changes,
+  // open it. This is intentionally in-memory only — we do not persist the
+  // auto-expand so that returning to a previously-collapsed group via a
+  // direct link still reflects the user's last manual state on reload.
   useEffect(() => {
     setOpenGroups(prev =>
       prev[activeGroupKey] ? prev : { ...prev, [activeGroupKey]: true }
     );
   }, [activeGroupKey]);
-
-  // TER-1306: Feature flags load asynchronously; if the ux.v2.nav-persist
-  // flag flips from false → true after the initial render, hydrate the
-  // sidebar from localStorage exactly once so the user still sees their
-  // persisted layout on cold loads.
-  useEffect(() => {
-    if (!navPersistEnabled || navHydratedFromStorageRef.current) {
-      return;
-    }
-    navHydratedFromStorageRef.current = true;
-    const persisted = getNavOpenGroups();
-    if (persisted.length === 0) {
-      return;
-    }
-    setOpenGroups(openGroupsFromPersisted(persisted));
-  }, [navPersistEnabled]);
 
   return (
     <>

--- a/client/src/components/ui/manus-sheet.tsx
+++ b/client/src/components/ui/manus-sheet.tsx
@@ -158,6 +158,25 @@ function ManusSheetContent({
       >
         {children}
         {/*
+         * TER-1366: Enforced "Esc to close" hint.
+         *
+         * Previously the hint was only rendered when consumers opted into
+         * `ManusSheetFooter` (its `showEscHint` prop). That left drawers
+         * without an explicit footer silently missing the affordance, which
+         * violated the UX v2 drawer contract. Rendering it directly in
+         * `ManusSheetContent` — below `{children}` — guarantees every drawer
+         * surface shows the hint regardless of whether a footer is used.
+         */}
+        <div
+          data-slot="manus-sheet-esc-hint"
+          className="text-muted-foreground flex items-center gap-1 border-t px-4 py-2 text-xs"
+        >
+          <kbd className="border-border bg-muted rounded border px-1.5 py-0.5 font-mono text-xs">
+            Esc
+          </kbd>
+          <span>to close</span>
+        </div>
+        {/*
          * Enforced close-X affordance.
          * Always rendered; cannot be opted out. Clicking this triggers
          * Radix's onOpenChange(false) via the Dialog.Close primitive, which
@@ -229,9 +248,10 @@ function ManusSheetDescription({
 
 export interface ManusSheetFooterProps extends React.ComponentProps<"div"> {
   /**
-   * If `false`, suppresses the "Esc to close" hint. Defaults to `true`.
-   * Consumers should only disable this in exceptional cases (e.g. nested
-   * footers inside multi-step flows) — the hint is a UX v2 contract.
+   * @deprecated TER-1366: The "Esc to close" hint is now rendered directly
+   * inside {@link ManusSheetContent} so that every drawer surface shows it
+   * regardless of whether a footer is used. This prop is preserved only
+   * for back-compat and has no effect.
    */
   showEscHint?: boolean;
 }
@@ -239,31 +259,20 @@ export interface ManusSheetFooterProps extends React.ComponentProps<"div"> {
 function ManusSheetFooter({
   className,
   children,
-  showEscHint = true,
+  // TER-1366: `showEscHint` is intentionally destructured (but unused) so
+  // that existing call sites compile without warnings. The hint itself now
+  // lives in `ManusSheetContent`.
+  showEscHint: _showEscHint,
   ...props
 }: ManusSheetFooterProps): React.ReactElement {
+  void _showEscHint;
   return (
     <div
       data-slot="manus-sheet-footer"
-      className={cn(
-        "mt-auto flex flex-col gap-2 border-t p-4",
-        className
-      )}
+      className={cn("mt-auto flex flex-col gap-2 border-t p-4", className)}
       {...props}
     >
       {children}
-      {showEscHint ? (
-        <p
-          data-slot="manus-sheet-esc-hint"
-          className="text-muted-foreground mt-1 text-xs"
-        >
-          Press{" "}
-          <kbd className="border-border bg-muted rounded border px-1.5 py-0.5 font-mono text-[10px]">
-            Esc
-          </kbd>{" "}
-          to close
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/docs/sessions/active/TER-1366-session.md
+++ b/docs/sessions/active/TER-1366-session.md
@@ -1,0 +1,6 @@
+# TER-1366 Session
+- **Ticket:** TER-1366
+- **Branch:** `fix/ter-1366-1368-manus-focus-nav-persist`
+- **Status:** In Progress
+- **Started:** 2026-04-24T00:05:22Z
+- **Agent:** Factory Droid (UX v2 fix wave)


### PR DESCRIPTION
## Summary

Completes two half-wired UX v2 fixes.

### TER-1366 — ManusSheet Esc hint + focus return
- The **"Esc to close" hint** is now always rendered inside `ManusSheetContent`, directly below `{children}`. Previously the hint only appeared when consumers opted into `ManusSheetFooter` (its `showEscHint` prop), which left drawers without an explicit footer silently missing the affordance and violated the UX v2 drawer contract.
- `ManusSheetFooter` keeps accepting the `showEscHint` prop for back-compat but treats it as a no-op (marked \`@deprecated\`).
- **Focus return** (`useReturnFocus`) was already built and wired inside `ManusSheetContent`. It captures \`document.activeElement\` during render (before Radix moves focus into the dialog) and restores it on unmount, covering both ref'd and legacy ref-less `SheetTrigger` call sites. No behavioural change needed here — verified it already satisfies TER-1366 AC.

### TER-1368 — Sidebar navState toggle persistence
- Persistence to localStorage (\`terp.nav.open-groups.v1\`) is now **unconditional**. The previous implementation gated reads/writes behind the \`ux.v2.nav-persist\` feature flag; because the flag resolves asynchronously, user toggles fired before the flag loaded were silently dropped and never persisted — which is exactly the "writes not persisted" behaviour observed in QA.
- \`toggleGroup\` now always writes the current open-groups set via \`setNavOpenGroups\` on every accordion change.
- Initial state reads persisted groups unconditionally, falling back to route-driven defaults when nothing is persisted.
- The now-unneeded async-hydration effect is removed.
- **Route-driven auto-expand** still works: whenever the active workspace group changes, it is opened in-memory (intentionally not persisted, so a direct link to a previously-collapsed workspace doesn't clobber the user's manual state).
- Drive-by: removed 3 pre-existing unused imports (\`UserCircle2\`, \`Avatar\`, \`AvatarFallback\`) flagged by eslint in the same file.

## Acceptance

**TER-1366**
- [x] Every drawer opened via \`ManusSheet\` shows "Esc to close" hint
- [x] Focus returns to the element that was active when the drawer opened (handled by existing \`useReturnFocus\`)
- [x] Existing Esc-to-close behaviour unchanged (Radix \`onOpenChange\`)
- [x] \`pnpm check\` passes

**TER-1368**
- [x] Expand/collapse sidebar group → localStorage is updated immediately
- [x] Refresh page → sidebar group state restored to user's last manual state
- [x] Route-driven auto-expand still works
- [x] \`pnpm check\` passes
- [x] \`pnpm lint\` passes on modified files

## Verification

\`\`\`
pnpm check     # zero TS errors
eslint client/src/components/ui/manus-sheet.tsx \\
       client/src/components/layout/Sidebar.tsx \\
       client/src/hooks/useReturnFocus.ts   # clean
\`\`\`

## Risk / Scope
- STRICT tier, UX-only change, no server / tRPC / DB / auth touched.
- \`ManusSheet\` has no production consumers yet (TER-1294 primitive rollout), so the hint reshuffle is zero-blast-radius.
- Sidebar persistence removes a flag-gated race; feature-flag seed (\`defaultEnabled: true\`) is unchanged.

Closes TER-1366, TER-1368.