### PR TITLE
fix(cogs-settings): add save affordance — TER-1334

### DIFF
--- a/client/src/components/cogs/CogsGlobalSettings.tsx
+++ b/client/src/components/cogs/CogsGlobalSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { trpc } from "@/lib/trpc";
 import {
   Card,
@@ -16,7 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { Info } from "lucide-react";
+import { Check, Info, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 const CHANNEL_LABELS = {
@@ -31,20 +32,46 @@ const BASIS_LABELS = {
   HIGH: "High end of range",
 } as const;
 
+type ChannelKey = keyof typeof CHANNEL_LABELS;
+
 export function CogsGlobalSettings() {
   const utils = trpc.useUtils();
   const { data, isLoading } =
     trpc.pricingDefaults.getRangePricingDefaults.useQuery();
 
+  const [savedChannel, setSavedChannel] = useState<ChannelKey | null>(null);
+  const savedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (savedTimeoutRef.current) {
+        clearTimeout(savedTimeoutRef.current);
+      }
+    },
+    []
+  );
+
   const mutation = trpc.pricingDefaults.setRangePricingDefault.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       await utils.pricingDefaults.getRangePricingDefaults.invalidate();
       toast.success("Range pricing default updated");
+      setSavedChannel(variables.channel);
+      if (savedTimeoutRef.current) {
+        clearTimeout(savedTimeoutRef.current);
+      }
+      savedTimeoutRef.current = setTimeout(() => {
+        setSavedChannel(prev => (prev === variables.channel ? null : prev));
+      }, 2000);
     },
     onError: error => {
       toast.error(error.message);
     },
   });
+
+  const pendingChannel: ChannelKey | null =
+    mutation.isPending && mutation.variables
+      ? mutation.variables.channel
+      : null;
 
   return (
     <div className="space-y-6">
@@ -53,7 +80,7 @@ export function CogsGlobalSettings() {
           <CardTitle className="text-lg">Range-Based COGS Defaults</CardTitle>
           <CardDescription>
             Choose which vendor range value becomes the default effective COGS
-            on each customer-facing channel.
+            on each customer-facing channel. Changes save automatically.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -83,7 +110,7 @@ export function CogsGlobalSettings() {
                     </Badge>
                   </div>
                 </div>
-                <div className="w-full md:w-56">
+                <div className="flex w-full flex-col gap-1 md:w-56">
                   <Label className="sr-only">
                     {CHANNEL_LABELS[setting.channel]} default
                   </Label>
@@ -97,7 +124,9 @@ export function CogsGlobalSettings() {
                     }
                     disabled={mutation.isPending}
                   >
-                    <SelectTrigger>
+                    <SelectTrigger
+                      aria-label={`${CHANNEL_LABELS[setting.channel]} default basis`}
+                    >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -106,6 +135,19 @@ export function CogsGlobalSettings() {
                       <SelectItem value="HIGH">High</SelectItem>
                     </SelectContent>
                   </Select>
+                  <div aria-live="polite" className="h-4 text-xs">
+                    {pendingChannel === setting.channel ? (
+                      <span className="flex items-center gap-1 text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Saving…
+                      </span>
+                    ) : savedChannel === setting.channel ? (
+                      <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                        <Check className="h-3 w-3" />
+                        Saved
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
               </div>
             ))}

--- a/docs/sessions/active/TER-1334-session.md
+++ b/docs/sessions/active/TER-1334-session.md
@@ -1,0 +1,6 @@
+# TER-1334 Agent Session
+
+- **Ticket:** TER-1334
+- **Branch:** `fix/ter-1334-cogs-settings-save-affordance`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Fixes TER-1334: COGS Settings page had no visible save affordance — after a user changed a Select, feedback was limited to a transient toast, so users couldn't tell if their selection had persisted.

## Changes

`client/src/components/cogs/CogsGlobalSettings.tsx`:
- Add an **aria-live** inline indicator next to each channel's Select that shows a spinner + *"Saving…"* while the mutation is in flight, and a green check + *"Saved"* for ~2s after success.
- Clarify auto-save behavior in the card description (*"Changes save automatically."*).
- Add an `aria-label` to each Select trigger for accessibility.
- Track per-channel save state via `mutation.variables?.channel` (pending) and a `savedChannel` state with an auto-clearing timeout (settled).

## Scope

UI only. No server / COGS calculation / auth / migration / financial-logic changes.

## Acceptance Criteria

- [x] CogsSettingsPage shows clear save affordance (Saving… / Saved indicator + existing toast)
- [x] User receives feedback when selection is saved
- [x] No regression on adjacent functionality — client-settings tab untouched
- [x] `pnpm check` passes (clean on full repo)
- [x] `pnpm lint` passes for the touched file

## Linear

TER-1334 (under Epic TER-1283 — UX v2 remediation)
