### PR TITLE
feat(analytics): add revenue bar chart to AnalyticsPage — TER-1330

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -50,8 +50,63 @@ import {
 } from "@/components/ui/empty-state";
 import { LoadingState } from "@/components/ui/loading-state";
 import { useLocation } from "wouter";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 type Period = "day" | "week" | "month" | "quarter" | "year" | "all";
+
+/**
+ * Format large revenue numbers for YAxis ticks (e.g. "$12.5k", "$1.2M").
+ */
+function formatCompactCurrency(value: number): string {
+  if (!Number.isFinite(value)) return "$0";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `$${(value / 1_000).toFixed(1)}k`;
+  return `$${Math.round(value)}`;
+}
+
+interface RevenueChartTooltipProps {
+  active?: boolean;
+  label?: string | number;
+  payload?: Array<{
+    payload?: { name: string; revenue: number; orders: number };
+  }>;
+}
+
+function RevenueChartTooltip({
+  active,
+  label,
+  payload,
+}: RevenueChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0]?.payload;
+  if (!point) return null;
+  return (
+    <div className="rounded-md border bg-background px-3 py-2 text-xs shadow-sm">
+      <div className="mb-1 font-semibold text-foreground">{label}</div>
+      <div className="text-muted-foreground">
+        Revenue:{" "}
+        <span className="font-medium text-foreground">
+          {formatCurrency(point.revenue)}
+        </span>
+      </div>
+      <div className="text-muted-foreground">
+        Orders:{" "}
+        <span className="font-medium text-foreground">
+          {point.orders.toLocaleString()}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 const periodLabels: Record<Period, string> = {
   day: "Last 24 hours",
@@ -330,7 +385,55 @@ export default function AnalyticsPage() {
               {trendsLoading ? (
                 <LoadingState message="Loading revenue trends..." size="sm" />
               ) : chartData.length > 0 ? (
-                <RevenueTrendsTable data={chartData} maxRows={6} />
+                <div className="space-y-4">
+                  <div
+                    className="h-[220px] w-full"
+                    role="img"
+                    aria-label="Revenue trend bar chart"
+                  >
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart
+                        data={chartData}
+                        margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                      >
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="hsl(var(--border))"
+                          strokeOpacity={0.5}
+                          vertical={false}
+                        />
+                        <XAxis
+                          dataKey="name"
+                          stroke="hsl(var(--muted-foreground))"
+                          fontSize={12}
+                          tickLine={false}
+                          axisLine={false}
+                        />
+                        <YAxis
+                          stroke="hsl(var(--muted-foreground))"
+                          fontSize={12}
+                          tickLine={false}
+                          axisLine={false}
+                          tickFormatter={formatCompactCurrency}
+                          width={64}
+                        />
+                        <Tooltip
+                          cursor={{
+                            fill: "hsl(var(--muted))",
+                            opacity: 0.3,
+                          }}
+                          content={<RevenueChartTooltip />}
+                        />
+                        <Bar
+                          dataKey="revenue"
+                          fill="hsl(var(--primary))"
+                          radius={[4, 4, 0, 0]}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </div>
+                  <RevenueTrendsTable data={chartData} maxRows={6} />
+                </div>
               ) : (
                 <EmptyState
                   {...emptyStateConfigs.analytics}

--- a/docs/sessions/active/ter-1330-session.md
+++ b/docs/sessions/active/ter-1330-session.md
@@ -1,0 +1,6 @@
+# ter-1330 Agent Session
+
+- **Ticket:** ter-1330
+- **Branch:** `fix/ter-1330-analytics-add-chart`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Adds a responsive **recharts `BarChart`** to the Analytics page so the "Revenue Trends" section is actually visual — previously the page rendered only a table despite being called "Analytics".

## What changed

- `client/src/pages/AnalyticsPage.tsx`
  - Imported `BarChart`, `Bar`, `XAxis`, `YAxis`, `Tooltip`, `ResponsiveContainer`, `CartesianGrid` from the already-installed `recharts` package (`^2.15.2`).
  - Added a small `formatCompactCurrency` helper that formats YAxis ticks as `$12.5k` / `$1.2M`.
  - Added a `RevenueChartTooltip` component that shows **revenue as currency** and **orders as a count** when hovering a bar.
  - Rendered the chart **immediately above the existing `RevenueTrendsTable`** inside the Overview tab's "Revenue Trends" card.
  - Chart height is **220px** inside a `ResponsiveContainer` (`width="100%"`); a `CartesianGrid` uses `strokeDasharray="3 3"` at 50% opacity.
  - Empty state behaviour is preserved: if `chartData` is empty, the existing `EmptyState` card is rendered instead of the chart.

## Data source

The chart uses the **already-fetched** `chartData` derived from `trpc.analytics.getRevenueTrends`, which is period-aware (fixed in TER-1326). No new server calls were added.

## Out of scope

- No changes to the KPI tiles, period selector, export dropdown, or other tabs.
- `RevenueTrendsTable` internals are untouched — the table still renders below the new chart with `maxRows={6}`.
- No server, schema, or migration changes.

## Verification

- `pnpm check` — passes (zero TypeScript errors).
- `npx eslint client/src/pages/AnalyticsPage.tsx` — passes with no warnings or errors.

## Acceptance criteria

- [x] AnalyticsPage shows a visual bar chart of revenue over time.
- [x] Chart uses data already fetched (`chartData`).
- [x] Chart is responsive (`ResponsiveContainer width="100%"`).
- [x] Empty state shows when no data.
- [x] `pnpm check` passes.
- [x] `pnpm lint` passes for the touched file.

Closes TER-1330.