### PR TITLE
fix(settings): redirect users settings alias - TER-1371

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -540,6 +540,14 @@ function Router() {
                   component={withErrorBoundary(ClientLedgerPage)}
                 />
                 <Route
+                  path="/settings/users"
+                  component={RedirectWithTab(
+                    "/settings/users",
+                    "/settings",
+                    "users"
+                  )}
+                />
+                <Route
                   path="/users"
                   component={RedirectWithTab("/users", "/settings", "users")}
                 />

--- a/client/src/lib/navigation/deadRouteRedirects.test.ts
+++ b/client/src/lib/navigation/deadRouteRedirects.test.ts
@@ -142,6 +142,11 @@ describe("TER-859 dead route redirects", () => {
   });
 
   describe("new admin/calendar/product aliases", () => {
+    it("redirects /settings/users to the users settings tab", () => {
+      const destination = buildRedirectWithTab("/settings", "users");
+      expect(destination).toBe("/settings?tab=users");
+    });
+
     it("redirects /admin/users to the users settings tab", () => {
       const destination = buildRedirectWithTab("/settings", "users");
       expect(destination).toBe("/settings?tab=users");

--- a/docs/sessions/active/TER-1371-session.md
+++ b/docs/sessions/active/TER-1371-session.md
@@ -1,0 +1,13 @@
+# TER-1371 Agent Session
+
+- **Ticket:** TER-1371
+- **Branch:** `terpctl/ter-1371-controlled-launch`
+- **Status:** In Progress
+- **Agent:** Hermes terpctl controlled pipeline
+- **Mode:** controlled launch → planning-only → scoped implementation
+- **Scope:** redirect `/settings/users` to `/settings?tab=users`
+
+## Verification
+
+- Targeted Vitest suite passed: 3 files, 37 tests.
+- No files outside approved scope changed before commit.


### PR DESCRIPTION
## Summary
- Redirect /settings/users to /settings?tab=users
- Add regression coverage for the legacy settings users alias

## Test Plan
- vitest run client/src/lib/navigation/deadRouteRedirects.test.ts client/src/pages/Settings.test.tsx client/src/config/routes.test.ts --reporter=verbose
- 3 files passed, 37 tests passed

Controlled by terpctl; no scope outside approved files.