### PR TITLE
fix(accounting): verify + complete invoice Status column raw HTML fix — TER-1324

### DIFF
--- a/docs/sessions/active/ter-1324-session.md
+++ b/docs/sessions/active/ter-1324-session.md
@@ -1,0 +1,6 @@
+# ter-1324 Agent Session
+
+- **Ticket:** ter-1324
+- **Branch:** `fix/ter-1324-invoices-status-raw-html`
+- **Status:** In Progress
+- **Agent:** Factory Droid

--- a/docs/sessions/active/ter-1324-session.md
+++ b/docs/sessions/active/ter-1324-session.md
@@ -1,6 +1,61 @@
-# ter-1324 Agent Session
+# TER-1324 Agent Session
 
-- **Ticket:** ter-1324
+- **Ticket:** TER-1324
 - **Branch:** `fix/ter-1324-invoices-status-raw-html`
-- **Status:** In Progress
+- **Status:** Verified — already fixed by PR #723 (TER-1360)
 - **Agent:** Factory Droid
+
+## Summary of Investigation
+
+TER-1324 reported that the AccountingWorkspace → Invoices tab Status column
+rendered raw `<span>` HTML markup in every row. Investigation found the bug
+was already addressed by PR #723 (TER-1360) on the main branch.
+
+### Where invoices render in the accounting workspace
+
+Only `client/src/components/spreadsheet-native/InvoicesSurface.tsx` renders
+the invoices grid. `AccountingWorkspacePage.tsx` lazy-loads this single
+surface for the `invoices` tab panel; no other invoice grid or Status column
+is rendered in the workspace.
+
+### Status column renderer — correct
+
+`statusCellRenderer` at line 325 returns JSX (not an HTML string):
+
+```tsx
+function statusCellRenderer(params: { value: string }) {
+  const status = params.value ?? "DRAFT";
+  const color = getInvoiceStatusClass(status);
+  const label = getInvoiceStatusLabel(status);
+  return (
+    <span className={`inline-flex ... ${color}`}>
+      {label}
+    </span>
+  );
+}
+```
+
+It is wired to the Status column via `cellRenderer: statusCellRenderer` at
+line 446. AG Grid React renders the JSX as a DOM element, so there is no
+raw markup leaking into cells.
+
+### Other renderers audited
+
+- `clientName` column renderer — returns JSX (`<div>`/`<span>` React elements)
+- `dueDate` column renderer — returns JSX for overdue badge
+- `amountDueFormatted` column renderer — returns JSX (TER-1253 fix)
+- Client ledger `type` column renderer — returns JSX
+- `paymentPct` uses `valueFormatter` (string, no markup) — safe
+
+### Verification
+
+- `pnpm check` — zero TypeScript errors
+- `pnpm lint` (scope) — clean for `InvoicesSurface.tsx`, `InvoicesSurface.test.tsx`, `AccountingWorkspacePage.tsx`
+- `pnpm exec vitest run client/src/components/spreadsheet-native/InvoicesSurface.test.tsx` — 13/13 passed, including the TER-1360 DOM guardrail that asserts no `<span class=` text leaks
+
+### Conclusion
+
+TER-1324 is complete. The Status column renders a styled badge as intended.
+Every `cellRenderer` in `InvoicesSurface.tsx` returns JSX, not HTML strings.
+This PR documents the verification and closes the duplicate tracking of the
+TER-1360 fix.


### PR DESCRIPTION
## Summary

**TER-1324** reported that the AccountingWorkspace → Invoices tab's Status column renders raw `<span>` HTML markup in every row. Investigation found the fix is **already complete** in `InvoicesSurface.tsx` (merged via PR #723 / TER-1360). This PR documents the verification so TER-1324 can be closed.

## What Was Found

The only component that renders the invoices grid in the accounting workspace is `client/src/components/spreadsheet-native/InvoicesSurface.tsx` (lazy-loaded from `AccountingWorkspacePage.tsx`). Its Status column is wired via:

```tsx
// line 446
{
  field: "status",
  headerName: "Status",
  cellRenderer: statusCellRenderer,
}
```

…and `statusCellRenderer` returns **JSX** (not an HTML string):

```tsx
function statusCellRenderer(params: { value: string }) {
  const status = params.value ?? "DRAFT";
  const color = getInvoiceStatusClass(status);
  const label = getInvoiceStatusLabel(status);
  return (
    <span className={`inline-flex ... ${color}`}>
      {label}
    </span>
  );
}
```

AG Grid React renders JSX as a real DOM element, so the badge renders correctly — no raw `<span class=…>` leaks.

## Renderers Audited in InvoicesSurface.tsx

| Column | Renderer | Returns |
| --- | --- | --- |
| `clientName` | inline arrow | JSX `<div>`/`<span>` |
| `dueDate` | inline arrow | JSX overdue badge |
| `amountDueFormatted` | inline arrow (TER-1253) | JSX `<span>` |
| `status` | `statusCellRenderer` | JSX `<span>` |
| `paymentPct` | `valueFormatter` (text only) | plain string, no markup |
| Ledger `type` | inline arrow | JSX `<span>` |

No raw-HTML-returning `cellRenderer` or `valueFormatter` remains.

## Verification

- `pnpm check` → zero TypeScript errors
- Scope `pnpm exec eslint` on `InvoicesSurface.tsx`, `InvoicesSurface.test.tsx`, `AccountingWorkspacePage.tsx` → clean
- `pnpm exec vitest run client/src/components/spreadsheet-native/InvoicesSurface.test.tsx` → **13/13 passed**, including the explicit guardrail:
  ```ts
  // Guardrail: no raw `<span class=` text should leak into the rendered DOM
  expect(overdueContainer.textContent ?? "").not.toContain("<span class=");
  ```

## Acceptance Criteria

- [x] Status column in AccountingWorkspace.invoices renders a styled badge (not raw HTML markup)
- [x] Every `cellRenderer` in InvoicesSurface.tsx that renders markup returns JSX, not HTML strings
- [x] `pnpm check` passes (TypeScript)
- [x] Scope `pnpm lint` passes

## Scope

- Docs-only: updates `docs/sessions/active/ter-1324-session.md` with investigation findings.
- No production code changes (the underlying fix already shipped in PR #723).

Linear: TER-1324