### PR TITLE
fix(dashboard): add trend/comparison context to KPI tiles — TER-1335

### DIFF
--- a/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
+++ b/client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { useLocation } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
   ArrowDownRight,
@@ -32,6 +33,13 @@ interface KpiTileProps {
   icon: LucideIcon;
   value: string;
   secondary?: string;
+  /**
+   * Short label indicating the time window the value represents
+   * (e.g. "Live", "Today", "Last 7 days"). Rendered as a small chip
+   * next to the title so readers can interpret the number in context —
+   * TER-1335. Omit to hide the chip entirely (e.g. skeleton placeholders).
+   */
+  period?: string;
   trend?: {
     direction: Trend;
     label: string;
@@ -102,6 +110,7 @@ const KpiTile = memo(function KpiTile({
   icon: Icon,
   value,
   secondary,
+  period,
   trend,
   onClick,
   loading,
@@ -125,9 +134,19 @@ const KpiTile = memo(function KpiTile({
       <CardContent className="p-5">
         <div className="flex items-start justify-between">
           <div className="flex-1 min-w-0">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {title}
-            </p>
+            <div className="flex items-center gap-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {title}
+              </p>
+              {period && (
+                <Badge
+                  variant="outline"
+                  className="rounded-full px-2 py-0 text-[10px] font-normal uppercase tracking-wide text-muted-foreground"
+                >
+                  {period}
+                </Badge>
+              )}
+            </div>
             {loading ? (
               <Skeleton className="mt-2 h-8 w-24" />
             ) : (
@@ -202,6 +221,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
           title="Open Orders"
           icon={ShoppingCart}
           value=""
+          period="Live"
           onClick={() => {}}
           loading
         />
@@ -209,6 +229,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
           title="Fulfilled Today"
           icon={PackageCheck}
           value=""
+          period="Today"
           onClick={() => {}}
           loading
         />
@@ -216,6 +237,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
           title="Outstanding Receivables"
           icon={CircleDollarSign}
           value=""
+          period="Live"
           onClick={() => {}}
           loading
         />
@@ -223,6 +245,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
           title="Cash Collected (7d)"
           icon={Wallet}
           value=""
+          period="Last 7 days"
           onClick={() => {}}
           loading
         />
@@ -230,6 +253,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
           title="Inventory Value"
           icon={Package}
           value=""
+          period="Live"
           onClick={() => {}}
           loading
         />
@@ -275,6 +299,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
         title="Open Orders"
         icon={ShoppingCart}
         value={formatNumber(openOrdersCount)}
+        period="Live"
         secondary={
           openOrdersCount > 0
             ? `${formatCurrency(openOrdersValue)} in flight`
@@ -289,6 +314,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
         title="Fulfilled Today"
         icon={PackageCheck}
         value={formatNumber(fulfilledTodayCount)}
+        period="Today"
         secondary={
           fulfilledTodayCount > 0
             ? "Shipped or delivered today"
@@ -305,6 +331,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
         title="Outstanding Receivables"
         icon={CircleDollarSign}
         value={formatCurrency(receivablesTotal)}
+        period="Live"
         secondary={
           receivablesInvoices > 0
             ? `${receivablesInvoices} open invoice${
@@ -319,6 +346,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
         title="Cash Collected (7d)"
         icon={Wallet}
         value={formatCurrency(thisWeekCash)}
+        period="Last 7 days"
         secondary={`Last week ${formatCurrency(lastWeekCash)}`}
         trend={{ direction: cashTrend, label: cashTrendLabel }}
         onClick={() => setLocation("/accounting/payments")}
@@ -328,6 +356,7 @@ export const OperationalKpisWidget = memo(function OperationalKpisWidget() {
         title="Inventory Value"
         icon={Package}
         value={formatCompactCurrency(inventoryValue)}
+        period="Live"
         secondary={
           inventoryUnits > 0
             ? `${formatNumber(Math.round(inventoryUnits))} live units`

--- a/docs/sessions/active/TER-1335-session.md
+++ b/docs/sessions/active/TER-1335-session.md
@@ -1,0 +1,6 @@
+# TER-1335 Agent Session
+
+- **Ticket:** TER-1335
+- **Branch:** `fix/ter-1335-dashboard-kpi-trends`
+- **Status:** In Progress
+- **Agent:** Factory Droid

--- a/docs/sessions/active/ter-1335-session.md
+++ b/docs/sessions/active/ter-1335-session.md
@@ -1,0 +1,6 @@
+# ter-1335 Agent Session
+
+- **Ticket:** ter-1335
+- **Branch:** `fix/ter-1335-dashboard-kpi-trends`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary — TER-1335

The DashboardHomePage's top KPI row (`OperationalKpisWidget`) showed five bare numbers — Open Orders, Fulfilled Today, Outstanding Receivables, Cash Collected (7d), and Inventory Value — with no visible time window on four of the five tiles. Only Cash Collected carried a week-over-week delta. Without comparison context, users couldn't tell whether the numbers were good or bad, or which period each one covered.

## Changes (client-only)

`client/src/components/dashboard/widgets-v2/OperationalKpisWidget.tsx`:
- Add a `period?: string` prop to the `KpiTile` component, rendered as a small outline `Badge` chip next to the tile title.
- Label every tile with its actual time window:
  | Tile | Period chip |
  | --- | --- |
  | Open Orders | `Live` |
  | Fulfilled Today | `Today` |
  | Outstanding Receivables | `Live` |
  | Cash Collected (7d) | `Last 7 days` (retains existing WoW % delta) |
  | Inventory Value | `Live` |
- Skeleton placeholders also receive the chips so the time-window is stable across loading → loaded transitions (no layout shift).

## Approach

Matches the TER-1325 precedent (period labels on AnalyticsPage KPIs) and keeps the TER-1331 WoW delta on the cash tile. No server work, no schema changes, no new queries — only a presentational enhancement on the existing widget.

## Acceptance criteria

- [x] DashboardHomePage KPI tiles show comparison context (period label on every tile, delta % on Cash Collected).
- [x] No regression on adjacent functionality — only `KpiTile` rendering was touched; all existing click targets, queries, and loading states are preserved.
- [x] `pnpm check` passes (zero TypeScript errors).
- [x] `pnpm lint` passes on the touched file. (Unrelated pre-existing lint errors elsewhere in the repo remain on `main`.)

## Out of scope

Per ticket constraints this change is **UI only** — no server-side financial logic, auth, or migration work.