### PR TITLE
fix(accounting): widen invoice column minWidths to prevent header truncation — TER-1329

### DIFF
--- a/client/src/components/spreadsheet-native/InvoicesSurface.tsx
+++ b/client/src/components/spreadsheet-native/InvoicesSurface.tsx
@@ -374,9 +374,11 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
     },
   },
   {
+    // TER-1329: minWidth widened so the "Invoice Date" header (12 chars +
+    // sort affordance) fits without truncation at the default column width.
     field: "invoiceDate",
     headerName: "Invoice Date",
-    minWidth: 120,
+    minWidth: 140,
     maxWidth: 140,
     cellClass: "powersheet-cell--locked",
   },
@@ -411,9 +413,11 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
     headerClass: "text-right",
   },
   {
+    // TER-1329: minWidth widened so the "Amount Due" header (10 chars +
+    // sort affordance) fits without truncation at the default column width.
     field: "amountDueFormatted",
     headerName: "Amount Due",
-    minWidth: 120,
+    minWidth: 130,
     maxWidth: 150,
     cellClass: "powersheet-cell--locked font-mono text-right",
     headerClass: "text-right",

--- a/docs/sessions/active/ter-1329-session.md
+++ b/docs/sessions/active/ter-1329-session.md
@@ -1,0 +1,6 @@
+# ter-1329 Agent Session
+
+- **Ticket:** ter-1329
+- **Branch:** `fix/ter-1329-invoices-column-header-widths`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Fixes TER-1329: Column headers in the Invoices grid (`InvoicesSurface`) were truncated at their default widths because `minWidth` was tuned to the cell content, not the header text plus sort affordance.

## Changes

Only `invoiceColumnDefs` in `client/src/components/spreadsheet-native/InvoicesSurface.tsx` was modified:

| Column            | headerName      | minWidth (old → new) | maxWidth |
| ----------------- | --------------- | -------------------- | -------- |
| `invoiceDate`     | "Invoice Date"  | 120 → **140**        | 140      |
| `amountDueFormatted` | "Amount Due" | 120 → **130**        | 150      |

Other columns were inspected and already have sufficient `minWidth` for their headers (`Invoice #`/130, `Client`/180, `Due Date`/120, `Total`/110, `Paid %`/80, `Status`/110), so they were left untouched.

## Acceptance Criteria

- [x] All invoice column headers display without truncation at the default column width
- [x] minWidth values increased only where needed (no unnecessary changes)
- [x] `pnpm check` passes (zero TS errors)
- [x] `pnpm lint` passes for `InvoicesSurface.tsx` (no new lint errors introduced by this change)

## Scope Notes

- Pure client-side grid config change; no server or schema changes.
- `ledgerColumnDefs` inspected — all headers already fit their `minWidth`, left unchanged.
- No change to column order, field names, renderers, or any other column properties.