### PR TITLE
feat(calendar): show client name + amount in event pills — TER-1332

### DIFF
--- a/client/src/components/calendar/AgendaView.tsx
+++ b/client/src/components/calendar/AgendaView.tsx
@@ -14,6 +14,9 @@ interface Event {
   description?: string | null;
   location?: string | null;
   module: string;
+  // TER-1332: optional enrichment so pills can show "ClientName ($amount)"
+  clientName?: string | null;
+  amount?: string | number | null;
 }
 
 interface AgendaViewProps {
@@ -114,8 +117,8 @@ export default function AgendaView({
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex-1">
-                        <div className="font-medium text-gray-900">
-                          {event.title}
+                        <div className="font-medium text-gray-900 truncate">
+                          {getEventPillLabel(event)}
                         </div>
                         {event.description && (
                           <div className="mt-1 text-sm text-gray-600 line-clamp-2">
@@ -246,4 +249,32 @@ function getStatusBadgeClass(status: string): string {
     default:
       return "bg-gray-100 text-gray-800";
   }
+}
+
+// TER-1332: Render meaningful pill labels based on event type.
+// DELIVERY / PAYMENT_DUE → "ClientName ($amount)" (fallback to title)
+// INTAKE → client name if present (fallback to title)
+function getEventPillLabel(event: Event): string {
+  const clientName = event.clientName?.trim();
+  if (event.eventType === "DELIVERY" || event.eventType === "PAYMENT_DUE") {
+    if (clientName) {
+      const formattedAmount = formatAmount(event.amount);
+      return formattedAmount ? `${clientName} (${formattedAmount})` : clientName;
+    }
+    return event.title;
+  }
+  if (event.eventType === "INTAKE") {
+    return clientName || event.title;
+  }
+  return event.title;
+}
+
+function formatAmount(amount: string | number | null | undefined): string {
+  if (amount === null || amount === undefined) return "";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "";
+  return `$${num.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
 }

--- a/client/src/components/calendar/DayView.tsx
+++ b/client/src/components/calendar/DayView.tsx
@@ -12,6 +12,9 @@ interface Event {
   priority: string;
   description?: string | null;
   location?: string | null;
+  // TER-1332: optional enrichment so pills can show "ClientName ($amount)"
+  clientName?: string | null;
+  amount?: string | number | null;
 }
 
 interface DayViewProps {
@@ -77,7 +80,7 @@ export default function DayView({ currentDate, events, onEventClick }: DayViewPr
                   event
                 )} hover:opacity-80`}
               >
-                <div className="font-medium">{event.title}</div>
+                <div className="font-medium truncate">{getEventPillLabel(event)}</div>
                 {event.location && (
                   <div className="mt-1 text-xs opacity-75">{event.location}</div>
                 )}
@@ -118,7 +121,7 @@ export default function DayView({ currentDate, events, onEventClick }: DayViewPr
                   >
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
-                        <div className="font-medium">{event.title}</div>
+                        <div className="font-medium truncate">{getEventPillLabel(event)}</div>
                         {event.description && (
                           <div className="mt-1 text-xs opacity-75 line-clamp-2">
                             {event.description}
@@ -180,4 +183,32 @@ function getEventColorClass(event: Event): string {
   } else {
     return "bg-gray-100 text-gray-800";
   }
+}
+
+// TER-1332: Render meaningful pill labels based on event type.
+// DELIVERY / PAYMENT_DUE → "ClientName ($amount)" (fallback to title)
+// INTAKE → client name if present (fallback to title)
+function getEventPillLabel(event: Event): string {
+  const clientName = event.clientName?.trim();
+  if (event.eventType === "DELIVERY" || event.eventType === "PAYMENT_DUE") {
+    if (clientName) {
+      const formattedAmount = formatAmount(event.amount);
+      return formattedAmount ? `${clientName} (${formattedAmount})` : clientName;
+    }
+    return event.title;
+  }
+  if (event.eventType === "INTAKE") {
+    return clientName || event.title;
+  }
+  return event.title;
+}
+
+function formatAmount(amount: string | number | null | undefined): string {
+  if (amount === null || amount === undefined) return "";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "";
+  return `$${num.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
 }

--- a/client/src/components/calendar/MonthView.tsx
+++ b/client/src/components/calendar/MonthView.tsx
@@ -11,6 +11,9 @@ interface Event {
   entityType?: string;
   entityId?: number;
   clientId?: number | null;
+  // TER-1332: optional enrichment so pills can show "ClientName ($amount)"
+  clientName?: string | null;
+  amount?: string | number | null;
   status: string;
   priority: string;
 }
@@ -144,7 +147,7 @@ export default function MonthView({ currentDate, events, onEventClick, onDateCli
                       {formatTime(event.startTime)}
                     </span>
                   )}
-                  {event.title}
+                  {getEventPillLabel(event)}
                 </button>
               ))}
               {day.events.length > 3 && (
@@ -191,4 +194,32 @@ function formatTime(time: string): string {
   const ampm = hour >= 12 ? "PM" : "AM";
   const displayHour = hour % 12 || 12;
   return `${displayHour}:${minutes}${ampm}`;
+}
+
+// TER-1332: Render meaningful pill labels based on event type.
+// DELIVERY / PAYMENT_DUE → "ClientName ($amount)" (fallback to title)
+// INTAKE → client name if present (fallback to title)
+function getEventPillLabel(event: Event): string {
+  const clientName = event.clientName?.trim();
+  if (event.eventType === "DELIVERY" || event.eventType === "PAYMENT_DUE") {
+    if (clientName) {
+      const formattedAmount = formatAmount(event.amount);
+      return formattedAmount ? `${clientName} (${formattedAmount})` : clientName;
+    }
+    return event.title;
+  }
+  if (event.eventType === "INTAKE") {
+    return clientName || event.title;
+  }
+  return event.title;
+}
+
+function formatAmount(amount: string | number | null | undefined): string {
+  if (amount === null || amount === undefined) return "";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "";
+  return `$${num.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
 }

--- a/client/src/components/calendar/WeekView.tsx
+++ b/client/src/components/calendar/WeekView.tsx
@@ -11,6 +11,9 @@ interface Event {
   entityType?: string;
   entityId?: number;
   clientId?: number | null;
+  // TER-1332: optional enrichment so pills can show "ClientName ($amount)"
+  clientName?: string | null;
+  amount?: string | number | null;
   status: string;
   priority: string;
 }
@@ -112,7 +115,7 @@ export default function WeekView({ currentDate, events, onEventClick }: WeekView
                         event
                       )} hover:opacity-80`}
                     >
-                      {event.title}
+                      {getEventPillLabel(event)}
                     </button>
                   ))}
                 </div>
@@ -163,4 +166,32 @@ function getEventColorClass(event: Event): string {
     // Fallback for other event types
     return "bg-gray-100 text-gray-800";
   }
+}
+
+// TER-1332: Render meaningful pill labels based on event type.
+// DELIVERY / PAYMENT_DUE → "ClientName ($amount)" (fallback to title)
+// INTAKE → client name if present (fallback to title)
+function getEventPillLabel(event: Event): string {
+  const clientName = event.clientName?.trim();
+  if (event.eventType === "DELIVERY" || event.eventType === "PAYMENT_DUE") {
+    if (clientName) {
+      const formattedAmount = formatAmount(event.amount);
+      return formattedAmount ? `${clientName} (${formattedAmount})` : clientName;
+    }
+    return event.title;
+  }
+  if (event.eventType === "INTAKE") {
+    return clientName || event.title;
+  }
+  return event.title;
+}
+
+function formatAmount(amount: string | number | null | undefined): string {
+  if (amount === null || amount === undefined) return "";
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (!Number.isFinite(num)) return "";
+  return `$${num.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
 }

--- a/client/src/pages/CalendarPage.tsx
+++ b/client/src/pages/CalendarPage.tsx
@@ -107,6 +107,8 @@ export default function CalendarPage() {
   );
 
   // Convert to format expected by view components
+  // TER-1332: pass through clientName + amount so event pills can show
+  // "ClientName ($amount)" instead of "Order N Delivery"
   const formattedEvents = dashboardEvents.map(event => ({
     id: event.id,
     title: event.title,
@@ -118,6 +120,8 @@ export default function CalendarPage() {
     entityType: event.entityType,
     entityId: event.entityId,
     clientId: event.clientId,
+    clientName: event.clientName,
+    amount: event.amount,
     status: "SCHEDULED",
     priority: "MEDIUM",
     module: "",

--- a/docs/sessions/active/ter-1332-session.md
+++ b/docs/sessions/active/ter-1332-session.md
@@ -1,0 +1,6 @@
+# ter-1332 Agent Session
+
+- **Ticket:** ter-1332
+- **Branch:** `fix/ter-1332-calendar-event-pill-content`
+- **Status:** In Progress
+- **Agent:** Factory Droid

--- a/server/routers/calendar.ts
+++ b/server/routers/calendar.ts
@@ -13,6 +13,7 @@ import { getDb } from "../db";
 import {
   calendarEvents,
   calendarRecurrenceInstances,
+  clients,
   orders,
   invoices,
 } from "../../drizzle/schema";
@@ -51,6 +52,7 @@ export const calendarRouter = router({
 
       try {
         // 1. Get intake appointments from calendar_events
+        // TER-1332: include clientName so pill can display it (amount is null for intake)
         const intakeAppointments = await db
           .select({
             id: calendarEvents.id,
@@ -61,8 +63,11 @@ export const calendarRouter = router({
             entityType: sql<string>`'calendar'`,
             entityId: calendarEvents.id,
             clientId: calendarEvents.clientId,
+            clientName: clients.name,
+            amount: sql<string | null>`NULL`,
           })
           .from(calendarEvents)
+          .leftJoin(clients, eq(calendarEvents.clientId, clients.id))
           .where(
             and(
               eq(calendarEvents.eventType, "INTAKE"),
@@ -73,6 +78,7 @@ export const calendarRouter = router({
           );
 
         // 2. Get order delivery dates from orders.dueDate
+        // TER-1332: include client name + order total so pill can display "ClientName ($amount)"
         const orderDeliveries = await db
           .select({
             id: orders.id,
@@ -83,8 +89,11 @@ export const calendarRouter = router({
             entityType: sql<string>`'order'`,
             entityId: orders.id,
             clientId: orders.clientId,
+            clientName: clients.name,
+            amount: orders.total,
           })
           .from(orders)
+          .leftJoin(clients, eq(orders.clientId, clients.id))
           .where(
             and(
               sql`${orders.dueDate} IS NOT NULL`,
@@ -96,6 +105,7 @@ export const calendarRouter = router({
           );
 
         // 3. Get payment due dates from invoices.dueDate
+        // TER-1332: include client name + invoice total so pill can display "ClientName ($amount)"
         const paymentDueDates = await db
           .select({
             id: invoices.id,
@@ -106,8 +116,11 @@ export const calendarRouter = router({
             entityType: sql<string>`'invoice'`,
             entityId: invoices.id,
             clientId: invoices.customerId,
+            clientName: clients.name,
+            amount: invoices.totalAmount,
           })
           .from(invoices)
+          .leftJoin(clients, eq(invoices.customerId, clients.id))
           .where(
             and(
               gte(invoices.dueDate, startDate),


### PR DESCRIPTION
## Summary

Fixes TER-1332. Calendar event pills previously showed truncated system IDs like "Order 123 Delivery" or "Payment Due - Invoice 456", which is not useful at a glance. This PR enriches the calendar dashboard events with client name + amount and renders those in pill labels across all four calendar views.

## Before / After

| Event type  | Before                              | After                       |
| ----------- | ----------------------------------- | --------------------------- |
| DELIVERY    | `Order 123 Delivery`                | `Acme Corp ($1,250)`       |
| PAYMENT_DUE | `Payment Due - Invoice 456`         | `Acme Corp ($980)`         |
| INTAKE      | raw calendar event title            | client name (if available)  |

When the client name is missing or empty, the pill falls back to the original `event.title` (non-regressing behavior).

## Changes

**Server (`server/routers/calendar.ts`)**
- Import `clients`.
- Left-join `clients` on each of the three dashboard event sources:
  - `calendarEvents` → `clients.id` (INTAKE)
  - `orders` → `clients.id` (DELIVERY)
  - `invoices.customerId` → `clients.id` (PAYMENT_DUE)
- Expose `clientName` and `amount` in each row (amount is `orders.total`, `invoices.totalAmount`, or `NULL` for intake).

**Client**
- `CalendarPage.tsx`: pass `clientName` and `amount` through to the view components.
- `MonthView.tsx`, `WeekView.tsx`, `DayView.tsx`, `AgendaView.tsx`:
  - Extend `Event` interface with optional `clientName` + `amount`.
  - New `getEventPillLabel(event)` helper renders "ClientName ($amount)" for DELIVERY / PAYMENT_DUE and client name for INTAKE, falling back to `event.title`.
  - Pill `truncate` class preserved.

## Verification

- `pnpm check` passes cleanly on the touched files (no new TS errors introduced).
- `pnpm lint` passes cleanly on the touched files (pre-existing repo-wide lint errors are unrelated to this change).
- No changes to calendar event creation/editing, financial logic, or page structure.

## Acceptance criteria
- [x] Order delivery pills show "ClientName ($amount)" instead of "Order N Delivery"
- [x] Payment due pills show "ClientName ($amount)" instead of "Payment Due - Invoice N"
- [x] Intake appointment pills show client name if available
- [x] Falls back to event.title if clientName is null
- [x] `pnpm check` passes
- [x] `pnpm lint` passes

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>