### PR TITLE
fix(matchmaking): surface Compute Matches primary action — TER-1336

### DIFF
--- a/client/src/pages/MatchmakingServicePage.tsx
+++ b/client/src/pages/MatchmakingServicePage.tsx
@@ -44,7 +44,15 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-import { Search, Plus, Package, Users, Target, Loader2 } from "lucide-react";
+import {
+  Search,
+  Plus,
+  Package,
+  Users,
+  Target,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
 import { ListSkeleton } from "@/components/ui/skeleton-loaders";
 import { BackButton } from "@/components/common/BackButton";
 import { useLocation } from "wouter";
@@ -175,21 +183,33 @@ export default function MatchmakingServicePage({
   // ERR-001: Get tRPC utils for proper cache invalidation
   const utils = trpc.useUtils();
 
+  // TER-1336: Track in-flight state for the primary "Compute Matches" action
+  const [isComputingMatches, setIsComputingMatches] = useState(false);
+
   // Fetch client needs with match counts
-  const { data: needsData, isLoading: needsLoading } =
-    trpc.clientNeeds.getAllWithMatches.useQuery({
-      status: statusFilter as "ACTIVE" | "FULFILLED" | "EXPIRED" | "CANCELLED",
-    });
+  const {
+    data: needsData,
+    isLoading: needsLoading,
+    refetch: refetchNeeds,
+  } = trpc.clientNeeds.getAllWithMatches.useQuery({
+    status: statusFilter as "ACTIVE" | "FULFILLED" | "EXPIRED" | "CANCELLED",
+  });
 
   // Fetch vendor supply
-  const { data: supplyData, isLoading: supplyLoading } =
-    trpc.vendorSupply.getAllWithMatches.useQuery({
-      status: "AVAILABLE",
-    });
+  const {
+    data: supplyData,
+    isLoading: supplyLoading,
+    refetch: refetchSupply,
+  } = trpc.vendorSupply.getAllWithMatches.useQuery({
+    status: "AVAILABLE",
+  });
 
   // Fetch all active needs with their matches (for suggested matches section)
-  const { data: matchesData, isLoading: matchesLoading } =
-    trpc.matching.getAllActiveNeedsWithMatches.useQuery();
+  const {
+    data: matchesData,
+    isLoading: matchesLoading,
+    refetch: refetchMatches,
+  } = trpc.matching.getAllActiveNeedsWithMatches.useQuery();
 
   // FE-QA-010: Fetch buyers for selected supply item
   const { data: buyersData, isLoading: buyersLoading } =
@@ -268,6 +288,22 @@ export default function MatchmakingServicePage({
       toast.error(error.message || "Failed to add supply item");
     },
   });
+
+  // TER-1336: Compute/Update Matches — primary action on the page.
+  // Refreshes client needs, supplier supply, and suggested matches so users
+  // can recompute the matching snapshot after changes upstream.
+  const handleComputeMatches = useCallback(async () => {
+    if (isComputingMatches) return;
+    setIsComputingMatches(true);
+    try {
+      await Promise.all([refetchNeeds(), refetchSupply(), refetchMatches()]);
+      toast.success("Matches updated");
+    } catch {
+      toast.error("Failed to update matches");
+    } finally {
+      setIsComputingMatches(false);
+    }
+  }, [isComputingMatches, refetchNeeds, refetchSupply, refetchMatches]);
 
   // TER-888: Handle Add Need form submit
   const handleAddNeedSubmit = useCallback(() => {
@@ -478,8 +514,21 @@ export default function MatchmakingServicePage({
               matching
             </p>
           </div>
-          <div className="flex gap-2">
-            <Button onClick={() => setAddNeedOpen(true)}>
+          <div className="flex flex-wrap gap-2">
+            {/* TER-1336: Primary action — recompute/refresh matches */}
+            <Button
+              onClick={handleComputeMatches}
+              disabled={isComputingMatches}
+              aria-label="Compute or update matches"
+            >
+              {isComputingMatches ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              {isComputingMatches ? "Updating..." : "Compute Matches"}
+            </Button>
+            <Button variant="outline" onClick={() => setAddNeedOpen(true)}>
               <Plus className="mr-2 h-4 w-4" />
               Add Need
             </Button>

--- a/docs/sessions/active/TER-1336-session.md
+++ b/docs/sessions/active/TER-1336-session.md
@@ -1,0 +1,6 @@
+# TER-1336 Agent Session
+
+- **Ticket:** TER-1336
+- **Branch:** `fix/ter-1336-matchmaking-compute-button`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Surfaces a prominent primary **Compute Matches** action on `MatchmakingServicePage`. Before this change, users landed on the matchmaking page with no visible control to recompute or refresh matches — the core action of the page was invisible.

## Changes

- Added a primary `Compute Matches` button to the page header, with a `RefreshCw` icon (swaps to `Loader2` spinner while in flight).
- Wired the button to a new `handleComputeMatches` callback that concurrently refetches the three data sources that drive the page:
  - `clientNeeds.getAllWithMatches`
  - `vendorSupply.getAllWithMatches`
  - `matching.getAllActiveNeedsWithMatches`
- Button is disabled during refresh to prevent duplicate submissions; success/error toasts surface the result.
- Demoted `Add Need` to `variant="outline"` so the compute action is the clear primary CTA; `Add Supply` stays outline.

## Acceptance Criteria

- [x] MatchmakingServicePage has a visible primary action button for computing/updating matches
- [x] No regression on Matchmaking adjacent functionality (all 9 existing tests pass)
- [x] `pnpm check` passes (zero TS errors)
- [x] `pnpm lint` passes on changed files (unchanged pre-existing lint errors in unrelated files remain — not touched)

## Scope / Out of Scope

Out of scope per ticket: matchmaking algorithm/server logic, auth, migrations. This PR is UI surfacing only — no server, schema, or business-logic changes.

Ticket: TER-1336 (UX v2 remediation under Epic TER-1283)