### PR TITLE
fix(photography): elevate primary bulk action — TER-1338

### DIFF
--- a/client/src/pages/PhotographyPage.tsx
+++ b/client/src/pages/PhotographyPage.tsx
@@ -367,23 +367,24 @@ export default function PhotographyPage({
             </div>
             <div className="flex items-center gap-2">
               {selectedItems.length > 0 && (
-                <>
-                  <span className="text-sm text-muted-foreground">
-                    {selectedItems.length} selected
-                  </span>
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={handleBulkMarkComplete}
-                    disabled={markComplete.isPending}
-                  >
-                    <CheckCircle className="h-4 w-4 mr-2" />
-                    Mark Selected Shot
-                  </Button>
-                </>
+                <span className="text-sm text-muted-foreground">
+                  {selectedItems.length} selected
+                </span>
               )}
               <Button variant="outline" size="sm" onClick={selectAll}>
                 Select All Ready to Review
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={handleBulkMarkComplete}
+                disabled={
+                  selectedItems.length === 0 || markComplete.isPending
+                }
+              >
+                <CheckCircle className="h-4 w-4 mr-2" />
+                Mark Shot
+                {selectedItems.length > 0 ? ` (${selectedItems.length})` : ""}
               </Button>
             </div>
           </div>

--- a/docs/sessions/active/TER-1338-session.md
+++ b/docs/sessions/active/TER-1338-session.md
@@ -1,0 +1,7 @@
+# TER-1338 Agent Session
+
+- **Ticket:** TER-1338
+- **Branch:** `fix/ter-1338-photography-primary-action`
+- **Status:** In Progress
+- **Started:** 2026-04-24T18:00:29Z
+- **Agent:** Factory Droid (wave-p5 launcher)


### PR DESCRIPTION
## Summary

The 'Mark Shot' bulk action is now always visible (disabled when nothing selected), making the page's primary workflow immediately apparent.

Fixes TER-1338.