### PR TITLE
fix(client-ledger): visually prioritize delinquent invoices — TER-1333

### DIFF
--- a/client/src/components/spreadsheet-native/InvoicesSurface.test.tsx
+++ b/client/src/components/spreadsheet-native/InvoicesSurface.test.tsx
@@ -525,4 +525,35 @@ describe("InvoicesSurface", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith("/clients/10?section=overview");
   });
+
+  // TER-1333: Delinquent invoices (past due, not PAID/VOID) must receive a
+  // visual priority indicator on the main invoice grid so users can spot
+  // overdue accounts at a glance. We assert both the row-level class from
+  // `getRowClass` and the derived `isDelinquent` flag on the row data.
+  it("marks delinquent invoice rows with a destructive row class", () => {
+    render(<InvoicesSurface />);
+
+    const gridProps = gridPropsByTitle.get("Invoices") as unknown as {
+      rows: Array<{ invoiceId: number; status: string; isDelinquent: boolean }>;
+      getRowClass?: (params: {
+        data?: { isDelinquent: boolean };
+      }) => string | undefined;
+    };
+
+    expect(gridProps).toBeDefined();
+    expect(gridProps.getRowClass).toBeTypeOf("function");
+
+    const overdue = gridProps.rows.find(r => r.status === "OVERDUE");
+    const paid = gridProps.rows.find(r => r.status === "PAID");
+
+    expect(overdue?.isDelinquent).toBe(true);
+    expect(paid?.isDelinquent).toBe(false);
+
+    const overdueClass = gridProps.getRowClass?.({ data: overdue });
+    const paidClass = gridProps.getRowClass?.({ data: paid });
+
+    expect(overdueClass).toContain("bg-destructive/5");
+    expect(overdueClass).toContain("border-l-destructive");
+    expect(paidClass).toBeUndefined();
+  });
 });

--- a/client/src/components/spreadsheet-native/InvoicesSurface.tsx
+++ b/client/src/components/spreadsheet-native/InvoicesSurface.tsx
@@ -122,6 +122,12 @@ export interface InvoiceGridRow {
   paymentPct: number;
   status: string;
   daysOverdue: number;
+  // TER-1333: True when the invoice is past its due date and still payable
+  // (not PAID/VOID). Used to drive the row-level visual priority (red tint)
+  // on the invoice grid so users can spot delinquent invoices at a glance,
+  // even if the DB `status` column has not yet flipped to 'OVERDUE' via the
+  // `invoices.checkOverdue` mutation.
+  isDelinquent: boolean;
   version: number | null;
   customerEmail: string | null;
   customerPhone: string | null;
@@ -298,8 +304,15 @@ function mapInvoicesToGridRows(
     const amountPaid = Math.min(amountPaidRaw, totalAmountNum).toFixed(2);
 
     const dueDate = item.dueDate ? new Date(item.dueDate) : null;
+    // TER-1333: Compute `daysOverdue` for any payable invoice past its due
+    // date, not only those whose DB status has flipped to 'OVERDUE'. The
+    // `invoices.checkOverdue` mutation can lag, so anchoring the delinquent
+    // signal to the live due-date keeps the grid badges, row highlight, and
+    // Inspector overdue chip consistent with what users see in the world.
+    const isPayable = status !== "PAID" && status !== "VOID";
     const daysOverdue =
-      status === "OVERDUE" && dueDate ? getDaysOverdue(dueDate) : 0;
+      isPayable && dueDate ? getDaysOverdue(dueDate) : 0;
+    const isDelinquent = daysOverdue > 0;
 
     return {
       rowKey: String(item.id),
@@ -318,6 +331,7 @@ function mapInvoicesToGridRows(
       paymentPct: getPaymentProgress(item),
       status,
       daysOverdue,
+      isDelinquent,
       customerEmail: clientObj?.email ?? null,
       customerPhone: clientObj?.phone ?? null,
       version:
@@ -368,8 +382,11 @@ const invoiceColumnDefs: ColDef<InvoiceGridRow>[] = [
     // TER-1360: Return JSX so contact details render as DOM, not escaped HTML.
     cellRenderer: (params: { data?: InvoiceGridRow; value: string }) => {
       if (!params.data) return params.value ?? "-";
-      const { customerEmail, customerPhone, status } = params.data;
-      if (status !== "OVERDUE" || (!customerEmail && !customerPhone)) {
+      const { customerEmail, customerPhone, isDelinquent } = params.data;
+      // TER-1333: Surface contact details for any delinquent invoice, not
+      // only those with DB status flipped to 'OVERDUE'. Matches the row-
+      // level visual priority driven by `isDelinquent`.
+      if (!isDelinquent || (!customerEmail && !customerPhone)) {
         return params.value ?? "-";
       }
       const contact = [customerPhone, customerEmail]
@@ -1481,6 +1498,14 @@ export function InvoicesSurface() {
               enableFillHandle={false}
               enableUndoRedo={false}
               onSelectionSummaryChange={setSelectionSummary}
+              // TER-1333: Paint delinquent invoice rows with a red-tinted
+              // background and destructive left-border accent so users can
+              // spot past-due accounts at a glance while scanning the grid.
+              getRowClass={params =>
+                params.data?.isDelinquent
+                  ? "bg-destructive/5 hover:bg-destructive/10 border-l-2 border-l-destructive"
+                  : undefined
+              }
               isLoading={invoicesQuery.isLoading}
               errorMessage={invoicesQuery.error?.message ?? null}
               emptyTitle="No invoices match"

--- a/docs/sessions/active/TER-1333-session.md
+++ b/docs/sessions/active/TER-1333-session.md
@@ -1,0 +1,6 @@
+# TER-1333 Agent Session
+
+- **Ticket:** TER-1333
+- **Branch:** `fix/ter-1333-client-ledger-delinquent-priority`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
## Summary

Fixes **TER-1333**: Delinquent invoices are not visually prioritized on the Client Ledger / Invoices surface.

Past-due invoices that still need to be paid now stand out in the grid with:

- A red-tinted row background (`bg-destructive/5`, brighter on hover)
- A destructive left-border accent (`border-l-2 border-l-destructive`)
- The existing overdue chip on the Due Date column (now driven by live due-date, not lagging DB status)
- Hover contact details (phone/email) surfaced for any delinquent row

## Why

Previously, the row-level overdue signal (badge, red due-date) fired only when the DB `status` column had flipped to `OVERDUE`. That flip depends on the `invoices.checkOverdue` mutation and can lag, leaving a clearly past-due invoice indistinguishable from a current one in the grid.

This change derives `daysOverdue` and a new `isDelinquent` flag purely from the invoice's payable status and live due date, then paints the whole row accordingly via AG Grid's `getRowClass`. That keeps the row paint, chip, and Inspector overdue treatment internally consistent and agreeing with what users see in the world.

## Scope (intentional)

- Client-side only — UI of `InvoicesSurface` (which backs both `/accounting/invoices` and `ClientLedgerPage`)
- Zero server-side, migration, or auth changes
- No new libraries

## Files

- `client/src/components/spreadsheet-native/InvoicesSurface.tsx`: `InvoiceGridRow` gains `isDelinquent`; `mapInvoicesToGridRows` derives `daysOverdue`/`isDelinquent` from the payable/due-date predicate; new `getRowClass` on the main PowersheetGrid
- `client/src/components/spreadsheet-native/InvoicesSurface.test.tsx`: new unit test asserting delinquent rows receive the destructive row class and PAID rows do not

## Acceptance Criteria

- [x] Delinquent invoices show a visual priority indicator (red tint + left border + existing Due Date chip)
- [x] No regression on adjacent ClientLedgerPage functionality (selection, inspector, ledger sub-view, banners, dialogs all unchanged)
- [x] `pnpm check` passes (zero TypeScript errors)
- [x] `pnpm lint` passes on the changed files
- [x] New unit test passes (`InvoicesSurface > marks delinquent invoice rows with a destructive row class`)

## Test Plan

1. Open `/accounting/invoices` (or the Client Ledger route).
2. Any invoice whose due date is past today and whose status is not `PAID`/`VOID` should now render with a red-tinted row and a destructive left border, even if its DB status has not yet flipped to `OVERDUE`.
3. `PAID` / `VOID` invoices continue to render in neutral styling.
4. Inspector and Client Ledger sub-view behavior are unchanged.

Linear: TER-1333 (Epic TER-1283 UX v2 remediation)