### PR TITLE
fix(samples): label quantity in product column — TER-1340

### DIFF
--- a/client/src/pages/SampleManagement.tsx
+++ b/client/src/pages/SampleManagement.tsx
@@ -280,7 +280,7 @@ export default function SampleManagement({
         const productSummary = products
           .map(
             product =>
-              `Product #${product.productId} (${product.quantity || "1"})`
+              `Product #${product.productId} (qty: ${product.quantity || "1"})`
           )
           .join(", ");
 

--- a/docs/sessions/active/TER-1340-session.md
+++ b/docs/sessions/active/TER-1340-session.md
@@ -1,0 +1,6 @@
+# TER-1340 Agent Session
+
+- **Ticket:** TER-1340
+- **Branch:** `fix/ter-1340-sample-product-column`
+- **Status:** In Progress
+- **Agent:** Factory Droid


### PR DESCRIPTION
Labels the parenthetical quantity in the SampleManagement product column to remove ambiguity. Fixes TER-1340.